### PR TITLE
Make injected context persist in history behind a config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The hypothesis: a small neural network trained via Monte Carlo Tree Search can l
                          └──────────────────────┘
 ```
 
+**Injection persistence**: by default, context drained from the queue is folded into the user message that enters conversation history, so injected findings stay visible to every later generation (and their tokens are accounted once, at injection). Setting `queue.persistent_injection = false` switches to transient "whisper" mode, where injected context is shown to the model for exactly one generation and then vanishes from history — kept as an experimental variable for A/B comparison.
+
 ## Project Phases
 
 The project is organized into 6 phases with 40 tracked issues:

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -49,7 +49,7 @@ class ModelConfig(BaseModel):
 
 
 class QueueConfig(BaseModel):
-    """Context queue thresholds."""
+    """Context queue thresholds and injection semantics."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -58,6 +58,7 @@ class QueueConfig(BaseModel):
     token_threshold: int = 1000
     expiry_turns: int = 10
     max_depth: int = 3
+    persistent_injection: bool = True
 
 
 class ToolBudgetConfig(BaseModel):
@@ -223,6 +224,7 @@ class HyperConfig(BaseModel):
             "thinking_level": self.model.thinking_level,
             "interrupt_config": self.to_interrupt_config(),
             "tool_token_budget": self.to_token_budget(),
+            "persistent_injection": self.queue.persistent_injection,
         }
         defaults.update(overrides)
         return EpisodeConfig(**defaults)

--- a/src/bicameral_agent/conscious_loop.py
+++ b/src/bicameral_agent/conscious_loop.py
@@ -174,10 +174,11 @@ class ConsciousLoop:
     def regenerate_with_context(self, context_str: str) -> AssistantResponse:
         """Re-generate the last assistant response with additional context.
 
-        Pops the last model message from history, finds the last user message,
-        and regenerates with the provided context. Does NOT increment turn count.
-        In persistent mode, the stored user message is replaced with the
-        context-augmented one so the context stays visible on later turns.
+        Pops the last model message from history, then regenerates the
+        preceding user message with the provided context. Does NOT increment
+        turn count. In persistent mode, the stored user message is replaced
+        with the context-augmented one so the context stays visible on later
+        turns.
         """
         if not self._history or self._history[-1].role != "model":
             raise ValueError("No model message to replace in history")
@@ -185,22 +186,20 @@ class ConsciousLoop:
         # Pop the last model message
         self._history.pop()
 
-        # Find the last user message
-        last_user_idx = None
-        for idx in range(len(self._history) - 1, -1, -1):
-            if self._history[idx].role == "user":
-                last_user_idx = idx
-                break
-        if last_user_idx is None:
+        # History must now end with the user message that prompted the
+        # replaced response — _generate builds its prompt as history[:-1]
+        # plus the (augmented) last message, so any other shape would
+        # silently duplicate messages.
+        if not self._history or self._history[-1].role != "user":
             raise ValueError("No user message found in history")
-        last_user_msg = self._history[last_user_idx].content
+        last_user_msg = self._history[-1].content
 
         start_ns = time.monotonic_ns()
         response = self._generate(last_user_msg, context_str)
         duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
 
         if self._persistent_injection:
-            self._history[last_user_idx] = ChatMessage(
+            self._history[-1] = ChatMessage(
                 role="user", content=_augment(last_user_msg, context_str)
             )
 

--- a/src/bicameral_agent/conscious_loop.py
+++ b/src/bicameral_agent/conscious_loop.py
@@ -3,6 +3,16 @@
 Orchestrates the conscious loop: runs generation turns, injects context from the
 ContextQueue at breakpoints, and handles interrupts when critical context arrives
 mid-generation.
+
+Injection persistence semantics (issue #49): by default injected context is
+*persistent* — the context-augmented user message is what enters conversation
+history, so injected findings remain visible to every subsequent generation.
+Because the queue drain is destructive and the augmented message is stored
+exactly once, the injected text is token-accounted once at injection and then
+carried as ordinary history. Passing ``persistent_injection=False`` restores
+the *transient* "whisper" behavior: context is prepended only for the
+immediate API call and vanishes from history afterwards, so it influences
+exactly one generation.
 """
 
 from __future__ import annotations
@@ -35,6 +45,13 @@ class ConsciousLoop:
     Each call to run_turn() sends a user message, checks for queued context
     at breakpoints, generates a response, and optionally interrupts and
     retries if critical context arrives during generation.
+
+    ``persistent_injection`` controls visibility of injected context across
+    turns. When True (default), the context-augmented user message is stored
+    in history, so injected context stays visible to all later generations
+    and is token-accounted exactly once. When False, injected context is
+    used only for the immediate API call (transient "whisper" mode) and
+    vanishes from history after one generation.
     """
 
     def __init__(
@@ -46,6 +63,7 @@ class ConsciousLoop:
         thinking_level: str = "medium",
         interrupt_config: InterruptConfig | None = None,
         on_completion: Callable[[AssistantResponse], None] | None = None,
+        persistent_injection: bool = True,
     ) -> None:
         self._client = client
         self._queue = queue
@@ -53,6 +71,7 @@ class ConsciousLoop:
         self._thinking_level = thinking_level
         self._interrupt_config = interrupt_config or InterruptConfig()
         self._on_completion = on_completion
+        self._persistent_injection = persistent_injection
         self._history: list[ChatMessage] = []
         self._turn_count = 0
 
@@ -74,7 +93,8 @@ class ConsciousLoop:
         3. Build messages and generate
         4. Check interrupt threshold — if triggered, report wasted tokens,
            freeze, drain again, regenerate
-        5. Unfreeze, append assistant response to history
+        5. Unfreeze; in persistent mode, replace the stored user message with
+           the context-augmented one; append assistant response to history
         6. Fire on_completion callback, return AssistantResponse
         """
         self._turn_count += 1
@@ -118,6 +138,14 @@ class ConsciousLoop:
 
         duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
 
+        if context_str is not None and self._persistent_injection:
+            # Persist the augmented message so injected context stays visible
+            # on later turns. It enters history exactly once (the drain was
+            # destructive), so its tokens are accounted once at injection.
+            self._history[-1] = ChatMessage(
+                role="user", content=_augment(user_message, context_str)
+            )
+
         self._history.append(ChatMessage(role="model", content=response.content))
 
         total_tokens = (
@@ -148,6 +176,8 @@ class ConsciousLoop:
 
         Pops the last model message from history, finds the last user message,
         and regenerates with the provided context. Does NOT increment turn count.
+        In persistent mode, the stored user message is replaced with the
+        context-augmented one so the context stays visible on later turns.
         """
         if not self._history or self._history[-1].role != "model":
             raise ValueError("No model message to replace in history")
@@ -156,17 +186,23 @@ class ConsciousLoop:
         self._history.pop()
 
         # Find the last user message
-        last_user_msg = None
-        for msg in reversed(self._history):
-            if msg.role == "user":
-                last_user_msg = msg.content
+        last_user_idx = None
+        for idx in range(len(self._history) - 1, -1, -1):
+            if self._history[idx].role == "user":
+                last_user_idx = idx
                 break
-        if last_user_msg is None:
+        if last_user_idx is None:
             raise ValueError("No user message found in history")
+        last_user_msg = self._history[last_user_idx].content
 
         start_ns = time.monotonic_ns()
         response = self._generate(last_user_msg, context_str)
         duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+
+        if self._persistent_injection:
+            self._history[last_user_idx] = ChatMessage(
+                role="user", content=_augment(last_user_msg, context_str)
+            )
 
         self._history.append(ChatMessage(role="model", content=response.content))
 
@@ -187,10 +223,7 @@ class ConsciousLoop:
         """Build messages and call the Gemini API."""
         prior = self._history[:-1]
 
-        if context_str is not None:
-            augmented_content = context_str + "\n\n" + user_message
-        else:
-            augmented_content = user_message
+        augmented_content = _augment(user_message, context_str)
 
         messages = prior + [ChatMessage(role="user", content=augmented_content)]
         return self._client.generate(
@@ -198,3 +231,10 @@ class ConsciousLoop:
             system_prompt=self._system_prompt,
             thinking_level=self._thinking_level,
         )
+
+
+def _augment(user_message: str, context_str: str | None) -> str:
+    """Prepend injected context to a user message."""
+    if context_str is None:
+        return user_message
+    return context_str + "\n\n" + user_message

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -14,6 +14,7 @@ priority_threshold = 3     # interrupt if any item >= CRITICAL (3)
 token_threshold = 1000     # interrupt if total pending tokens reach this
 expiry_turns = 10          # turns before a queue item expires
 max_depth = 3              # queue depth guard for heuristic controller
+persistent_injection = true  # injected context enters history (false = transient one-generation whisper)
 
 [tools]
 # Default budget applied to all tools unless overridden below.

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -85,6 +85,7 @@ class EpisodeConfig:
     score_episode: bool = False
     use_lexical_scorer: bool = False
     injection_mode: InjectionMode = InjectionMode.BREAKPOINT
+    persistent_injection: bool = True
 
 
 class EpisodeRunner:
@@ -147,6 +148,7 @@ class EpisodeRunner:
             system_prompt=cfg.system_prompt,
             thinking_level=cfg.thinking_level,
             interrupt_config=cfg.interrupt_config,
+            persistent_injection=cfg.persistent_injection,
         )
         sim_user = SimulatedUser(
             client=active_client,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ class TestDefaults:
         assert cfg.queue.token_threshold == 1000
         assert cfg.queue.expiry_turns == 10
         assert cfg.queue.max_depth == 3
+        assert cfg.queue.persistent_injection is True
 
     def test_tools_defaults(self):
         cfg = HyperConfig()
@@ -225,6 +226,7 @@ class TestAdapters:
         assert ec.thinking_level == "medium"
         assert ec.tool_token_budget.max_calls == 10
         assert ec.tool_token_budget.max_input_tokens == 50_000
+        assert ec.persistent_injection is True
 
     def test_to_episode_config_with_overrides(self):
         cfg = HyperConfig()

--- a/tests/test_conscious_loop.py
+++ b/tests/test_conscious_loop.py
@@ -258,6 +258,62 @@ class TestInjectionPersistence:
 
         assert loop.history[0].content == "Hello"
 
+    def test_persistent_interrupt_combined_context_persists(self):
+        """Persistent: breakpoint + interrupt context both persist across turns."""
+        responses = [
+            _make_response("first"),
+            _make_response("second"),
+            _make_response("r2"),
+        ]
+        loop, client, queue = _make_loop(
+            interrupt_config=InterruptConfig(priority_threshold=Priority.CRITICAL),
+        )
+        # Breakpoint item drained before generation; a critical item arrives
+        # during the first generation and triggers the interrupt path.
+        self._enqueue(queue, content="BREAKPOINT FACT")
+        client.generate.side_effect = _enqueue_on_generate(
+            queue, responses, content="INTERRUPT FACT",
+        )
+
+        result = loop.run_turn("msg1")
+
+        assert result.interrupted
+        stored = loop.history[0].content
+        assert "BREAKPOINT FACT" in stored
+        assert "INTERRUPT FACT" in stored
+        assert "msg1" in stored
+
+        # The combined context is visible in the next turn's API call.
+        loop.run_turn("msg2")
+        third_call_msgs = client.generate.call_args_list[2][0][0]
+        prior = "\n".join(m.content for m in third_call_msgs[:-1])
+        assert "BREAKPOINT FACT" in prior
+        assert "INTERRUPT FACT" in prior
+
+    def test_transient_interrupt_context_not_persisted(self):
+        """Transient: interrupt context vanishes from history after the turn."""
+        responses = [
+            _make_response("first"),
+            _make_response("second"),
+            _make_response("r2"),
+        ]
+        loop, client, queue = _make_loop(
+            interrupt_config=InterruptConfig(priority_threshold=Priority.CRITICAL),
+            persistent_injection=False,
+        )
+        client.generate.side_effect = _enqueue_on_generate(
+            queue, responses, content="INTERRUPT FACT",
+        )
+
+        result = loop.run_turn("msg1")
+
+        assert result.interrupted
+        assert loop.history[0].content == "msg1"
+
+        loop.run_turn("msg2")
+        third_call_msgs = client.generate.call_args_list[2][0][0]
+        assert all("INTERRUPT FACT" not in m.content for m in third_call_msgs)
+
 
 class TestInterrupt:
     """Critical item triggers turn restart with injection."""

--- a/tests/test_conscious_loop.py
+++ b/tests/test_conscious_loop.py
@@ -32,6 +32,7 @@ def _make_loop(
     system_prompt=None,
     interrupt_config=None,
     on_completion=None,
+    persistent_injection=True,
 ) -> tuple[ConsciousLoop, MagicMock, ContextQueue]:
     """Create a ConsciousLoop with a mocked GeminiClient."""
     client = MagicMock(spec=GeminiClient)
@@ -46,6 +47,7 @@ def _make_loop(
         system_prompt=system_prompt,
         interrupt_config=interrupt_config,
         on_completion=on_completion,
+        persistent_injection=persistent_injection,
     )
     return loop, client, queue
 
@@ -166,16 +168,93 @@ class TestBreakpointInjection:
         last_msg = messages[-1]
         assert last_msg.content == "Hi"
 
-    def test_history_stores_original_message(self):
-        """History should store the original user message, not the augmented one."""
-        loop, _, queue = _make_loop()
+class TestInjectionPersistence:
+    """Visibility semantics of injected context across turns (issue #49)."""
+
+    @staticmethod
+    def _enqueue(queue: ContextQueue, content: str = "INJECTED FACT") -> None:
         queue.enqueue(QueueItem(
-            content="Context",
+            content=content,
             priority=Priority.HIGH,
             source_tool_id="tool1",
             token_count=5,
         ))
+
+    def test_persistent_history_stores_augmented_message(self):
+        """Default (persistent): history stores context + user message."""
+        loop, _, queue = _make_loop()
+        self._enqueue(queue)
         loop.run_turn("Hello")
+
+        assert "INJECTED FACT" in loop.history[0].content
+        assert "Hello" in loop.history[0].content
+
+    def test_persistent_context_visible_on_later_turns(self):
+        """Default (persistent): injected context reaches turn N+1's API call."""
+        responses = [_make_response("r1"), _make_response("r2")]
+        loop, client, queue = _make_loop(generate_side_effect=responses)
+        self._enqueue(queue)
+        loop.run_turn("msg1")
+        loop.run_turn("msg2")
+
+        second_call_msgs = client.generate.call_args_list[1][0][0]
+        prior_contents = [m.content for m in second_call_msgs[:-1]]
+        assert any("INJECTED FACT" in c for c in prior_contents)
+
+    def test_persistent_context_appears_exactly_once(self):
+        """Injected text enters the prompt once — no duplicate accounting."""
+        responses = [_make_response("r1"), _make_response("r2")]
+        loop, client, queue = _make_loop(generate_side_effect=responses)
+        self._enqueue(queue)
+        loop.run_turn("msg1")
+        loop.run_turn("msg2")
+
+        second_call_msgs = client.generate.call_args_list[1][0][0]
+        joined = "\n".join(m.content for m in second_call_msgs)
+        assert joined.count("INJECTED FACT") == 1
+
+    def test_transient_history_stores_original_message(self):
+        """Transient: history stores the raw user message, not the augmented one."""
+        loop, _, queue = _make_loop(persistent_injection=False)
+        self._enqueue(queue)
+        loop.run_turn("Hello")
+
+        assert loop.history[0].content == "Hello"
+
+    def test_transient_context_vanishes_after_one_generation(self):
+        """Transient: context is in turn N's call but absent from turn N+1's."""
+        responses = [_make_response("r1"), _make_response("r2")]
+        loop, client, queue = _make_loop(
+            generate_side_effect=responses, persistent_injection=False,
+        )
+        self._enqueue(queue)
+        loop.run_turn("msg1")
+        loop.run_turn("msg2")
+
+        first_call_msgs = client.generate.call_args_list[0][0][0]
+        assert "INJECTED FACT" in first_call_msgs[-1].content
+
+        second_call_msgs = client.generate.call_args_list[1][0][0]
+        assert all("INJECTED FACT" not in m.content for m in second_call_msgs)
+
+    def test_persistent_regenerate_updates_history(self):
+        """Default (persistent): regeneration context persists in history."""
+        loop, client, _ = _make_loop()
+        loop.run_turn("Hello")
+
+        client.generate.return_value = _make_response("regen")
+        loop.regenerate_with_context("NEW CONTEXT")
+
+        assert "NEW CONTEXT" in loop.history[0].content
+        assert "Hello" in loop.history[0].content
+
+    def test_transient_regenerate_keeps_history_raw(self):
+        """Transient: regeneration context does not enter history."""
+        loop, client, _ = _make_loop(persistent_injection=False)
+        loop.run_turn("Hello")
+
+        client.generate.return_value = _make_response("regen")
+        loop.regenerate_with_context("NEW CONTEXT")
 
         assert loop.history[0].content == "Hello"
 
@@ -411,7 +490,10 @@ class TestRegenerateWithContext:
         assert loop.turn_count == 2  # unchanged
         assert len(loop.history) == 4  # unchanged
         assert loop.history[-1].content == "r2_regen"
-        assert loop.history[-2].content == "msg2"
+        # Persistent injection (default): the stored user message now carries
+        # the regeneration context alongside the original text.
+        assert "msg2" in loop.history[-2].content
+        assert "new info" in loop.history[-2].content
 
 
 class TestMultiTurnConversation:


### PR DESCRIPTION
## Summary

Fixes the injection visibility bug from #49: injected queue context was built into the immediate API call only, while the raw user message entered `_history`, so injected findings influenced exactly one generation and then vanished. Injection persistence is now a config flag (`persistent_injection`), defaulting to **persistent** — the context-augmented user message enters history — with the previous transient "whisper" behavior kept as an experimental variable for A/B comparison.

## Work performed

- `src/bicameral_agent/conscious_loop.py` — new keyword-only `persistent_injection: bool = True` on `ConsciousLoop`. In persistent mode, `run_turn` replaces the stored raw user message with the context-augmented one (including combined context after an interrupt-regenerate), and `regenerate_with_context` replaces the last user message in place. The augmented message enters history exactly once and the queue drain is destructive, so injected text is token-accounted once at injection (issue work item: config flag + single token accounting). Module and class docstrings document the chosen semantics (work item: docstring documentation).
- `src/bicameral_agent/episode_runner.py` — `EpisodeConfig.persistent_injection` field (default `True`), threaded into the `ConsciousLoop` construction.
- `src/bicameral_agent/config.py` — additive `persistent_injection: bool = True` on `QueueConfig`, threaded through `to_episode_config()`; kept minimal to avoid conflicts with concurrent config changes.
- `src/bicameral_agent/data/default_config.toml` — `persistent_injection = true` under `[queue]` with an explanatory comment.
- `README.md` — architecture section now documents injection persistence semantics and the transient A/B mode (work item: README documentation).
- `tests/test_conscious_loop.py` — new `TestInjectionPersistence` class asserting visibility semantics across turns for BOTH modes (work item: tests): persistent history storage, context visible on turn N+1, injected text appears exactly once in the prompt, transient raw-history storage, transient context vanishing after one generation, and regenerate-with-context behavior in both modes. Updated two existing assertions that encoded the old transient default.
- `tests/test_config.py` — coverage for the new config default and its `to_episode_config` threading.

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 899 passed, 34 skipped
- `uv run --extra dev --extra torch ruff check src/ tests/` — all checks passed

Closes #49