### PR TITLE
Fix training-data leakage and feature-encoding bugs in encoder/pipeline

### DIFF
--- a/src/bicameral_agent/encoder.py
+++ b/src/bicameral_agent/encoder.py
@@ -9,7 +9,7 @@ Feature vector layout (64 dimensions)
 =====  ======================================  ====
 Index  Feature                                 Dims
 =====  ======================================  ====
-0      turn_number                                1
+0      turn_number (user messages so far)         1
 1      total_tokens_so_far                        1
 2–33   topic_embedding                           32
 34     estimated_confidence                       1
@@ -22,7 +22,7 @@ Index  Feature                                 Dims
 50–52  sentiment_shift (one-hot)                  3
 53     queue_depth                                1
 54     queue_token_total                          1
-55     queue_max_priority (ordinal)               1
+55     queue_max_priority (ordinal, 0 = empty)    1
 56     queue_time_since_last_drain                1
 57     queue_pending_tool_count                   1
 58     queue_estimated_next_arrival               1
@@ -46,9 +46,13 @@ from bicameral_agent.followup_classifier import FollowUpClassifier
 from bicameral_agent.heuristic_controller import TOOL_IDS
 from bicameral_agent.queue import QueueState
 from bicameral_agent.schema import Message, ToolInvocation, UserEvent, UserEventType
+from bicameral_agent.signal_classifier import _sentiment_score
 
 FEATURE_DIM: int = 64
 """Dimensionality of the encoded state vector."""
+
+QUEUE_STATE_DIM: int = 6
+"""Number of queue-state features produced by :func:`encode_queue_state`."""
 
 # ---------------------------------------------------------------------------
 # Normalization caps
@@ -82,6 +86,35 @@ def _cap_norm(val: float, cap: float) -> float:
     """Cap-and-divide normalization: ``min(val, cap) / cap`` -> [0, 1]."""
     return min(val, cap) / cap
 
+
+def encode_queue_state(queue_state: QueueState | None) -> np.ndarray:
+    """Encode a queue snapshot into ``QUEUE_STATE_DIM`` normalized features.
+
+    Shared by :class:`StateEncoder` and the training pipeline so both
+    halves of the training state vector use identical caps and encoding.
+
+    Indices: depth, token_total, max_priority (ordinal), time_since_last_drain,
+    pending_tool_count, estimated_next_arrival.
+
+    The priority ordinal is ``(value + 1) / (max + 1)`` so ``Priority.LOW``
+    (value 0) encodes to 0.25 and 0.0 is reserved for an empty queue.
+    """
+    out = np.zeros(QUEUE_STATE_DIM, dtype=np.float32)
+    if queue_state is None:
+        return out
+
+    out[0] = _cap_norm(queue_state.depth, _QUEUE_DEPTH_CAP)
+    out[1] = _cap_norm(queue_state.token_total, _QUEUE_TOKEN_TOTAL_CAP)
+    out[2] = (
+        (queue_state.max_priority.value + 1.0) / (_PRIORITY_MAX + 1.0)
+        if queue_state.max_priority is not None
+        else 0.0
+    )
+    out[3] = _cap_norm(queue_state.time_since_last_drain, _TIME_SINCE_DRAIN_CAP)
+    out[4] = _cap_norm(queue_state.pending_tool_count, _PENDING_TOOL_COUNT_CAP)
+    out[5] = _cap_norm(queue_state.estimated_next_arrival, _ESTIMATED_ARRIVAL_CAP)
+    return out
+
 # ---------------------------------------------------------------------------
 # Hedging keywords (for confidence estimation)
 # ---------------------------------------------------------------------------
@@ -99,48 +132,6 @@ _HEDGE_KEYWORDS: frozenset[str] = frozenset(
         "probably",
         "likely",
         "unclear",
-    }
-)
-
-# ---------------------------------------------------------------------------
-# Sentiment keyword sets
-# ---------------------------------------------------------------------------
-_POSITIVE_KEYWORDS: frozenset[str] = frozenset(
-    {
-        "good",
-        "great",
-        "thanks",
-        "perfect",
-        "nice",
-        "excellent",
-        "awesome",
-        "helpful",
-        "love",
-        "wonderful",
-        "amazing",
-        "appreciate",
-        "yes",
-        "correct",
-        "right",
-    }
-)
-_NEGATIVE_KEYWORDS: frozenset[str] = frozenset(
-    {
-        "bad",
-        "wrong",
-        "terrible",
-        "awful",
-        "hate",
-        "useless",
-        "horrible",
-        "worst",
-        "no",
-        "incorrect",
-        "broken",
-        "fail",
-        "error",
-        "annoying",
-        "frustrating",
     }
 )
 
@@ -205,9 +196,10 @@ class StateEncoder:
 
         vec = np.zeros(FEATURE_DIM, dtype=np.float32)
 
-        # 0: turn_number (normalized)
-        msg_count = len(conversation_history)
-        vec[0] = _cap_norm(msg_count, _TURN_CAP)
+        # 0: turn_number — count of user messages so far (normalized).
+        # Consistent with the turn_number used for feature 62.
+        user_msg_count = sum(1 for m in conversation_history if m.role == "user")
+        vec[0] = _cap_norm(user_msg_count, _TURN_CAP)
 
         # 1: total_tokens_so_far (normalized)
         total_tokens = sum(m.token_count for m in conversation_history)
@@ -244,7 +236,7 @@ class StateEncoder:
         vec[50:53] = self._compute_sentiment_shift(conversation_history)
 
         # 53–58: queue state (6 dims)
-        vec[53:59] = self._encode_queue_state(queue_state)
+        vec[53:59] = encode_queue_state(queue_state)
 
         # 59–61: latency context (3 dims)
         vec[59:62] = self._encode_latency_context(latency_predictions)
@@ -449,34 +441,15 @@ class StateEncoder:
         return out
 
     @staticmethod
-    def _encode_queue_state(queue_state: QueueState | None) -> np.ndarray:
-        """Encode queue state into 6 normalized features.
-
-        Indices: depth, token_total, max_priority (ordinal),
-        time_since_last_drain, pending_tool_count, estimated_next_arrival.
-        """
-        out = np.zeros(6, dtype=np.float32)
-        if queue_state is None:
-            return out
-
-        out[0] = _cap_norm(queue_state.depth, _QUEUE_DEPTH_CAP)
-        out[1] = _cap_norm(queue_state.token_total, _QUEUE_TOKEN_TOTAL_CAP)
-        out[2] = (queue_state.max_priority.value / _PRIORITY_MAX) if queue_state.max_priority is not None else 0.0
-        out[3] = _cap_norm(queue_state.time_since_last_drain, _TIME_SINCE_DRAIN_CAP)
-        out[4] = _cap_norm(queue_state.pending_tool_count, _PENDING_TOOL_COUNT_CAP)
-        out[5] = _cap_norm(queue_state.estimated_next_arrival, _ESTIMATED_ARRIVAL_CAP)
-        return out
-
-    @staticmethod
     def _encode_latency_context(
         latency_predictions: dict[str, float] | None,
     ) -> np.ndarray:
-        """Encode predicted latency for each tool into 3 normalized features.
+        """Encode predicted latency for each tool into normalized features.
 
         One slot per tool in ``_TOOL_VOCAB`` order, using pre-computed
         ``mean_ms`` values capped at ``_LATENCY_MS_CAP``.
         """
-        out = np.zeros(3, dtype=np.float32)
+        out = np.zeros(len(_TOOL_VOCAB), dtype=np.float32)
         if latency_predictions is None:
             return out
 
@@ -500,14 +473,9 @@ class StateEncoder:
             return out
 
         out[0] = _cap_norm(turn_number, _MAX_TURNS_CAP)
-        max_turns_eff = max_turns if max_turns is not None else _MAX_TURNS_CAP
+        # Guard against a caller-supplied max_turns of 0 (or negative).
+        max_turns_eff = (
+            max_turns if max_turns is not None and max_turns > 0 else _MAX_TURNS_CAP
+        )
         out[1] = min(turn_number / max_turns_eff, 1.0)
         return out
-
-
-def _sentiment_score(text: str) -> int:
-    """Simple keyword-counting sentiment score."""
-    text_lower = text.lower()
-    pos = sum(1 for kw in _POSITIVE_KEYWORDS if kw in text_lower)
-    neg = sum(1 for kw in _NEGATIVE_KEYWORDS if kw in text_lower)
-    return pos - neg

--- a/src/bicameral_agent/policy_value_net.py
+++ b/src/bicameral_agent/policy_value_net.py
@@ -104,7 +104,8 @@ class PolicyValueNetwork(nn.Module):
         Parameters
         ----------
         state:
-            1-D array of shape ``(input_dim,)``.
+            1-D array of shape ``(input_dim,)``. Any float dtype is
+            accepted; the input is cast to float32.
 
         Returns
         -------
@@ -112,33 +113,50 @@ class PolicyValueNetwork(nn.Module):
             ``(probs, value)`` where ``probs`` is shape ``(num_actions,)``
             and ``value`` is a Python float.
         """
-        x = torch.from_numpy(state).unsqueeze(0)
+        x = torch.as_tensor(state, dtype=torch.float32).unsqueeze(0)
         probs, value = self.forward(x)
         return probs.squeeze(0).numpy(), value.item()
 
     @torch.no_grad()
-    def sample_action(self, state: np.ndarray, temperature: float = 1.0) -> Action:
+    def sample_action(
+        self,
+        state: np.ndarray,
+        temperature: float = 1.0,
+        generator: torch.Generator | None = None,
+    ) -> Action:
         """Sample an action from the policy with temperature scaling.
 
         Parameters
         ----------
         state:
-            1-D array of shape ``(input_dim,)``.
+            1-D array of shape ``(input_dim,)``. Any float dtype is
+            accepted; the input is cast to float32.
         temperature:
             Controls exploration. Values < 1 sharpen the distribution
             (more greedy), values > 1 flatten it (more exploratory).
-            Must be positive.
+            Must be strictly positive.
+        generator:
+            Optional ``torch.Generator`` for reproducible sampling.
+            When *None*, the global torch RNG is used.
 
         Returns
         -------
         Action
             The sampled action.
+
+        Raises
+        ------
+        ValueError
+            If ``temperature`` is not strictly positive.
         """
-        x = torch.from_numpy(state).unsqueeze(0)
+        if temperature <= 0.0:
+            msg = f"temperature must be > 0, got {temperature}"
+            raise ValueError(msg)
+        x = torch.as_tensor(state, dtype=torch.float32).unsqueeze(0)
         logits, _ = self._shared_forward(x)
         scaled_logits = logits / temperature
         probs = torch.softmax(scaled_logits, dim=-1)
-        idx = torch.multinomial(probs, num_samples=1).item()
+        idx = torch.multinomial(probs, num_samples=1, generator=generator).item()
         return ACTION_ORDER[idx]
 
     @property

--- a/src/bicameral_agent/replay.py
+++ b/src/bicameral_agent/replay.py
@@ -133,6 +133,9 @@ class EpisodeReplayer:
 
         A decision point is each assistant message, with the state being
         everything up to (but not including) that assistant message.
+        Events, injections, and tool completions at exactly the action's
+        timestamp are excluded: they may have been logged after the action
+        within the same millisecond and must not leak into its state.
 
         Yields:
             DecisionPoint with full state and the action taken.
@@ -142,10 +145,12 @@ class EpisodeReplayer:
             if msg.role == "user":
                 turn_number += 1
             elif msg.role == "assistant":
-                # State is everything before this assistant message
+                # State is everything strictly before this assistant message
                 prior_messages = self._episode.messages[:i]
                 cutoff_ms = msg.timestamp_ms
-                state = self._build_state(turn_number, prior_messages, cutoff_ms)
+                state = self._build_state(
+                    turn_number, prior_messages, cutoff_ms, inclusive=False
+                )
                 yield DecisionPoint(state=state, action=msg)
 
     def _build_state(
@@ -153,6 +158,8 @@ class EpisodeReplayer:
         turn_number: int,
         messages: list[Message],
         cutoff_ms: int,
+        *,
+        inclusive: bool = True,
     ) -> ReplayState:
         """Build a ReplayState from the given parameters.
 
@@ -160,17 +167,24 @@ class EpisodeReplayer:
             turn_number: Number of user turns seen.
             messages: Messages included in the state.
             cutoff_ms: Timestamp cutoff for injections, tools, and events.
+            inclusive: When True, items with timestamp == cutoff_ms are
+                included. Decision points use False (strict cutoff) so
+                same-millisecond items logged after an action do not leak
+                into that action's state.
 
         Returns:
             A fully populated ReplayState.
         """
         episode = self._episode
 
+        def before_cutoff(ts: int) -> bool:
+            return ts <= cutoff_ms if inclusive else ts < cutoff_ms
+
         # Partition context injections by time and consumption status
         pending: list[ContextInjection] = []
         consumed: list[ContextInjection] = []
         for inj in episode.context_injections:
-            if inj.timestamp_ms > cutoff_ms:
+            if not before_cutoff(inj.timestamp_ms):
                 continue
             if inj.consumed and inj.consumed_at_turn is not None and inj.consumed_at_turn < turn_number:
                 consumed.append(inj)
@@ -181,15 +195,15 @@ class EpisodeReplayer:
         active: list[ToolInvocation] = []
         completed: list[ToolInvocation] = []
         for tool in episode.tool_invocations:
-            if tool.invoked_at_ms > cutoff_ms:
+            if not before_cutoff(tool.invoked_at_ms):
                 continue
-            if tool.completed_at_ms <= cutoff_ms:
+            if before_cutoff(tool.completed_at_ms):
                 completed.append(tool)
             else:
                 active.append(tool)
 
         # Filter user events
-        events = [e for e in episode.user_events if e.timestamp_ms <= cutoff_ms]
+        events = [e for e in episode.user_events if before_cutoff(e.timestamp_ms)]
 
         return ReplayState(
             turn_number=turn_number,

--- a/src/bicameral_agent/signal_classifier.py
+++ b/src/bicameral_agent/signal_classifier.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import re
 
 import numpy as np
 
@@ -86,7 +87,8 @@ _SENTIMENT_INDEX = {SentimentShift.POSITIVE: 15, SentimentShift.NEUTRAL: 16, Sen
 
 
 # ---------------------------------------------------------------------------
-# Sentiment keywords (duplicated from encoder.py for module independence)
+# Sentiment keywords (canonical copy; encoder.py imports _sentiment_score
+# from this module so both stay in sync)
 # ---------------------------------------------------------------------------
 _POSITIVE_KEYWORDS: frozenset[str] = frozenset(
     {
@@ -128,11 +130,20 @@ _NEGATIVE_KEYWORDS: frozenset[str] = frozenset(
 )
 
 
+# Word-boundary patterns so keywords don't fire inside other words
+# (e.g. "no" inside "know"/"nothing", "right" inside "bright").
+_POSITIVE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(rf"\b{re.escape(kw)}\b", re.IGNORECASE) for kw in _POSITIVE_KEYWORDS
+)
+_NEGATIVE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(rf"\b{re.escape(kw)}\b", re.IGNORECASE) for kw in _NEGATIVE_KEYWORDS
+)
+
+
 def _sentiment_score(text: str) -> int:
-    """Simple keyword-counting sentiment score."""
-    text_lower = text.lower()
-    pos = sum(1 for kw in _POSITIVE_KEYWORDS if kw in text_lower)
-    neg = sum(1 for kw in _NEGATIVE_KEYWORDS if kw in text_lower)
+    """Simple keyword-counting sentiment score (word-boundary matching)."""
+    pos = sum(1 for p in _POSITIVE_PATTERNS if p.search(text))
+    neg = sum(1 for p in _NEGATIVE_PATTERNS if p.search(text))
     return pos - neg
 
 

--- a/src/bicameral_agent/training_pipeline.py
+++ b/src/bicameral_agent/training_pipeline.py
@@ -13,7 +13,7 @@ Index      Component                                  Dims
 0–63       Reasoning state (StateEncoder.encode)        64
 64–81      User signal vector (SignalClassifier)        18
 82–93      One-hot of last 3 tool invocations           12
-94–96      Time since each of last 3 tool invocations    3
+94–96      Seconds since last 3 tool invocations         3
 97–102     Queue state                                   6
 103–105    Predicted latency per tool                    3
 106–107    Turn number + episode completion fraction     2
@@ -50,7 +50,13 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from bicameral_agent.encoder import FEATURE_DIM, StateEncoder, _cap_norm
+from bicameral_agent.encoder import (
+    FEATURE_DIM,
+    QUEUE_STATE_DIM,
+    StateEncoder,
+    _cap_norm,
+    encode_queue_state,
+)
 from bicameral_agent.followup_classifier import FollowUpClassifier, FollowUpType
 from bicameral_agent.heuristic_controller import TOOL_IDS, Action
 from bicameral_agent.queue import Priority, QueueState
@@ -73,10 +79,13 @@ if TYPE_CHECKING:  # pragma: no cover
 # Dimensions
 # ---------------------------------------------------------------------------
 
+# Tool vocabulary (order matters for one-hot indexing)
+_TOOL_VOCAB: tuple[str, ...] = tuple(TOOL_IDS.values())  # 3 tools
+
 _TOOL_HISTORY_ONEHOT = 12  # 3 slots × 4 tools (scanner/auditor/refresher/none)
 _TOOL_HISTORY_TIME = 3
-_QUEUE_DIMS = 6
-_LATENCY_DIMS = 3
+_QUEUE_DIMS = QUEUE_STATE_DIM
+_LATENCY_DIMS = len(_TOOL_VOCAB)  # one slot per tool in the vocabulary
 _PROGRESS_DIMS = 2
 
 STATE_DIM: int = (
@@ -99,11 +108,9 @@ _OFF_QUEUE = _OFF_TOOL_TIMES + _TOOL_HISTORY_TIME
 _OFF_LATENCY = _OFF_QUEUE + _QUEUE_DIMS
 _OFF_PROGRESS = _OFF_LATENCY + _LATENCY_DIMS
 
-# Tool vocabulary (order matters for one-hot indexing)
-_TOOL_VOCAB: tuple[str, ...] = tuple(TOOL_IDS.values())  # 3 tools
-
 # Action -> categorical index. Mirrors policy_value_net.ACTION_ORDER but
-# defined here to avoid a hard dependency on torch.
+# defined here to avoid a hard dependency on torch. A cross-check test
+# asserts the two stay identical (tests/test_training_pipeline.py).
 _ACTION_ORDER: tuple[Action, ...] = (
     Action.SCANNER,
     Action.AUDITOR,
@@ -113,17 +120,16 @@ _ACTION_ORDER: tuple[Action, ...] = (
 _ACTION_INDEX: dict[Action, int] = {a: i for i, a in enumerate(_ACTION_ORDER)}
 
 # ---------------------------------------------------------------------------
-# Normalization caps
+# Normalization caps (queue caps live in encoder.encode_queue_state, which is
+# shared with the StateEncoder slice of the vector)
 # ---------------------------------------------------------------------------
-_TURNS_SINCE_TOOL_CAP = 20.0
-_QUEUE_DEPTH_CAP = 20
-_QUEUE_TOKEN_TOTAL_CAP = 10_000
-_PRIORITY_MAX = 3.0
-_TIME_SINCE_DRAIN_CAP = 60.0
-_PENDING_TOOL_COUNT_CAP = 3
-_ESTIMATED_ARRIVAL_CAP = 30.0
+_TOOL_RECENCY_SECONDS_CAP = 300.0  # elapsed seconds since a tool invocation
 _LATENCY_MS_CAP = 30_000.0
 _TURN_CAP = 200
+
+# Default configured episode turn limit; must match the EpisodeConfig used
+# to generate the episodes (episode_runner.EpisodeConfig.max_turns).
+DEFAULT_MAX_TURNS = 25
 
 # Reward weights (per issue spec)
 R_STOP: float = -0.3
@@ -180,16 +186,34 @@ class TrainingDataPipeline:
         StateEncoder instance. If *None*, a default encoder is created.
     latency_model:
         ToolLatencyModel for the predicted-latency feature slice. If
-        *None*, a fresh model is created (predictions use built-in defaults).
+        *None*, a fresh model is created (predictions use built-in
+        defaults). This intentionally matches serving time, where
+        ``episode_runner`` also constructs a fresh ``ToolLatencyModel``
+        per episode: the default predictions are a deterministic function
+        of context features, so training and serving stay consistent.
+        Once a trained latency model exists (#44), pass the same trained
+        model here and at serving time.
+    max_turns:
+        The configured episode turn limit used when the episodes were
+        generated (``EpisodeConfig.max_turns``). Used for the
+        completion-fraction features (dims 63/107). The episode's actual
+        final turn count must NOT be used here: it is unavailable at
+        inference time and leaks the episode's outcome (e.g. early STOPs)
+        into every decision-point state.
     """
 
     def __init__(
         self,
         encoder: StateEncoder | None = None,
         latency_model: ToolLatencyModel | None = None,
+        max_turns: int = DEFAULT_MAX_TURNS,
     ) -> None:
+        if max_turns < 1:
+            msg = f"max_turns must be >= 1, got {max_turns}"
+            raise ValueError(msg)
         self._encoder = encoder or StateEncoder()
         self._latency_model = latency_model or ToolLatencyModel()
+        self._max_turns = max_turns
 
     # ------------------------------------------------------------------
     # Public API
@@ -216,7 +240,7 @@ class TrainingDataPipeline:
         # Build state vectors and per-step rewards
         n = len(decision_points)
         states = [
-            self._build_state_vector(dp.state, dp.action, episode)
+            self._build_state_vector(dp.state, dp.action)
             for dp in decision_points
         ]
         next_states = [
@@ -294,7 +318,6 @@ class TrainingDataPipeline:
         self,
         state: ReplayState,
         action_msg: Message,
-        episode: Episode,
     ) -> np.ndarray:
         """Build the 108-dim state vector at a decision point.
 
@@ -324,9 +347,10 @@ class TrainingDataPipeline:
             for tool_id in _TOOL_VOCAB
         }
 
-        # Estimate max turns from the episode (best-effort; falls back to
-        # episode total turns).
-        max_turns = max(episode.outcome.total_turns, state.turn_number, 1)
+        # Use the configured turn limit — never the episode's actual final
+        # turn count, which would leak future information (the label) into
+        # the completion-fraction features.
+        max_turns = self._max_turns
 
         # 0–63: encoder output
         encoded = self._encoder.encode(
@@ -354,8 +378,8 @@ class TrainingDataPipeline:
             self._encode_tool_history_times(tool_history, action_msg.timestamp_ms)
         )
 
-        # 97–102: queue state
-        vec[_OFF_QUEUE : _OFF_QUEUE + _QUEUE_DIMS] = self._encode_queue(queue_snapshot)
+        # 97–102: queue state (shared encoding with the StateEncoder slice)
+        vec[_OFF_QUEUE : _OFF_QUEUE + _QUEUE_DIMS] = encode_queue_state(queue_snapshot)
 
         # 103–105: latency predictions
         for i, tool_id in enumerate(_TOOL_VOCAB):
@@ -400,29 +424,14 @@ class TrainingDataPipeline:
         """Time since each of the last 3 invocations (normalized seconds).
 
         Slot order matches the one-hot encoding (most recent first).
+        Elapsed seconds are capped at ``_TOOL_RECENCY_SECONDS_CAP``.
         Missing slots are 1.0 (treated as "long ago / never").
         """
         out = np.ones(_TOOL_HISTORY_TIME, dtype=np.float32)
         recent = list(tool_history)[-3:][::-1]
         for slot, inv in enumerate(recent):
             elapsed_s = max(0.0, (cutoff_ms - inv.completed_at_ms) / 1000.0)
-            out[slot] = _cap_norm(elapsed_s, _TURNS_SINCE_TOOL_CAP)
-        return out
-
-    @staticmethod
-    def _encode_queue(qs: QueueState) -> np.ndarray:
-        """Encode a QueueState into 6 normalized features."""
-        out = np.zeros(_QUEUE_DIMS, dtype=np.float32)
-        out[0] = _cap_norm(qs.depth, _QUEUE_DEPTH_CAP)
-        out[1] = _cap_norm(qs.token_total, _QUEUE_TOKEN_TOTAL_CAP)
-        out[2] = (
-            (qs.max_priority.value / _PRIORITY_MAX)
-            if qs.max_priority is not None
-            else 0.0
-        )
-        out[3] = _cap_norm(qs.time_since_last_drain, _TIME_SINCE_DRAIN_CAP)
-        out[4] = _cap_norm(qs.pending_tool_count, _PENDING_TOOL_COUNT_CAP)
-        out[5] = _cap_norm(qs.estimated_next_arrival, _ESTIMATED_ARRIVAL_CAP)
+            out[slot] = _cap_norm(elapsed_s, _TOOL_RECENCY_SECONDS_CAP)
         return out
 
     @staticmethod

--- a/src/bicameral_agent/training_pipeline.py
+++ b/src/bicameral_agent/training_pipeline.py
@@ -82,8 +82,13 @@ if TYPE_CHECKING:  # pragma: no cover
 # Tool vocabulary (order matters for one-hot indexing)
 _TOOL_VOCAB: tuple[str, ...] = tuple(TOOL_IDS.values())  # 3 tools
 
-_TOOL_HISTORY_ONEHOT = 12  # 3 slots × 4 tools (scanner/auditor/refresher/none)
-_TOOL_HISTORY_TIME = 3
+_TOOL_HISTORY_SLOTS = 3  # how many recent invocations are encoded
+# Per-slot one-hot width: one index per tool plus a trailing "none/unknown"
+# entry. Derived from the vocabulary so adding a tool cannot silently
+# collide with the "none" index.
+_TOOL_ONEHOT_WIDTH = len(_TOOL_VOCAB) + 1
+_TOOL_HISTORY_ONEHOT = _TOOL_HISTORY_SLOTS * _TOOL_ONEHOT_WIDTH  # 12
+_TOOL_HISTORY_TIME = _TOOL_HISTORY_SLOTS
 _QUEUE_DIMS = QUEUE_STATE_DIM
 _LATENCY_DIMS = len(_TOOL_VOCAB)  # one slot per tool in the vocabulary
 _PROGRESS_DIMS = 2
@@ -397,23 +402,25 @@ class TrainingDataPipeline:
     def _encode_tool_history_onehot(
         tool_history: list[ToolInvocation],
     ) -> np.ndarray:
-        """One-hot encode the last 3 tool invocations.
+        """One-hot encode the last ``_TOOL_HISTORY_SLOTS`` tool invocations.
 
-        Layout: 3 consecutive 4-slot chunks, ordered most-recent-first.
-        Each chunk: [scanner, auditor, refresher, none/unknown].
+        Layout: consecutive ``_TOOL_ONEHOT_WIDTH``-wide chunks, ordered
+        most-recent-first. Each chunk: one index per tool in
+        ``_TOOL_VOCAB`` order, then a trailing "none/unknown" index.
         """
         out = np.zeros(_TOOL_HISTORY_ONEHOT, dtype=np.float32)
-        recent = list(tool_history)[-3:][::-1]  # most recent first
-        for slot in range(3):
-            base = slot * 4
+        none_idx = len(_TOOL_VOCAB)
+        recent = list(tool_history)[-_TOOL_HISTORY_SLOTS:][::-1]  # most recent first
+        for slot in range(_TOOL_HISTORY_SLOTS):
+            base = slot * _TOOL_ONEHOT_WIDTH
             if slot < len(recent):
                 tool_id = recent[slot].tool_id
                 if tool_id in _TOOL_VOCAB:
                     out[base + _TOOL_VOCAB.index(tool_id)] = 1.0
                 else:
-                    out[base + 3] = 1.0
+                    out[base + none_idx] = 1.0
             else:
-                out[base + 3] = 1.0  # "none"
+                out[base + none_idx] = 1.0  # "none"
         return out
 
     @staticmethod
@@ -421,14 +428,14 @@ class TrainingDataPipeline:
         tool_history: list[ToolInvocation],
         cutoff_ms: int,
     ) -> np.ndarray:
-        """Time since each of the last 3 invocations (normalized seconds).
+        """Time since each recent invocation (normalized seconds).
 
         Slot order matches the one-hot encoding (most recent first).
         Elapsed seconds are capped at ``_TOOL_RECENCY_SECONDS_CAP``.
         Missing slots are 1.0 (treated as "long ago / never").
         """
         out = np.ones(_TOOL_HISTORY_TIME, dtype=np.float32)
-        recent = list(tool_history)[-3:][::-1]
+        recent = list(tool_history)[-_TOOL_HISTORY_SLOTS:][::-1]
         for slot, inv in enumerate(recent):
             elapsed_s = max(0.0, (cutoff_ms - inv.completed_at_ms) / 1000.0)
             out[slot] = _cap_norm(elapsed_s, _TOOL_RECENCY_SECONDS_CAP)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -10,6 +10,7 @@ from bicameral_agent.encoder import (
     FEATURE_DIM,
     StateEncoder,
     _sentiment_score,
+    encode_queue_state,
 )
 from bicameral_agent.queue import Priority, QueueState
 from bicameral_agent.schema import (
@@ -205,6 +206,24 @@ class TestAC6Documentation:
         from bicameral_agent import FEATURE_DIM as exported
 
         assert exported == 64
+
+
+# ── Feature 0 semantics ──────────────────────────────────────────────
+
+
+class TestTurnNumberFeature:
+    """Feature 0 is the turn number (count of user messages), not the
+    total message count."""
+
+    def test_counts_user_messages_only(self, encoder):
+        msgs = [
+            Message(role="user", content="q1", timestamp_ms=100, token_count=1),
+            Message(role="assistant", content="a1", timestamp_ms=200, token_count=1),
+            Message(role="user", content="q2", timestamp_ms=300, token_count=1),
+            Message(role="assistant", content="a2", timestamp_ms=400, token_count=1),
+        ]
+        vec = encoder.encode(msgs)
+        assert vec[0] == pytest.approx(2 / 100)  # 2 user turns, _TURN_CAP=100
 
 
 # ── Unit tests for private helpers ───────────────────────────────────
@@ -449,6 +468,18 @@ class TestSentimentScore:
     def test_neutral(self):
         assert _sentiment_score("the weather today") == 0
 
+    def test_no_substring_match_negative(self):
+        # "no" must not fire inside "know" / "nothing"
+        assert _sentiment_score("I know nothing about this") == 0
+
+    def test_no_substring_match_positive(self):
+        # "right" must not fire inside "bright"
+        assert _sentiment_score("the bright light") == 0
+
+    def test_word_boundary_still_matches_whole_words(self):
+        assert _sentiment_score("no, that is wrong") < 0
+        assert _sentiment_score("that is right") > 0
+
 
 # ── Queue state encoding tests ──────────────────────────────────────
 
@@ -464,10 +495,25 @@ class TestQueueStateEncoding:
         vec = encoder.encode([], queue_state=sample_queue_state)
         assert vec[53] == pytest.approx(5 / 20)  # depth
         assert vec[54] == pytest.approx(500 / 10_000)  # token_total
-        assert vec[55] == pytest.approx(1 / 3)  # MEDIUM=1, /3.0
+        assert vec[55] == pytest.approx(2 / 4)  # MEDIUM=1, (1+1)/(3+1)
         assert vec[56] == pytest.approx(2.5 / 60)  # time_since_last_drain
         assert vec[57] == pytest.approx(2 / 3)  # pending_tool_count
         assert vec[58] == pytest.approx(1.0 / 30)  # estimated_next_arrival
+
+    def test_low_priority_distinct_from_empty_queue(self):
+        """Priority.LOW must not encode identically to an empty queue."""
+        qs_low = QueueState(
+            depth=1,
+            token_total=10,
+            max_priority=Priority.LOW,
+            time_since_last_drain=0.0,
+            pending_tool_count=1,
+            estimated_next_arrival=0.0,
+        )
+        out = encode_queue_state(qs_low)
+        assert out[2] == pytest.approx(1 / 4)  # LOW=0 -> (0+1)/(3+1)
+        assert out[2] > 0.0
+        np.testing.assert_array_equal(encode_queue_state(None)[2], 0.0)
 
     def test_queue_state_caps(self, encoder):
         qs = QueueState(
@@ -554,6 +600,11 @@ class TestEpisodeProgressEncoding:
         vec = encoder.encode([], turn_number=50)
         assert vec[62] == pytest.approx(50 / 200)
         assert vec[63] == pytest.approx(50 / 200)  # falls back to _MAX_TURNS_CAP
+
+    def test_max_turns_zero_does_not_crash(self, encoder):
+        vec = encoder.encode([], turn_number=5, max_turns=0)
+        assert np.all(np.isfinite(vec))
+        assert vec[63] == pytest.approx(5 / 200)  # falls back to _MAX_TURNS_CAP
 
 
 # ── Backward compatibility tests ─────────────────────────────────────

--- a/tests/test_policy_value_net.py
+++ b/tests/test_policy_value_net.py
@@ -184,6 +184,40 @@ class TestSampleAction:
         # With high temp, should see at least 3 distinct actions
         assert len(counts) >= 3, f"only {len(counts)} distinct actions at high temperature"
 
+    def test_zero_temperature_raises(self, net: PolicyValueNetwork, state: np.ndarray) -> None:
+        with pytest.raises(ValueError):
+            net.sample_action(state, temperature=0.0)
+        with pytest.raises(ValueError):
+            net.sample_action(state, temperature=-1.0)
+
+    def test_generator_makes_sampling_reproducible(
+        self, net: PolicyValueNetwork, state: np.ndarray
+    ) -> None:
+        def sample_seq(seed: int) -> list[Action]:
+            gen = torch.Generator().manual_seed(seed)
+            return [
+                net.sample_action(state, temperature=5.0, generator=gen)
+                for _ in range(20)
+            ]
+
+        assert sample_seq(7) == sample_seq(7)
+
+
+# ---- Input dtype handling ----
+
+
+class TestInputDtype:
+    def test_predict_accepts_float64(self, net: PolicyValueNetwork) -> None:
+        state64 = np.random.default_rng(0).random(FEATURE_DIM)  # float64
+        probs, value = net.predict(state64)
+        assert probs.shape == (NUM_ACTIONS,)
+        assert isinstance(value, float)
+
+    def test_sample_action_accepts_float64(self, net: PolicyValueNetwork) -> None:
+        state64 = np.random.default_rng(0).random(FEATURE_DIM)  # float64
+        action = net.sample_action(state64)
+        assert action in ACTION_ORDER
+
 
 # ---- Action mapping ----
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -271,6 +271,42 @@ class TestIterDecisionPoints:
             assert isinstance(point.state, ReplayState)
             assert isinstance(point.action, Message)
 
+    def test_same_millisecond_event_excluded_from_decision_state(self):
+        """An event at exactly the action's timestamp must not leak into
+        that decision point's state (it may have been logged after the
+        action within the same millisecond)."""
+        episode = Episode(
+            messages=[
+                Message(role="user", content="hi", timestamp_ms=100, token_count=2),
+                Message(role="assistant", content="hello", timestamp_ms=200, token_count=2),
+            ],
+            user_events=[
+                UserEvent(event_type=UserEventType.STOP, timestamp_ms=200),
+            ],
+            tool_invocations=[
+                ToolInvocation(
+                    tool_id="tool-a",
+                    invoked_at_ms=150,
+                    completed_at_ms=200,
+                    input_tokens=1,
+                    output_tokens=1,
+                ),
+            ],
+            outcome=EpisodeOutcome(total_tokens=4, total_turns=1, wall_clock_ms=100),
+        )
+        replayer = EpisodeReplayer(episode)
+        (point,) = replayer.iter_decision_points()
+
+        # The same-millisecond STOP is not part of the decision state
+        assert len(point.state.user_events) == 0
+        # The tool completing at exactly the cutoff is still active, not done
+        assert len(point.state.completed_tool_invocations) == 0
+        assert len(point.state.active_tool_invocations) == 1
+
+        # state_at_time keeps its documented inclusive semantics
+        state = replayer.state_at_time(200)
+        assert len(state.user_events) == 1
+
     def test_no_assistant_messages_yields_nothing(self):
         """An episode with no assistant messages yields no decision points."""
         episode = Episode(

--- a/tests/test_signal_classifier.py
+++ b/tests/test_signal_classifier.py
@@ -210,6 +210,22 @@ class TestSentimentShift:
     def test_no_messages(self):
         assert SignalClassifier._classify_sentiment([]) == SentimentShift.NEUTRAL
 
+    def test_no_inside_know_nothing_is_neutral(self):
+        """Word-boundary matching: "no" must not fire inside know/nothing."""
+        msgs = [
+            _msg("user", "hello there", ts=1000),
+            _msg("user", "I know nothing about this", ts=2000),
+        ]
+        assert SignalClassifier._classify_sentiment(msgs) == SentimentShift.NEUTRAL
+
+    def test_right_inside_bright_is_neutral(self):
+        """Word-boundary matching: "right" must not fire inside "bright"."""
+        msgs = [
+            _msg("user", "hello there", ts=1000),
+            _msg("user", "the bright light", ts=2000),
+        ]
+        assert SignalClassifier._classify_sentiment(msgs) == SentimentShift.NEUTRAL
+
 
 # ---------------------------------------------------------------------------
 # TestSignalVector

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -466,6 +466,15 @@ def test_action_order_matches_policy_value_net() -> None:
     assert _ACTION_ORDER == ACTION_ORDER
 
 
+def test_default_max_turns_matches_episode_config() -> None:
+    """DEFAULT_MAX_TURNS must stay identical to EpisodeConfig.max_turns,
+    otherwise a config-default change silently mis-scales the
+    completion-fraction features (dims 63/107)."""
+    from bicameral_agent.episode_runner import EpisodeConfig
+
+    assert DEFAULT_MAX_TURNS == EpisodeConfig().max_turns
+
+
 def test_queue_slices_identical_between_encoder_and_pipeline(
     pipeline: TrainingDataPipeline,
 ) -> None:

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -18,10 +18,12 @@ from bicameral_agent.schema import (
     UserEventType,
 )
 from bicameral_agent.training_pipeline import (
+    DEFAULT_MAX_TURNS,
     DISCOUNT_GAMMA,
     STATE_DIM,
     TrainingDataPipeline,
     _ACTION_INDEX,
+    _ACTION_ORDER,
     R_DRAIN_CONSUMED,
     R_REDIRECT_CORRECTION,
     R_STOP,
@@ -409,6 +411,103 @@ def test_state_vector_reflects_only_past_messages(
     # Second decision point: state has user msgs 0,1 and assistant msg 1.
     # Identical despite differing later messages.
     np.testing.assert_array_equal(ex_a[1].state, ex_b[1].state)
+
+
+def test_completion_fraction_uses_configured_max_turns(
+    pipeline: TrainingDataPipeline,
+) -> None:
+    """Dims 63/107 are turn / configured max_turns, not turn / actual length."""
+    episode = _build_episode(num_turns=4)
+    examples = pipeline.process_episode(episode)
+    for i, ex in enumerate(examples):
+        turn = i + 1
+        expected = turn / DEFAULT_MAX_TURNS
+        assert ex.state[63] == pytest.approx(expected)
+        assert ex.state[107] == pytest.approx(expected)
+
+    # A custom configured limit changes the fraction accordingly.
+    custom = TrainingDataPipeline(max_turns=10)
+    examples = custom.process_episode(episode)
+    assert examples[1].state[63] == pytest.approx(2 / 10)
+    assert examples[1].state[107] == pytest.approx(2 / 10)
+
+
+def test_no_leakage_from_episode_length(pipeline: TrainingDataPipeline) -> None:
+    """Turn-k states of a short and a long episode with identical prefixes
+    must be identical: the episode's final turn count is future information
+    and must not appear in any feature (e.g. completion fraction).
+    """
+    short = _build_episode(num_turns=4)
+    long = _build_episode(num_turns=8)
+    ex_short = pipeline.process_episode(short)
+    ex_long = pipeline.process_episode(long)
+
+    for k in range(len(ex_short)):
+        np.testing.assert_array_equal(ex_short[k].state, ex_long[k].state)
+
+
+def test_pipeline_rejects_invalid_max_turns() -> None:
+    with pytest.raises(ValueError):
+        TrainingDataPipeline(max_turns=0)
+
+
+# ---------------------------------------------------------------------------
+# Cross-module consistency
+# ---------------------------------------------------------------------------
+
+
+def test_action_order_matches_policy_value_net() -> None:
+    """_ACTION_ORDER must stay identical to policy_value_net.ACTION_ORDER,
+    otherwise action indices in training data silently mismatch the policy
+    head."""
+    pytest.importorskip("torch")
+    from bicameral_agent.policy_value_net import ACTION_ORDER
+
+    assert _ACTION_ORDER == ACTION_ORDER
+
+
+def test_queue_slices_identical_between_encoder_and_pipeline(
+    pipeline: TrainingDataPipeline,
+) -> None:
+    """Both queue slices of the state vector use the shared encoding."""
+    base_ts = 1_000_000
+    inj = ContextInjection(
+        content="ctx",
+        source_tool_id="research_gap_scanner",
+        priority=0,  # Priority.LOW — must be distinguishable from empty
+        timestamp_ms=base_ts + 100,
+        token_count=50,
+        consumed=False,
+    )
+    episode = _build_episode(num_turns=2, context_injections=[inj])
+    examples = pipeline.process_episode(episode)
+    for ex in examples:
+        np.testing.assert_array_equal(ex.state[53:59], ex.state[97:103])
+    # The pending LOW-priority injection is visible from turn 1 onward.
+    assert examples[0].state[55] == pytest.approx(1 / 4)
+
+
+# ---------------------------------------------------------------------------
+# Tool-recency features (seconds cap)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_recency_uses_seconds_cap() -> None:
+    """Elapsed time since a tool invocation must not saturate at 20s."""
+    inv = ToolInvocation(
+        tool_id=TOOL_IDS[Action.SCANNER],
+        invoked_at_ms=0,
+        completed_at_ms=0,
+        input_tokens=1,
+        output_tokens=1,
+    )
+    # 30s ago: with the old turns-based cap (20) this saturated to 1.0.
+    out = TrainingDataPipeline._encode_tool_history_times([inv], cutoff_ms=30_000)
+    assert out[0] == pytest.approx(30.0 / 300.0)
+    assert out[0] < 1.0
+    # Empty slots stay at 1.0 ("long ago / never").
+    assert out[1] == 1.0
+    assert out[2] == 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the training-data integrity findings from the 2026-07-06 code review: future-information leakage into decision-point states, wrong/degenerate feature encodings, and silent-corruption risks between the encoder, training pipeline, replay engine, and policy/value net. Unblocks #26/#27 training on re-run data.

## Work performed

- **Configured max_turns for completion fractions**: `TrainingDataPipeline` now takes `max_turns` (default 25, matching `EpisodeConfig.max_turns`) and no longer derives it from `episode.outcome.total_turns`, which leaked the episode's final length into dims 63/107 at every decision point. Added `test_no_leakage_from_episode_length`, which compares turn-k states of a 4-turn and an 8-turn episode with identical prefixes (the previous leakage tests only compared equal-length episodes), plus a test pinning the fraction to `turn / configured_max_turns`.
- **Word-boundary sentiment matching**: `_sentiment_score` now uses per-keyword `\b`-anchored regexes. `signal_classifier.py` holds the canonical implementation; `encoder.py` imports it instead of keeping a duplicate copy. Tests cover the issue's execution-verified false positives: "I know nothing about this" and "the bright light" now score 0 in both modules.
- **Feature semantics / units / latency dims / Priority.LOW**:
  - Feature 0 now counts user messages (the documented turn number, consistent with feature 62) instead of `len(conversation_history)`; docstring updated.
  - Tool-recency dims 94–96 now divide elapsed seconds by a 300s seconds cap (`_TOOL_RECENCY_SECONDS_CAP`) instead of the 20-*turn* cap, so they no longer saturate at 20s.
  - Latency dims (59–61/103–105) stay wired to the injectable `ToolLatencyModel`, defaulting to a fresh model. Justification: serving (`episode_runner.py:157`) also constructs a fresh `ToolLatencyModel` per episode, and its default predictions are a deterministic function of context features — so training and serving are identical today. Zeroing only the training side would *create* train/serve skew, and no trained model exists until #44. Documented in the constructor docstring; pass the same trained model to both sides once #44 lands.
  - `Priority.LOW` (value 0) no longer collides with "empty queue": the ordinal is `(value + 1) / (max + 1)` (LOW=0.25, CRITICAL=1.0, empty=0.0).
- **Cross-module consistency**: added `test_action_order_matches_policy_value_net` asserting `training_pipeline._ACTION_ORDER == policy_value_net.ACTION_ORDER`; queue caps + 6-dim queue encoding are now a single shared `encode_queue_state()` in `encoder.py` used by both vector halves (with a test asserting slices 53–58 and 97–102 are identical); latency slot counts derive from `len(_TOOL_VOCAB)` in both files instead of hardcoded 3.
- **Strict replay cutoff**: `iter_decision_points` builds states with a strict `<` timestamp cutoff, so same-millisecond events/injections/tool-completions logged after the action no longer leak in. `state_at_turn` / `state_at_time` keep their documented inclusive semantics.
- **Small guards**: `encoder._encode_episode_progress` falls back to the cap when `max_turns <= 0` (no ZeroDivisionError); `predict`/`sample_action` cast inputs to float32 (float64 arrays now work); `sample_action` raises `ValueError` for `temperature <= 0` (was NaN sampling) and accepts an optional `torch.Generator` for reproducible sampling.
- **Docs**: code docstrings updated where feature semantics changed (feature 0, priority ordinal, recency units). The README 53-vs-64 dim table is left to #55 as instructed.

## Test plan

- `uv run --extra torch pytest -q` — 912 passed, 34 skipped
- `uv run ruff check src/ tests/` — clean
- New/updated tests: leakage across different-length episodes, configured-max_turns fractions, word-boundary sentiment (both modules), feature-0 semantics, seconds-cap recency, LOW-vs-empty queue encoding, shared queue-slice equality, `_ACTION_ORDER` cross-check, strict decision-point cutoff (same-ms event/tool), float64 inputs, temperature validation, seeded-generator reproducibility, `max_turns=0` guards
- Manually verified the issue's repro cases: `_sentiment_score("I know nothing about this") == 0`, `_sentiment_score("the bright light") == 0`, `encode_queue_state(LOW)[2] == 0.25` vs empty `0.0`, float64 `predict` works, `temperature=0` raises

Closes #51