### PR TITLE
Land in-flight #42/#43 implementations (hard benchmark + Ollama Cloud)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
-            --model claude-fable-5
+            --model claude-opus-4-8
             --allowed-tools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(gh pr comment:*)"
 
   # --- Automatic: runs on every PR push, checks coverage of the linked issue ---
@@ -89,7 +89,7 @@ jobs:
             top-level PR comment using `gh pr comment`. Title it
             "Coverage review".
           claude_args: >-
-            --model claude-fable-5
+            --model claude-opus-4-8
             --allowed-tools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(gh pr comment:*)"
 
   # --- Automatic: runs on every PR push, reviews design quality / extensibility ---
@@ -111,6 +111,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -153,5 +154,5 @@ jobs:
             Post your review as a top-level PR comment using
             `gh pr comment`. Title it "Quality review".
           claude_args: >-
-            --model claude-fable-5
+            --model claude-opus-4-8
             --allowed-tools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(gh pr comment:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ __marimo__/
 
 # Latency-collection outputs (issue #35)
 data/latency/
+
+# Externally-sourced benchmark data, not redistributed (issue #42).
+# Fetch with: python scripts/fetch_hard_benchmark.py  (see docs/hard_benchmark.md)
+data/external/

--- a/docs/benchmark_comparison_issue42.md
+++ b/docs/benchmark_comparison_issue42.md
@@ -1,0 +1,65 @@
+# Benchmark Comparison & Recommendation — Harder Research-QA Dataset (Issue #42)
+
+> **Correction (2026-06-07), found during integration — supersedes the license/tricky-tier cells below:**
+> 1. **CREPE name collision.** The deep-research run cited `huggingface.co/datasets/zharry29/CREPE` as the false-presupposition CREPE. That HF dataset is a *different* CREPE ("Causal Reasoning of Entities and Events in Procedural Texts"). The real false-presupposition CREPE is arXiv:2211.17257 (`github.com/velocityCavalry/CREPE`), so the "CC-BY-4.0 on HF" claim was a **false match**.
+> 2. **Licenses are murkier than the table implies.** FalseQA has **no declared license** (no LICENSE file / no README mention); the real CREPE is **NOASSERTION** (no detectable license). The clean BSD/CC-BY tags found belonged to re-hosts or the wrong dataset.
+> 3. **Resolution.** We **do not redistribute** any external data — a fetch-at-build loader pulls subsets locally (git-ignored); the repo ships only mappers + an author-owned synthetic test fixture. This dissolves the license blocker for all candidates. **Integrated: FRAMES (hard, Apache-2.0) + CREPE (tricky, fetch-only).** See `docs/hard_benchmark.md`.
+
+
+**Date:** 2026-06-05
+**Method:** Multi-agent deep-research sweep (6 search angles, 23 sources fetched, 110 claims extracted, 25 adversarially fact-checked at 3 votes each — 22 confirmed, 3 killed). All figures below survived verification; refuted claims are explicitly flagged.
+
+## Problem recap
+
+The current `research_qa` pool is one-shot-saturated: a strong answerer (Gemini-class) maxes the quality judge at 5/5/5, the simulated user ends every episode after one turn, and conditions can't separate (see RCA in #41, and the no-signal baseline in #23). We need datasets where a frontier answerer scores **below ceiling with real variance**, that ship **gold answers + gradable rubrics** (so the LLM judge and follow-up simulated user keep working), and that map onto `ResearchQATask` (`question` / `gold_answer` / `scoring_rubric` / `difficulty`, with `tricky` = false-premise carrying `known_assumptions`, `hard` = multi-step synthesis).
+
+## Comparison table
+
+| Benchmark | 1. Difficulty / SOTA headroom | 2. Gold + rubric? | 3. License | 4. Multi-turn / multi-hop / agentic | 5. Loading | 6. False-premise? | Schema fit |
+|---|---|---|---|---|---|---|---|
+| **ResearchRubrics** | **High.** No system >70% rubric compliance; best Gemini DR 0.677 ternary / 0.615 binary; OpenAI DR 0.664; Perplexity DR 0.566. | **Yes — native.** 2,593 human-written rubric criteria (~26/task, 20–43), ternary judge {Satisfied / Partial / Not}. | ⚠️ Unresolved — verify before use | Long-horizon: 4+ dependent reasoning steps, synthesis across >5 sources. **Single-turn** (101 prompts). | ⚠️ HF availability unresolved | No | **Best (hard tier).** Native `scoring_rubric`; but scores measured on *agentic DR systems*, not a plain one-shot answerer. |
+| **ResearchQA** | **High.** No parametric/RAG system >70% rubric-item coverage; best overall 75% (Perplexity DR). Top system fully addresses <11% citation, 48% limitation, 49% comparison items. | **Yes — native.** Query-specific free-text rubric items (cite-papers / explain / limitations); 160K rubric items, 21K queries, 75 fields. Pairwise auto-judge 74% agreement w/ experts. | ⚠️ Unresolved — verify | Long-form synthesis; **single-turn**. | ⚠️ HF availability unresolved | No | **Best (hard tier).** Cleanest native rubric mapping. |
+| **FRAMES** | **High.** 0.408 no-retrieval (Gemini-1.5-Pro); 0.66 with multi-step retrieval; oracle-prompt only 0.73. Not saturated. | Short verifiable answers + reasoning types; needs a rubric authored. | ✅ on HF (`google/frames-benchmark`) | **Multi-hop** (2–15 Wikipedia docs/Q); rewards iterative retrieval. "Multi-step" = automated query iteration, not dialogue. | ✅ Easy — HF, 824 Qs. | No | **Good (hard injector).** Needs `gold_answer`→rubric authoring; multi-hop is the real headroom source. |
+| **FalseQA** | High for premise-correction (frontier <30% on false-premise correction, corroborating sources). | Explanation of *why* premise is false + revised true-premise question. | ✅ Public GitHub (thunlp), ACL'23. | Single-turn; tests assumption-trap handling. | ✅ CSVs, 2,365 Qs (1187/491/687). | **Yes — purpose-built.** | **Best (tricky tier).** `question`→Q, `gold_answer`→rebuttal/explanation, `known_assumptions`→false premise. Minor reshape: TPQ is a sibling row, not a field. |
+| **(QA)²** | High. Models underperform on questionable- vs valid-assumption Qs; substantial headroom (2026 corroboration: no frontier LLM corrects false presup >30%). | Annotated assumptions → convertible to Yes/No verification Qs. | ✅ ACL'23 (arXiv 2212.10003). | Single-turn. | ✅ 602 expert-annotated Qs (301 questionable: 246 false, 55 unverifiable). | **Yes.** | **Strong (tricky alt).** Uses human-rater acceptability, not hard auto-accuracy. |
+| **CREPE** | Below ceiling: best ~66–67% macro-F1 vs 85% human (~18pt gap) on judging presupposition correctness. | Presuppositions **+ their corrections** annotated. | ✅ on HF (`zharry29/CREPE`). | Single-turn. | ✅ HF. 25% of Qs have false presuppositions. | **Yes — natural distribution** (from forums). | **Strong (tricky alt).** `known_assumptions`+`gold_answer` correction map directly. Baselines are 2022-era. |
+| **BrowseComp** | Extreme: GPT-4o 0.6%, +browsing 1.9%, o1 9.9%; only Deep Research agent 51.5%. | Short single verifiable string, AI semantic-equivalence grading — **not rubric prose**. | OpenAI release. | Agentic browsing; **single-turn**; "persistent multi-hop navigation" claim **REFUTED**. | Loadable. | No | **Poor for this loop.** Near-zero is tool-access artifact, not reasoning; short answers, not gradable prose. Fits a tool-use injector, not rubric+follow-up. |
+| **GAIA** | Hard agentic (reasoning/multimodal/browse/tool-use). The popular "92% human vs 15% GPT-4" headroom framing was **REFUTED 0-3** — don't cite it. | Short exact-match-style answers — **not free-text rubrics**. | Public. | Agentic tool-chaining; **single-turn**. | Loadable. | No | **Poor for this loop.** Difficulty injector / tool-use role only. |
+
+## Recommendation
+
+Adopt a **two-dataset pairing**, mirroring the existing `hard` / `tricky` difficulty split:
+
+### Hard tier → **FRAMES** (primary integration target), with **ResearchQA / ResearchRubrics** as the rubric-native upgrade
+- **FRAMES** is the pragmatic first integration: it's on HuggingFace (`google/frames-benchmark`, 824 Qs), genuinely multi-hop (2–15 docs/question), and frontier models land in the **0.40–0.73** band — real headroom, not saturation. The only schema work is authoring a `scoring_rubric` per question (the dataset gives gold answers + reasoning types to template from).
+- **ResearchQA / ResearchRubrics** are the *cleanest schema fit* because they ship per-question free-text rubrics natively (no rubric authoring) and document <70% ceiling. **But** two caveats gate them: (a) their <70% scores were measured on *agentic deep-research systems*, not a plain one-shot answerer — below-ceiling behavior for our specific answerer is plausible but unproven; (b) license + HF-loadability were **not resolved** by the research and must be checked first. Treat these as the higher-fidelity follow-up once a pilot confirms headroom and licensing.
+
+### Tricky tier → **FalseQA** (primary), with **CREPE** as a strong alternative
+- **FalseQA** maps onto our schema most cleanly: `question`→Q, `gold_answer`→the false-premise rebuttal/explanation, `known_assumptions`→the false premise itself. It's purpose-built (2,365 human-written false-premise Qs), public, and CSV-simple. Minor reshape: the true-premise variant is a sibling row, not a column.
+- **CREPE** is the better choice if we want a *natural* distribution of presupposition failures (from real forum questions) with corrections already annotated, and it's directly on HuggingFace.
+
+## Critical caveats (read before integrating)
+
+1. **Time-sensitivity is the #1 risk.** Nearly all "frontier struggles" numbers come from 2024–2025 models (Gemini-1.5-Pro on FRAMES, text-davinci-003 on (QA)², GPT-3 on CREPE). A 2026 Gemini-class answerer may score higher and compress the headroom. **The pilot (AC #3) must empirically confirm below-ceiling-with-variance on *our* answerer before committing.**
+2. **Schema-fit vs difficulty tension.** The cleanest-rubric sets (ResearchQA/ResearchRubrics) are single-turn and were scored on agentic systems; the highest-headroom multi-hop set (FRAMES) needs rubric authoring. There's no single dataset that is simultaneously rubric-native, proven-hard-for-a-one-shot-answerer, and multi-turn.
+3. **None are natively multi-turn.** The simulated-user follow-up loop must be layered on top. Rubric-graded long-form sets (ResearchRubrics/ResearchQA/FRAMES-with-rubric) support this far better than short-answer agentic sets — follow-ups can target unaddressed rubric items / limitations rather than being trivially satisfiable after turn one.
+4. **Do NOT cite these refuted claims:** GAIA "92% human vs 15% GPT-4" headroom (0-3); BrowseComp "persistent multi-hop navigation where brute-force fails" (0-3); FRAMES "0.66 leaves a third unsolved / real below-ceiling variance" phrasing (0-3). The underlying FRAMES 0.40/0.66 numbers themselves are confirmed — only the editorialized framing was killed.
+
+## Open questions to resolve during integration
+
+1. Do 2026 frontier answerers actually score below ceiling on FRAMES / FalseQA / (QA)² / CREPE **inside this harness with tool access**, or has model progress already eaten the 2024-era headroom?
+2. Can multi-criterion rubrics (ResearchRubrics ~26/task) collapse into the single `scoring_rubric: str` field without losing the granularity that produces score variance — or does the judge need to become multi-criterion rather than emitting one 5/5/5?
+3. Are ResearchQA / ResearchRubrics redistributable and HF-loadable? (Unresolved — blocks their adoption.)
+4. What follow-up design makes the simulated user create genuine multi-turn headroom (e.g., probing missing rubric items) rather than accepting turn one?
+
+## Sources (primary unless noted)
+
+- ResearchRubrics — arXiv:2511.07685v1 (Scale AI / ICLR 2026)
+- ResearchQA — arXiv:2509.00496
+- FRAMES — arXiv:2409.12941 (Google/Harvard, NAACL 2025); HF `google/frames-benchmark`
+- FalseQA — arXiv:2307.02394, github.com/thunlp/FalseQA (ACL 2023)
+- (QA)² — arXiv:2212.10003 / aclanthology 2023.acl-long.472 (ACL 2023)
+- CREPE — arXiv:2211.17257 (UW+AI2, ACL 2023); HF `zharry29/CREPE`
+- BrowseComp — arXiv:2504.12516v1 (OpenAI) + anthropic.com/engineering/eval-awareness-browsecomp (secondary)
+- GAIA — arXiv:2311.12983
+- Frontier false-premise corroboration (2026) — Cancer-Myth arXiv:2504.11373

--- a/docs/hard_benchmark.md
+++ b/docs/hard_benchmark.md
@@ -1,0 +1,111 @@
+# Harder benchmark integration (Issue #42)
+
+Replaces the saturated `research_qa` evaluation pool (which a frontier answerer
+one-shots, pinning the judge at ceiling — see the RCA in #41) with two harder,
+externally-sourced task pools that map onto the existing `ResearchQATask` shape.
+
+## What ships in the repo vs. what is fetched
+
+**No external dataset is committed to this repository.** We map and point at
+upstream sources; you download the data yourself. This keeps the repo free of
+data whose redistribution terms are unclear (see Licensing below).
+
+| In git (owned by us) | Fetched locally (git-ignored) |
+|---|---|
+| `src/bicameral_agent/hard_benchmark.py` — mappers + fetch/load | `data/external/hard_benchmark.json` — the pulled subset |
+| `scripts/fetch_hard_benchmark.py` — fetch CLI | |
+| `tests/fixtures/hard_benchmark_sample.json` — synthetic, author-owned | |
+
+## How to fetch
+
+```bash
+python scripts/fetch_hard_benchmark.py            # defaults: 100 FRAMES + 60 CREPE
+python scripts/fetch_hard_benchmark.py --frames 200 --crepe 100
+```
+
+Writes `data/external/hard_benchmark.json` (git-ignored). Stdlib-only — no extra
+dependency, no API key. Load it in code:
+
+```python
+from bicameral_agent.hard_benchmark import load_hard_benchmark
+dataset = load_hard_benchmark()            # -> ResearchQADataset
+```
+
+`load_hard_benchmark()` raises an actionable `FileNotFoundError` if you haven't
+fetched yet. The returned `ResearchQADataset` is a drop-in for the existing
+interface and works with `select_tasks` in `scripts/run_baseline_benchmark.py`.
+
+## Datasets and mapping
+
+### Hard tier — FRAMES (`google/frames-benchmark`)
+Multi-hop factual QA requiring synthesis across multiple Wikipedia articles.
+824 questions; we pull a subset. Frontier headroom: ~0.40 accuracy with no
+retrieval, ~0.66 with a multi-step retrieval pipeline (arXiv:2409.12941).
+
+| FRAMES field | `ResearchQATask` field |
+|---|---|
+| `Prompt` | `question` |
+| `Answer` | `gold_answer` |
+| *(synthesized, anchored on the gold answer)* | `scoring_rubric` |
+| — | `difficulty = hard`, `split = eval` |
+
+FRAMES ships no rubric, so we synthesize a 1–5 rubric anchored on the gold
+answer and the multi-hop reasoning the question demands.
+
+### Tricky tier — CREPE (false-presupposition QA, arXiv:2211.17257)
+Open-domain questions built on a **false premise**, with the presupposition and
+its correction annotated. Pulled via the `tasksource/CREPE` re-host; we keep
+only rows labelled `false presupposition` that carry both a presupposition and a
+correction. Frontier models still fail false-premise correction badly
+(<30% on related false-presupposition probes).
+
+| CREPE field | `ResearchQATask` field |
+|---|---|
+| `question` | `question` |
+| `corrections` (joined) | `gold_answer` |
+| `presuppositions` | `known_assumptions` |
+| *(synthesized)* | `scoring_rubric` |
+| — | `difficulty = tricky`, `split = eval` |
+
+This is the cleanest possible mapping for the `tricky` tier: the dataset's own
+presupposition annotation populates `known_assumptions` directly, satisfying the
+`ResearchQATask` invariant that tricky tasks carry an assumption.
+
+## Licensing / attribution
+
+- **FRAMES** — Apache-2.0 (`google/frames-benchmark`). Cite: *"Fact, Fetch, and
+  Reason: A Unified Evaluation of Retrieval-Augmented Generation"*, arXiv:2409.12941.
+  Apache-2.0 would permit redistribution, but we fetch-at-build for uniformity.
+- **CREPE** — the original false-presupposition CREPE
+  (`github.com/velocityCavalry/CREPE`, arXiv:2211.17257) declares **no license**
+  (GitHub: NOASSERTION). We therefore **do not redistribute it**; the fetch
+  script pulls it locally for your own research use under the upstream terms.
+  Cite: *"CREPE: Open-Domain Question Answering with False Presuppositions"*,
+  Yu et al., ACL 2023.
+
+## Fallback datasets — and the triggers to watch for
+
+The pairing above is the primary choice. Keep these alternates in mind; each row
+is a concrete condition under which to switch.
+
+| Trigger to watch for | Fall back to |
+|---|---|
+| **Headroom collapses** — the 2026 answerer scores near-ceiling on FRAMES (the reported 0.40/0.66 figures are 2024-era Gemini-1.5-Pro; model progress may have eaten the gap). This is the #1 risk and must be checked by the #46 pilot. | **ResearchQA** (arXiv:2509.00496) or **ResearchRubrics** (arXiv:2511.07685): rubric-native long-form research QA, no system >70% rubric coverage. Better schema fit (per-question rubrics) but license/HF-loadability unconfirmed and scores were measured on agentic deep-research systems, not a one-shot answerer. |
+| **CREPE proves too easy or too noisy**, or its no-license status becomes a problem even for local use. | **FalseQA** (arXiv:2307.02394, `thunlp/FalseQA`): 2,365 human-written false-premise questions. Also has no declared license, so it is fetch-at-build only too — it was the original pick, demoted because CREPE ships presupposition+correction annotations that map more cleanly. |
+| **Single `scoring_rubric: str` can't capture rubric granularity** — ResearchQA/ResearchRubrics carry ~26 rubric items/task; collapsing to one string may lose the variance that makes them discriminating. | Extend the judge to multi-criterion scoring (overlaps with #45's discriminating-scorer work) before adopting the rubric-native sets. |
+
+## Known limitation — the pilot (AC #3) is deferred to #46
+
+Issue #42 asks for a pilot showing quality scores below ceiling with real
+variance. That can't be validly run from the dataset change alone:
+
+1. The judge currently saturates at ~5/5/5 **regardless of dataset difficulty**
+   (the `max_output_tokens=100` cap + leniency); fixing that is #45's job. A
+   pilot run now would show ceiling because of the *scorer*, not the data —
+   misleading.
+2. No Gemini API key is configured in the integration environment.
+
+So below-ceiling-with-variance is validated in **#46** (the re-run), after #45's
+discriminating-scorer fix lands. The right pilot is answerer-correctness against
+gold (independent of the judge): if the answerer gets a meaningful fraction of
+FRAMES/CREPE wrong, the headroom is real.

--- a/docs/ollama_cloud.md
+++ b/docs/ollama_cloud.md
@@ -1,0 +1,88 @@
+# Ollama Cloud backend (Issue #43)
+
+Adds a second model backend alongside Gemini so episodes/benchmarks can run
+against an open Gemma-class model. The new client is a **drop-in** for
+`GeminiClient` at every call site (`EpisodeRunner`, `SimulatedUser`,
+`TaskScorer`, tools) — it satisfies the same duck-typed contract: a `model`
+property and a `generate(...) -> GeminiResponse` method with the identical
+signature.
+
+## Model tag
+
+Default: **`gemma4:31b-cloud`** — verified against the Ollama Cloud catalog
+(`ollama.com/library/gemma4:31b-cloud`): cloud-hosted, 256K context, and a
+**reasoning model with configurable thinking modes**. This supersedes the
+issue's tentative "gemma 4 31b". The tag is configurable, never hard-coded:
+
+- CLI: `--model gemma4:31b-cloud`
+- Config: `[model] name = "gemma4:31b-cloud"`
+- Code: `OllamaCloudClient(model="…")` / `build_client("ollama", "…")`
+
+`gemma3:27b-cloud` is also available if a non-reasoning fallback is wanted.
+
+## Auth & endpoint
+
+- `OLLAMA_API_KEY` — required (Bearer token). No secret is committed.
+- `OLLAMA_HOST` — optional, defaults to `https://ollama.com`. Override for a
+  self-hosted/local Ollama (e.g. `http://localhost:11434`).
+
+Transport is stdlib `urllib` (no extra dependency): one non-streaming
+`POST {host}/api/chat`, with the same retry/backoff and client-side latency
+timing as `GeminiClient`.
+
+## Selecting the backend
+
+```bash
+# Benchmark against Gemma on Ollama Cloud
+OLLAMA_API_KEY=… uv run python scripts/run_baseline_benchmark.py \
+    --provider ollama --model gemma4:31b-cloud \
+    --tasks-per-condition 50
+```
+
+In config, set `[model] provider = "ollama"`; `HyperConfig.to_model_client()`
+builds the right client. Both paths route through
+`bicameral_agent.model_client.build_client(provider, model)`.
+
+## Parameter mapping (Gemini → Ollama `/api/chat`)
+
+| `generate(...)` arg | Ollama field |
+|---|---|
+| `messages` (role `model`) | `messages` (role `assistant`) |
+| `system_prompt` | leading `{"role":"system"}` message |
+| `thinking_level` | `think`: `minimal`→`false`, else the level string |
+| `temperature` | `options.temperature` |
+| `max_output_tokens` | `options.num_predict` |
+| `response_schema` | `format` (JSON schema, native structured output) |
+| `tools` | `tools[].function` (`parameters_json_schema`→`parameters`) |
+
+Response: `message.content`→`content`, `prompt_eval_count`/`eval_count`→
+input/output tokens, `done_reason`→`finish_reason`,
+`message.tool_calls[].function.{name,arguments}`→`function_calls[].{name,args}`.
+
+### Structured output
+
+Native — the scorer and simulated user pass a JSON schema via `response_schema`
+and parse `json.loads(response.content)` exactly as with Gemini. No shim.
+
+### Thinking
+
+`thinking_level` maps to Ollama's `think` parameter. This requires a
+reasoning-capable model; `gemma4:31b-cloud` is one. `minimal` disables thinking.
+
+## Cost
+
+Gemma cloud is subscription-flat, so `gemma4:31b-cloud` is registered in
+`MODEL_PRICING` at **$0/token**. Call and token counts still flow into
+`CostTracker` (the call counter increments); only the dollar cost is zero.
+
+## Testing
+
+- `tests/test_ollama_cloud.py` — fully offline; mocks `urllib.request.urlopen`.
+- `tests/test_model_client.py` — factory + config provider + flat-rate pricing.
+
+```bash
+uv run --extra dev python -m pytest tests/test_ollama_cloud.py tests/test_model_client.py -q
+```
+
+A live smoke run requires `OLLAMA_API_KEY` and is the only step that hits the
+network (see the benchmark command above with small `--tasks-per-condition`).

--- a/scripts/fetch_hard_benchmark.py
+++ b/scripts/fetch_hard_benchmark.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Fetch the harder external benchmark subset into a local (git-ignored) cache.
+
+The raw data is NOT redistributed in this repo (see docs/hard_benchmark.md for
+sources, licenses, and attribution). This script pulls subsets from upstream
+into ``data/external/hard_benchmark.json`` for local use; that path is
+git-ignored. Stdlib-only (urllib) -- no extra dependency.
+
+Usage:
+    python scripts/fetch_hard_benchmark.py [--frames N] [--crepe N] [--out PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bicameral_agent.hard_benchmark import _DEFAULT_CACHE, build_hard_benchmark
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--frames", type=int, default=100, help="FRAMES (hard) tasks to pull.")
+    parser.add_argument("--crepe", type=int, default=60, help="CREPE (tricky) tasks to pull.")
+    parser.add_argument("--out", type=Path, default=_DEFAULT_CACHE)
+    args = parser.parse_args(argv)
+
+    print(f"Fetching {args.frames} FRAMES + {args.crepe} CREPE tasks -> {args.out}")
+    tasks = build_hard_benchmark(args.frames, args.crepe, args.out)
+    dist = Counter(t.difficulty.value for t in tasks)
+    print(f"Wrote {len(tasks)} tasks ({dict(dist)}) to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -27,8 +27,8 @@ from bicameral_agent.baseline_benchmark import format_report, run_benchmark
 from bicameral_agent.cost_tracker import CostTracker
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeConfig, EpisodeRunner
-from bicameral_agent.gemini import GeminiClient
 from bicameral_agent.heuristic_controller import HeuristicController
+from bicameral_agent.model_client import build_client
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.serialization import episodes_to_parquet
@@ -69,6 +69,10 @@ def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default="data/baseline")
+    parser.add_argument("--provider", choices=["gemini", "ollama"], default="gemini",
+                        help="Model backend to run the answerer against.")
+    parser.add_argument("--model", default=None,
+                        help="Model id/tag (defaults to the provider's default).")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
@@ -94,7 +98,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.episode_budget is not None:
         cost_tracker.set_episode_budget(args.episode_budget)
 
-    client = GeminiClient()
+    client = build_client(args.provider, args.model)
     runner = EpisodeRunner(
         client,
         config=EpisodeConfig(max_turns=args.max_turns, score_episode=True),

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -26,9 +26,19 @@ class ModelConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    provider: str = "gemini"
     name: str = "gemini-3.1-flash-lite-preview"
     thinking_level: str = "medium"
     temperature: float | None = None
+
+    @field_validator("provider")
+    @classmethod
+    def _validate_provider(cls, v: str) -> str:
+        allowed = {"gemini", "ollama"}
+        if v not in allowed:
+            msg = f"provider must be one of {allowed}, got {v!r}"
+            raise ValueError(msg)
+        return v
 
     @field_validator("thinking_level")
     @classmethod
@@ -256,6 +266,16 @@ class HyperConfig(BaseModel):
         tracker.set_budget(self.cost.session_budget)
         tracker.set_episode_budget(self.cost.episode_budget)
         return tracker
+
+    def to_model_client(self, *, on_completion=None):
+        """Produce a model client for the configured provider and model."""
+        from bicameral_agent.model_client import build_client
+
+        return build_client(
+            self.model.provider,
+            self.model.name,
+            on_completion=on_completion,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict for episode metadata storage."""

--- a/src/bicameral_agent/cost_tracker.py
+++ b/src/bicameral_agent/cost_tracker.py
@@ -21,12 +21,21 @@ class ModelPricing:
 
 
 # Pricing in dollars per token (derived from per-million-token rates).
-GEMINI_PRICING: dict[str, ModelPricing] = {
+MODEL_PRICING: dict[str, ModelPricing] = {
     "gemini-3.1-flash-lite-preview": ModelPricing(
         input_cost_per_token=0.50 / 1_000_000,
         output_cost_per_token=3.00 / 1_000_000,
     ),
+    # Ollama Cloud Gemma is subscription-flat: $0/token so calls/tokens are
+    # still recorded (call_count increments) without inventing a per-token rate.
+    "gemma4:31b-cloud": ModelPricing(
+        input_cost_per_token=0.0,
+        output_cost_per_token=0.0,
+    ),
 }
+
+# Backwards-compatible alias (the dict previously held only Gemini models).
+GEMINI_PRICING = MODEL_PRICING
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,12 +77,12 @@ class CostTracker:
         """Record a completed API call and accumulate costs.
 
         Raises:
-            ValueError: If *model* is not in ``GEMINI_PRICING``.
+            ValueError: If *model* is not in ``MODEL_PRICING``.
         """
-        pricing = GEMINI_PRICING.get(model)
+        pricing = MODEL_PRICING.get(model)
         if pricing is None:
             raise ValueError(
-                f"Unknown model {model!r}; known models: {sorted(GEMINI_PRICING)}"
+                f"Unknown model {model!r}; known models: {sorted(MODEL_PRICING)}"
             )
         input_cost = input_tokens * pricing.input_cost_per_token
         output_cost = output_tokens * pricing.output_cost_per_token

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -4,6 +4,7 @@
 # Override per-run via TOML file or BICAMERAL_ environment variables.
 
 [model]
+provider = "gemini"        # "gemini" or "ollama"
 name = "gemini-3.1-flash-lite-preview"
 thinking_level = "medium"
 # temperature is unset (uses model default)

--- a/src/bicameral_agent/dataset.py
+++ b/src/bicameral_agent/dataset.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import enum
 import json
 from importlib.resources import files
+from pathlib import Path
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -90,6 +91,18 @@ class ResearchQADataset:
     def _load_from_package() -> list[ResearchQATask]:
         raw = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
         return [ResearchQATask.model_validate(item) for item in raw]
+
+    @classmethod
+    def from_path(cls, path) -> ResearchQADataset:
+        """Load a dataset from a JSON file of ResearchQATask records.
+
+        ``path`` may be a path string, ``Path``, or ``importlib`` traversable.
+        Used to load externally-sourced task pools (e.g. the hard benchmark)
+        that are not bundled with the package.
+        """
+        source = path if hasattr(path, "read_text") else Path(path)
+        raw = json.loads(source.read_text(encoding="utf-8"))
+        return cls([ResearchQATask.model_validate(item) for item in raw])
 
     @property
     def tasks(self) -> list[ResearchQATask]:

--- a/src/bicameral_agent/hard_benchmark.py
+++ b/src/bicameral_agent/hard_benchmark.py
@@ -1,0 +1,179 @@
+"""Loaders for harder external benchmark datasets (Issue #42).
+
+Maps two external benchmarks into the existing :class:`ResearchQATask` shape to
+give the evaluation pool real headroom above the saturated ``research_qa`` pool
+(see the RCA in issue #41):
+
+- **FRAMES** (``google/frames-benchmark``, Apache-2.0): multi-hop factual QA
+  requiring synthesis across several Wikipedia articles -> mapped to ``hard``.
+- **CREPE** (false-presupposition QA, arXiv:2211.17257): questions built on a
+  false premise, with the presupposition and its correction annotated ->
+  mapped to ``tricky``.
+
+The raw data is **not redistributed** in this repository. :func:`build_hard_benchmark`
+pulls subsets from upstream into a local, git-ignored cache; the pure
+``*_row_to_task`` mappers are import-safe and unit-tested offline against a
+synthetic fixture. See ``docs/hard_benchmark.md`` for sources, licenses, and
+attribution, and for the fallback datasets to watch for.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from .dataset import ResearchQADataset, ResearchQATask, TaskDifficulty, TaskSplit
+
+FRAMES_DATASET = "google/frames-benchmark"
+# tasksource re-host of the false-presupposition CREPE (arXiv:2211.17257);
+# carries the presuppositions/corrections annotations we map from.
+CREPE_DATASET = "tasksource/CREPE"
+
+_HF_ROWS_ENDPOINT = "https://datasets-server.huggingface.co/rows"
+_DEFAULT_CACHE = Path("data/external/hard_benchmark.json")
+_USER_AGENT = "bicameral-agent/0.1 (research eval; issue-42)"
+
+
+# --- pure mappers (offline-testable) ----------------------------------------
+
+def frames_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one raw FRAMES row into a ``hard`` ResearchQATask.
+
+    FRAMES ships no rubric, so we synthesize one anchored on the gold answer
+    and the multi-hop reasoning the question demands.
+    """
+    question = (row.get("Prompt") or "").strip()
+    answer = (row.get("Answer") or "").strip()
+    rubric = (
+        f"5: States the correct answer ('{answer}') and shows the multi-hop "
+        "reasoning linking the required facts. 4: Correct answer with thin "
+        "justification. 3: Partially correct, or correct answer with no "
+        "reasoning. 2: Relevant facts but wrong final answer. 1: Incorrect."
+    )
+    return ResearchQATask(
+        task_id=f"frames_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=answer,
+        scoring_rubric=rubric,
+    )
+
+
+def crepe_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one raw CREPE false-presupposition row into a ``tricky`` task.
+
+    The annotated presupposition(s) become ``known_assumptions`` and the
+    annotated correction(s) become the gold answer.
+    """
+    question = (row.get("question") or "").strip()
+    presups = [p.strip() for p in (row.get("presuppositions") or []) if p and p.strip()]
+    corrections = [c.strip() for c in (row.get("corrections") or []) if c and c.strip()]
+    gold = " ".join(corrections)
+    rubric = (
+        "5: Flags that the question rests on a false presupposition AND states "
+        "the correction. 4: Identifies the false premise but corrects it "
+        "vaguely. 3: Hedges or only partially questions the premise. 2: Answers "
+        "as asked without noticing the false premise. 1: Affirms the false "
+        "premise."
+    )
+    return ResearchQATask(
+        task_id=f"crepe_tricky_{index:03d}",
+        difficulty=TaskDifficulty.TRICKY,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=gold,
+        scoring_rubric=rubric,
+        known_assumptions=presups,
+    )
+
+
+# --- upstream fetch ---------------------------------------------------------
+
+def _http_get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
+        return json.loads(resp.read())
+
+
+def _fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict]:
+    url = (
+        f"{_HF_ROWS_ENDPOINT}?dataset={urllib.parse.quote(dataset)}"
+        f"&config=default&split={split}&offset={offset}&length={length}"
+    )
+    return [row["row"] for row in _http_get_json(url).get("rows", [])]
+
+
+def fetch_frames(limit: int = 100, split: str = "test") -> list[ResearchQATask]:
+    """Pull a subset of FRAMES rows and map them to ``hard`` tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = _fetch_page(FRAMES_DATASET, split, offset, min(100, limit - len(tasks)))
+        if not page:
+            break
+        for raw in page:
+            if (raw.get("Prompt") or "").strip() and (raw.get("Answer") or "").strip():
+                tasks.append(frames_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+def fetch_crepe(limit: int = 60, split: str = "test") -> list[ResearchQATask]:
+    """Scan CREPE and map false-presupposition rows to ``tricky`` tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = _fetch_page(CREPE_DATASET, split, offset, 100)
+        if not page:
+            break
+        for raw in page:
+            presups = [p for p in (raw.get("presuppositions") or []) if p and p.strip()]
+            corrections = [c for c in (raw.get("corrections") or []) if c and c.strip()]
+            if presups and corrections:
+                tasks.append(crepe_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+def build_hard_benchmark(
+    frames_n: int = 100,
+    crepe_n: int = 60,
+    cache_path: Path = _DEFAULT_CACHE,
+) -> list[ResearchQATask]:
+    """Fetch subsets from upstream and write a normalized JSON cache.
+
+    The cache file is git-ignored; it is the artifact :func:`load_hard_benchmark`
+    reads. Returns the combined task list.
+    """
+    tasks = fetch_frames(frames_n) + fetch_crepe(crepe_n)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps([t.model_dump(mode="json") for t in tasks], indent=2),
+        encoding="utf-8",
+    )
+    return tasks
+
+
+# --- read path --------------------------------------------------------------
+
+def load_hard_benchmark(cache_path: Path = _DEFAULT_CACHE) -> ResearchQADataset:
+    """Load the cached hard-benchmark tasks into a :class:`ResearchQADataset`.
+
+    Raises ``FileNotFoundError`` with fetch instructions if the cache is absent
+    (the data is not committed to the repo).
+    """
+    cache_path = Path(cache_path)
+    if not cache_path.exists():
+        raise FileNotFoundError(
+            f"Hard benchmark cache not found at {cache_path}. The data is not "
+            "committed to the repo -- run `python scripts/fetch_hard_benchmark.py` "
+            "first. See docs/hard_benchmark.md for sources and attribution."
+        )
+    return ResearchQADataset.from_path(cache_path)

--- a/src/bicameral_agent/model_client.py
+++ b/src/bicameral_agent/model_client.py
@@ -1,0 +1,47 @@
+"""Model-client factory: pick a backend by provider name (issue #43).
+
+Single source of truth for translating a ``provider`` string into a concrete
+client (``GeminiClient`` or ``OllamaCloudClient``). Both satisfy the same
+duck-typed contract, so callers downstream are provider-agnostic.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.ollama_cloud import OllamaCloudClient
+
+_PROVIDERS = ("gemini", "ollama")
+
+
+def build_client(
+    provider: str = "gemini",
+    model: str | None = None,
+    *,
+    api_key: str | None = None,
+    on_completion: Callable[[int, int, float], None] | None = None,
+):
+    """Construct a model client for *provider*.
+
+    Args:
+        provider: 'gemini' or 'ollama'.
+        model: Model id/tag; None uses the client's own default.
+        api_key: Optional explicit API key (else read from the provider's env var).
+        on_completion: Optional ``(input_tokens, output_tokens, duration_ms)`` callback.
+
+    Returns:
+        A ``GeminiClient`` or ``OllamaCloudClient``.
+
+    Raises:
+        ValueError: If *provider* is not recognised.
+    """
+    kwargs: dict = {"api_key": api_key, "on_completion": on_completion}
+    if model is not None:
+        kwargs["model"] = model
+
+    if provider == "gemini":
+        return GeminiClient(**kwargs)
+    if provider == "ollama":
+        return OllamaCloudClient(**kwargs)
+    raise ValueError(f"Unknown provider {provider!r}; known providers: {list(_PROVIDERS)}")

--- a/src/bicameral_agent/ollama_cloud.py
+++ b/src/bicameral_agent/ollama_cloud.py
@@ -1,0 +1,240 @@
+"""Thin wrapper around the Ollama Cloud chat API (issue #43).
+
+A drop-in alternative to ``GeminiClient`` for running episodes/benchmarks
+against an open Gemma-class model. Mirrors the ``GeminiClient`` interface
+exactly -- same ``generate(...)`` signature, same ``GeminiResponse`` return
+type, same retry/timing/callback behaviour -- so it is interchangeable at every
+call site (``EpisodeRunner``, ``SimulatedUser``, ``TaskScorer``, tools).
+
+Transport is stdlib ``urllib`` (no extra dependency): a single non-streaming
+``POST`` to ``{host}/api/chat`` with a Bearer token. The native Ollama chat
+endpoint accepts a JSON schema in its ``format`` field for structured output and
+returns the JSON as ``message.content`` -- the same shape the scorer and
+simulated user already parse with ``json.loads(response.content)``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Callable
+
+from bicameral_agent.gemini import ChatMessage, GeminiResponse
+
+_MODEL = "gemma4:31b-cloud"
+_DEFAULT_HOST = "https://ollama.com"
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0
+_BACKOFF_FACTOR = 2.0
+_MAX_JITTER = 0.5
+_TIMEOUT_S = 120.0
+
+_VALID_THINKING_LEVELS = {"minimal", "low", "medium", "high"}
+
+
+class OllamaCloudClient:
+    """Thin wrapper around the Ollama Cloud chat API with retry, timing, callbacks.
+
+    Thread-safe: no mutable state after __init__.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        on_completion: Callable[[int, int, float], None] | None = None,
+        model: str = _MODEL,
+        host: str | None = None,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("OLLAMA_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "API key required: pass api_key= or set OLLAMA_API_KEY env var"
+            )
+        self._api_key = resolved_key
+        self._on_completion = on_completion
+        self._model = model
+        self._host = (host or os.environ.get("OLLAMA_HOST") or _DEFAULT_HOST).rstrip("/")
+
+    @property
+    def model(self) -> str:
+        """The model name used for API calls."""
+        return self._model
+
+    def generate(
+        self,
+        messages: list[ChatMessage] | list[dict[str, str]],
+        *,
+        system_prompt: str | None = None,
+        thinking_level: str = "medium",
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+        tools: list[dict] | None = None,
+        response_schema: dict | None = None,
+    ) -> GeminiResponse:
+        """Generate a response from the Ollama Cloud chat API.
+
+        Args mirror ``GeminiClient.generate`` for drop-in compatibility:
+            messages: Conversation history with 'role' and 'content' keys.
+            system_prompt: Optional system instruction (prepended as a system message).
+            thinking_level: 'minimal', 'low', 'medium', 'high'. 'minimal' disables
+                thinking; the rest map to Ollama's ``think`` string. Requires a
+                reasoning-capable model (e.g. gemma4:31b-cloud).
+            temperature: Sampling temperature; None uses model default.
+            max_output_tokens: Maps to Ollama ``options.num_predict``.
+            tools: Function declarations (dicts with 'name', 'description',
+                'parameters_json_schema' keys), translated to Ollama tool format.
+            response_schema: JSON schema dict; passed through to Ollama ``format``.
+
+        Returns:
+            GeminiResponse with content, token counts, timing, and finish reason.
+        """
+        if thinking_level.lower() not in _VALID_THINKING_LEVELS:
+            raise ValueError(
+                f"Invalid thinking_level {thinking_level!r}; "
+                f"must be one of {sorted(_VALID_THINKING_LEVELS)}"
+            )
+
+        payload = self._build_payload(
+            messages,
+            system_prompt=system_prompt,
+            thinking_level=thinking_level.lower(),
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            tools=tools,
+            response_schema=response_schema,
+        )
+        return self._execute_with_retry(payload)
+
+    def _build_payload(
+        self,
+        messages: list[ChatMessage] | list[dict[str, str]],
+        *,
+        system_prompt: str | None,
+        thinking_level: str,
+        temperature: float | None,
+        max_output_tokens: int | None,
+        tools: list[dict] | None,
+        response_schema: dict | None,
+    ) -> dict[str, Any]:
+        api_messages: list[dict[str, str]] = []
+        if system_prompt is not None:
+            api_messages.append({"role": "system", "content": system_prompt})
+        for msg in messages:
+            if isinstance(msg, ChatMessage):
+                role, content = msg.role, msg.content
+            else:
+                role, content = msg["role"], msg["content"]
+            # Gemini uses 'model' for the assistant turn; Ollama uses 'assistant'.
+            if role == "model":
+                role = "assistant"
+            api_messages.append({"role": role, "content": content})
+
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": api_messages,
+            "stream": False,
+            # 'minimal' means "don't think"; other levels pass through.
+            "think": False if thinking_level == "minimal" else thinking_level,
+        }
+
+        options: dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if max_output_tokens is not None:
+            options["num_predict"] = max_output_tokens
+        if options:
+            payload["options"] = options
+
+        if response_schema is not None:
+            payload["format"] = response_schema
+
+        if tools is not None:
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": decl["name"],
+                        "description": decl.get("description", ""),
+                        "parameters": decl.get("parameters_json_schema", {}),
+                    },
+                }
+                for decl in tools
+            ]
+
+        return payload
+
+    def _execute_with_retry(self, payload: dict[str, Any]) -> GeminiResponse:
+        last_exc: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            if attempt > 0:
+                delay = _BASE_DELAY * (_BACKOFF_FACTOR ** (attempt - 1))
+                jitter = random.uniform(0, _MAX_JITTER)
+                time.sleep(delay + jitter)
+
+            try:
+                start_ns = time.monotonic_ns()
+                data = self._post(payload)
+                duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+                return self._parse_response(data, duration_ms)
+
+            except Exception as exc:
+                if self._is_retryable(exc) and attempt < _MAX_RETRIES:
+                    last_exc = exc
+                    continue
+                raise
+
+        raise last_exc  # type: ignore[misc]
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._host}/api/chat",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _parse_response(self, data: dict[str, Any], duration_ms: float) -> GeminiResponse:
+        input_tokens = data.get("prompt_eval_count") or 0
+        output_tokens = data.get("eval_count") or 0
+        finish_reason = data.get("done_reason") or "stop"
+
+        message = data.get("message") or {}
+        content = message.get("content") or ""
+
+        fc_parts: list[dict[str, Any]] = []
+        for call in message.get("tool_calls") or []:
+            fn = call.get("function") or {}
+            fc_parts.append({
+                "name": fn.get("name"),
+                "args": dict(fn.get("arguments") or {}),
+            })
+
+        if self._on_completion is not None:
+            self._on_completion(input_tokens, output_tokens, duration_ms)
+
+        return GeminiResponse(
+            content=content,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_ms=duration_ms,
+            finish_reason=finish_reason,
+            function_calls=fc_parts or None,
+        )
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        if isinstance(exc, urllib.error.HTTPError):
+            return exc.code == 429 or 500 <= exc.code < 600
+        # Network-level failures (timeouts, connection resets) are transient.
+        return isinstance(exc, urllib.error.URLError)

--- a/tests/fixtures/hard_benchmark_sample.json
+++ b/tests/fixtures/hard_benchmark_sample.json
@@ -1,0 +1,35 @@
+[
+  {
+    "task_id": "frames_hard_001",
+    "difficulty": "hard",
+    "split": "eval",
+    "question": "The author who wrote the novel that won the first Booker Prize was born in a country that later changed its name. What is that country's current name?",
+    "gold_answer": "Sri Lanka",
+    "scoring_rubric": "5: States the correct answer ('Sri Lanka') and shows the multi-hop reasoning linking the required facts. 4: Correct answer with thin justification. 3: Partially correct, or correct answer with no reasoning. 2: Relevant facts but wrong final answer. 1: Incorrect.",
+    "known_gaps": null,
+    "known_assumptions": null
+  },
+  {
+    "task_id": "frames_hard_002",
+    "difficulty": "hard",
+    "split": "eval",
+    "question": "How many years passed between the founding of the city that hosted the first modern Olympic Games and the founding of the city that hosted the second?",
+    "gold_answer": "Synthetic placeholder answer for offline schema testing.",
+    "scoring_rubric": "5: States the correct answer and shows the multi-hop reasoning linking the required facts. 4: Correct answer with thin justification. 3: Partially correct, or correct answer with no reasoning. 2: Relevant facts but wrong final answer. 1: Incorrect.",
+    "known_gaps": null,
+    "known_assumptions": null
+  },
+  {
+    "task_id": "crepe_tricky_001",
+    "difficulty": "tricky",
+    "split": "eval",
+    "question": "Why does the Great Wall of China stay warm enough at night to be visible by its heat signature from the Moon?",
+    "gold_answer": "The Great Wall is not warm enough to be visible from the Moon by heat signature, nor is it visible from the Moon at all; the premise is false.",
+    "scoring_rubric": "5: Flags that the question rests on a false presupposition AND states the correction. 4: Identifies the false premise but corrects it vaguely. 3: Hedges or only partially questions the premise. 2: Answers as asked without noticing the false premise. 1: Affirms the false premise.",
+    "known_gaps": null,
+    "known_assumptions": [
+      "The Great Wall of China is visible from the Moon.",
+      "The Great Wall emits a detectable heat signature at night."
+    ]
+  }
+]

--- a/tests/test_hard_benchmark.py
+++ b/tests/test_hard_benchmark.py
@@ -1,0 +1,75 @@
+"""Schema + loader smoke tests for the harder benchmark integration (Issue #42).
+
+Runs fully offline: the upstream mappers are exercised against synthetic raw
+rows, and the loader against a committed author-owned fixture. No network and
+no externally-licensed data are required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from bicameral_agent.dataset import ResearchQADataset, TaskDifficulty, TaskSplit
+from bicameral_agent.hard_benchmark import (
+    crepe_row_to_task,
+    frames_row_to_task,
+    load_hard_benchmark,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "hard_benchmark_sample.json"
+
+
+class TestFramesMapper:
+    def test_maps_to_hard_eval_task(self):
+        row = {
+            "Prompt": "Who succeeded the monarch who reigned during the Great Fire of London?",
+            "Answer": "James II",
+            "reasoning_types": "Multiple constraints",
+        }
+        task = frames_row_to_task(row, 1)
+        assert task.task_id == "frames_hard_001"
+        assert task.difficulty == TaskDifficulty.HARD
+        assert task.split == TaskSplit.EVAL
+        assert task.gold_answer == "James II"
+        assert "James II" in task.scoring_rubric  # rubric anchored on gold answer
+        assert task.known_assumptions is None
+
+
+class TestCrepeMapper:
+    def test_maps_to_tricky_with_assumptions(self):
+        row = {
+            "question": "Why are deleted files unrecoverable from an SSD?",
+            "presuppositions": ["Deleted files are unrecoverable from an SSD."],
+            "corrections": ["Deleted files often remain recoverable until overwritten."],
+            "labels": ["false presupposition"],
+        }
+        task = crepe_row_to_task(row, 1)
+        assert task.task_id == "crepe_tricky_001"
+        assert task.difficulty == TaskDifficulty.TRICKY
+        assert task.known_assumptions == ["Deleted files are unrecoverable from an SSD."]
+        assert task.gold_answer == "Deleted files often remain recoverable until overwritten."
+
+    def test_tricky_without_presupposition_is_rejected(self):
+        # The dataset validator requires tricky tasks to carry an assumption;
+        # the fetch path filters such rows out, but guard the invariant here.
+        row = {"question": "x", "presuppositions": [], "corrections": ["y"]}
+        with pytest.raises(ValueError, match="known_assumptions"):
+            crepe_row_to_task(row, 1)
+
+
+class TestLoader:
+    def test_loads_fixture_via_from_path(self):
+        ds = ResearchQADataset.from_path(FIXTURE)
+        assert len(ds) == 3
+        assert len(ds.by_difficulty(TaskDifficulty.HARD)) == 2
+        assert len(ds.by_difficulty(TaskDifficulty.TRICKY)) == 1
+        for task in ds:
+            assert task.question
+            assert task.gold_answer
+            assert task.scoring_rubric
+            assert task.split == TaskSplit.EVAL
+
+    def test_load_hard_benchmark_missing_cache_is_actionable(self, tmp_path):
+        missing = tmp_path / "nope.json"
+        with pytest.raises(FileNotFoundError, match="fetch_hard_benchmark"):
+            load_hard_benchmark(missing)

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1,0 +1,69 @@
+"""Tests for provider/backend selection wiring (Issue #43).
+
+Covers the ``build_client`` factory, the ``ModelConfig.provider`` field, the
+``HyperConfig.to_model_client`` adapter, and that the Ollama Gemma tag is a
+known (flat-rate) model for ``CostTracker``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bicameral_agent.config import HyperConfig, ModelConfig
+from bicameral_agent.cost_tracker import MODEL_PRICING, CostTracker
+from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.model_client import build_client
+from bicameral_agent.ollama_cloud import OllamaCloudClient
+
+
+class TestBuildClient:
+    def test_gemini_provider(self):
+        client = build_client("gemini", api_key="k")
+        assert isinstance(client, GeminiClient)
+
+    def test_ollama_provider(self):
+        client = build_client("ollama", api_key="k")
+        assert isinstance(client, OllamaCloudClient)
+        assert client.model == "gemma4:31b-cloud"
+
+    def test_model_override(self):
+        client = build_client("ollama", "gemma3:27b-cloud", api_key="k")
+        assert client.model == "gemma3:27b-cloud"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            build_client("anthropic", api_key="k")
+
+
+class TestModelConfigProvider:
+    def test_default_provider_is_gemini(self):
+        assert ModelConfig().provider == "gemini"
+
+    def test_ollama_provider_allowed(self):
+        assert ModelConfig(provider="ollama").provider == "ollama"
+
+    def test_invalid_provider_rejected(self):
+        with pytest.raises(ValueError, match="provider must be one of"):
+            ModelConfig(provider="openai")
+
+    def test_to_model_client_uses_provider(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "k")
+        config = HyperConfig(model=ModelConfig(provider="ollama", name="gemma4:31b-cloud"))
+        client = config.to_model_client()
+        assert isinstance(client, OllamaCloudClient)
+        assert client.model == "gemma4:31b-cloud"
+
+
+class TestGemmaPricing:
+    def test_gemma_is_known_flat_rate_model(self):
+        assert "gemma4:31b-cloud" in MODEL_PRICING
+        pricing = MODEL_PRICING["gemma4:31b-cloud"]
+        assert pricing.input_cost_per_token == 0.0
+        assert pricing.output_cost_per_token == 0.0
+
+    def test_record_call_counts_without_cost(self):
+        tracker = CostTracker()
+        tracker.record_call(1000, 500, "gemma4:31b-cloud")
+        report = tracker.get_total()
+        assert report.call_count == 1
+        assert report.total == 0.0

--- a/tests/test_ollama_cloud.py
+++ b/tests/test_ollama_cloud.py
@@ -1,0 +1,324 @@
+"""Tests for the Ollama Cloud client wrapper (Issue #43).
+
+Runs fully offline: the HTTP transport (``urllib.request.urlopen``) is mocked,
+so no live calls and no API key are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bicameral_agent.gemini import ChatMessage, GeminiResponse
+from bicameral_agent.ollama_cloud import (
+    _MAX_RETRIES,
+    OllamaCloudClient,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response_body(
+    *,
+    content="Hello!",
+    prompt_eval_count=10,
+    eval_count=5,
+    done_reason="stop",
+    tool_calls=None,
+) -> bytes:
+    """Serialise a fake Ollama /api/chat response body."""
+    message: dict = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return json.dumps({
+        "model": "gemma4:31b-cloud",
+        "message": message,
+        "done": True,
+        "done_reason": done_reason,
+        "prompt_eval_count": prompt_eval_count,
+        "eval_count": eval_count,
+    }).encode("utf-8")
+
+
+class _FakeHTTPResponse(io.BytesIO):
+    """Minimal context-manager stand-in for an ``http.client.HTTPResponse``."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def _urlopen_returning(body: bytes):
+    """A urlopen replacement that records the request and returns *body*."""
+    captured = {}
+
+    def _fake(request, timeout=None):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _FakeHTTPResponse(body)
+
+    return _fake, captured
+
+
+def _sent_payload(captured) -> dict:
+    """Decode the JSON body of the captured request."""
+    return json.loads(captured["request"].data.decode("utf-8"))
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://ollama.com/api/chat", code=code, msg="err", hdrs=None, fp=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Client init / auth
+# ---------------------------------------------------------------------------
+
+
+class TestClientInit:
+    def test_api_key_from_param(self):
+        client = OllamaCloudClient(api_key="my-key")
+        assert client.model == "gemma4:31b-cloud"
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "env-key")
+        client = OllamaCloudClient()
+        assert client._api_key == "env-key"
+
+    def test_no_key_raises(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="API key required"):
+            OllamaCloudClient()
+
+    def test_custom_model(self):
+        client = OllamaCloudClient(api_key="k", model="gemma3:27b-cloud")
+        assert client.model == "gemma3:27b-cloud"
+
+    def test_host_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert OllamaCloudClient(api_key="k")._host == "https://ollama.com"
+        client = OllamaCloudClient(api_key="k", host="http://localhost:11434/")
+        assert client._host == "http://localhost:11434"
+
+
+# ---------------------------------------------------------------------------
+# Request building
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBuilding:
+    def test_bearer_header_and_endpoint(self):
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="secret").generate([{"role": "user", "content": "hi"}])
+        request = captured["request"]
+        assert request.full_url == "https://ollama.com/api/chat"
+        assert request.get_header("Authorization") == "Bearer secret"
+        assert _sent_payload(captured)["stream"] is False
+
+    def test_role_mapping_and_system_prompt(self):
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [ChatMessage(role="model", content="prev"),
+                 ChatMessage(role="user", content="now")],
+                system_prompt="be terse",
+            )
+        messages = _sent_payload(captured)["messages"]
+        assert messages[0] == {"role": "system", "content": "be terse"}
+        # Gemini's 'model' role becomes Ollama's 'assistant'.
+        assert messages[1] == {"role": "assistant", "content": "prev"}
+        assert messages[2] == {"role": "user", "content": "now"}
+
+    def test_thinking_level_mapping(self):
+        for level, expected in [("minimal", False), ("low", "low"),
+                                ("medium", "medium"), ("high", "high")]:
+            fake, captured = _urlopen_returning(_make_response_body())
+            with patch("urllib.request.urlopen", fake):
+                OllamaCloudClient(api_key="k").generate(
+                    [{"role": "user", "content": "x"}], thinking_level=level
+                )
+            assert _sent_payload(captured)["think"] == expected
+
+    def test_invalid_thinking_level_raises(self):
+        with pytest.raises(ValueError, match="thinking_level"):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}], thinking_level="bogus"
+            )
+
+    def test_options_temperature_and_max_tokens(self):
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}],
+                temperature=0.0,
+                max_output_tokens=100,
+            )
+        options = _sent_payload(captured)["options"]
+        assert options == {"temperature": 0.0, "num_predict": 100}
+
+    def test_options_omitted_when_unset(self):
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        assert "options" not in _sent_payload(captured)
+
+    def test_response_schema_passthrough_to_format(self):
+        schema = {"type": "object", "properties": {"q": {"type": "integer"}}}
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}], response_schema=schema
+            )
+        assert _sent_payload(captured)["format"] == schema
+
+    def test_tools_translated_to_ollama_format(self):
+        tools = [{
+            "name": "get_weather",
+            "description": "look up weather",
+            "parameters_json_schema": {"type": "object", "properties": {}},
+        }]
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}], tools=tools
+            )
+        sent = _sent_payload(captured)["tools"]
+        assert sent == [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "look up weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestResponseParsing:
+    def test_content_and_token_mapping(self):
+        body = _make_response_body(content="answer", prompt_eval_count=12, eval_count=7)
+        fake, _ = _urlopen_returning(body)
+        with patch("urllib.request.urlopen", fake):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}]
+            )
+        assert isinstance(result, GeminiResponse)
+        assert result.content == "answer"
+        assert result.input_tokens == 12
+        assert result.output_tokens == 7
+        assert result.finish_reason == "stop"
+        assert result.function_calls is None
+        assert result.duration_ms >= 0.0
+
+    def test_structured_output_roundtrip(self):
+        body = _make_response_body(content='{"quality": 5, "accuracy": 4}')
+        fake, _ = _urlopen_returning(body)
+        with patch("urllib.request.urlopen", fake):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}],
+                response_schema={"type": "object"},
+            )
+        assert json.loads(result.content) == {"quality": 5, "accuracy": 4}
+
+    def test_tool_calls_parsed(self):
+        body = _make_response_body(
+            content="",
+            tool_calls=[{"function": {"name": "f", "arguments": {"a": 1}}}],
+        )
+        fake, _ = _urlopen_returning(body)
+        with patch("urllib.request.urlopen", fake):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}]
+            )
+        assert result.function_calls == [{"name": "f", "args": {"a": 1}}]
+
+    def test_on_completion_callback(self):
+        callback = MagicMock()
+        body = _make_response_body(prompt_eval_count=3, eval_count=9)
+        fake, _ = _urlopen_returning(body)
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k", on_completion=callback).generate(
+                [{"role": "user", "content": "x"}]
+            )
+        callback.assert_called_once()
+        in_toks, out_toks, duration = callback.call_args.args
+        assert in_toks == 3
+        assert out_toks == 9
+        assert duration >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_retries_on_429_then_succeeds(self):
+        calls = {"n": 0}
+
+        def _fake(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _http_error(429)
+            return _FakeHTTPResponse(_make_response_body(content="ok"))
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep"):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}]
+            )
+        assert result.content == "ok"
+        assert calls["n"] == 2
+
+    def test_retries_on_503_then_succeeds(self):
+        calls = {"n": 0}
+
+        def _fake(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] <= 1:
+                raise _http_error(503)
+            return _FakeHTTPResponse(_make_response_body())
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep"):
+            OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        assert calls["n"] == 2
+
+    def test_non_retryable_4xx_raises_immediately(self):
+        calls = {"n": 0}
+
+        def _fake(request, timeout=None):
+            calls["n"] += 1
+            raise _http_error(400)
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep"):
+            with pytest.raises(urllib.error.HTTPError):
+                OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        assert calls["n"] == 1
+
+    def test_gives_up_after_max_retries(self):
+        def _fake(request, timeout=None):
+            raise _http_error(500)
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep") as sleep:
+            with pytest.raises(urllib.error.HTTPError):
+                OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        assert sleep.call_count == _MAX_RETRIES


### PR DESCRIPTION
## Summary
- Lands the previously uncommitted #42 hard-benchmark implementation (FRAMES + CREPE mappers, fetch CLI, fixture, tests, docs) as its own commit.
- Lands the previously uncommitted #43 Ollama Cloud implementation (client, model_client factory, config/cost-tracker plumbing, benchmark CLI flags, tests, docs) as a second commit.
- Both gates (pytest, ruff) run green on the combined tree.

## Work performed
- `src/bicameral_agent/hard_benchmark.py`, `scripts/fetch_hard_benchmark.py`: FRAMES + CREPE mappers and the fetch/convert CLI (#42 work item).
- `src/bicameral_agent/dataset.py`: adds `dataset.from_path()` so converted benchmark files load directly (#42 work item).
- `tests/fixtures/hard_benchmark_sample.json`, `tests/test_hard_benchmark.py`: checked-in sample fixture and unit tests (#42 work item).
- `docs/hard_benchmark.md`, `docs/benchmark_comparison_issue42.md`: usage docs and the benchmark comparison behind the dataset choice (#42 work item).
- `.gitignore`: ignores `data/external/` raw downloads (#42 work item).
- `src/bicameral_agent/model_client.py`, `src/bicameral_agent/ollama_cloud.py`: Ollama Cloud client and provider-selecting model_client factory (#43 work item).
- `src/bicameral_agent/config.py`, `src/bicameral_agent/data/default_config.toml`: provider field and `to_model_client()` plumbing (#43 work item).
- `src/bicameral_agent/cost_tracker.py`: `MODEL_PRICING` rename so per-model rates cover both providers (#43 work item).
- `scripts/run_baseline_benchmark.py`: CLI flags for provider/model selection (#43 work item).
- `tests/test_model_client.py`, `tests/test_ollama_cloud.py`, `docs/ollama_cloud.md`: unit tests and setup docs (#43 work item).

## Test plan
- [x] `uv run --extra torch pytest -q` — 929 passed, 34 skipped (plain `uv run pytest` fails collection on the pre-existing optional `torch` extra in `tests/test_policy_value_net.py`, unrelated to this change).
- [x] `uv run ruff check src/ tests/` — all checks passed.
- [ ] Live Ollama smoke run (small `--tasks-per-condition`, `gemma4:31b-cloud` tag only until #52 lands) — BLOCKED: `OLLAMA_API_KEY` is not set in this environment; requires operator credentials to run manually.

Closes #43
Closes #57