### PR TITLE
Fix docs drift, harden hard-benchmark fetch, add misc guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The hypothesis: a small neural network trained via Monte Carlo Tree Search can l
 
 ## Project Phases
 
+> **Status note:** the baseline control run (#23) produced no usable signal — see the RCA in epic [#41](https://github.com/elicollinson/bicameral-agent/issues/41). Remediation is in progress under that epic (harder benchmark, multi-provider backends, experiment-validity fixes); the original phase plan below is superseded until the #46 baseline re-run lands.
+
 The project is organized into 6 phases with 40 tracked issues:
 
 | Phase | Name | Issues | Description |
@@ -100,13 +102,28 @@ ruff check src/ tests/
 pytest --cov=bicameral_agent
 ```
 
+## Model Providers
+
+Two backends satisfy the same client contract (`src/bicameral_agent/model_client.py`), so episodes and benchmarks are provider-agnostic:
+
+- **Gemini** (default) — requires `GEMINI_API_KEY`
+- **Ollama Cloud** — open Gemma-class models; requires `OLLAMA_API_KEY` (see `docs/ollama_cloud.md`)
+
+Select a backend per run with the `--provider` flag on scripts that support it:
+
+```bash
+uv run python scripts/run_baseline_benchmark.py --provider ollama --model gemma4:31b-cloud
+```
+
+or via the `[model]` config section (`provider = "gemini"` or `"ollama"`), overridable with `BICAMERAL_` environment variables.
+
 ## State Encoder
 
-The `StateEncoder` compresses conversation state into a fixed 53-dimensional feature vector for the MCTS controller. The layout:
+The `StateEncoder` compresses conversation state into a fixed 64-dimensional feature vector (`FEATURE_DIM = 64` in `src/bicameral_agent/encoder.py`) for the MCTS controller. The layout:
 
 | Index | Feature | Dims |
 |-------|---------|------|
-| 0 | turn_number | 1 |
+| 0 | turn_number (user messages so far) | 1 |
 | 1 | total_tokens_so_far | 1 |
 | 2–33 | topic_embedding | 32 |
 | 34 | estimated_confidence | 1 |
@@ -117,6 +134,19 @@ The `StateEncoder` compresses conversation state into a fixed 53-dimensional fea
 | 46–48 | response_latency_bucket (one-hot) | 3 |
 | 49 | message_length_ratio | 1 |
 | 50–52 | sentiment_shift (one-hot) | 3 |
+| 53 | queue_depth | 1 |
+| 54 | queue_token_total | 1 |
+| 55 | queue_max_priority (ordinal, 0 = empty) | 1 |
+| 56 | queue_time_since_last_drain | 1 |
+| 57 | queue_pending_tool_count | 1 |
+| 58 | queue_arrival_interval_ema | 1 |
+| 59 | latency_research_gap_scanner | 1 |
+| 60 | latency_assumption_auditor | 1 |
+| 61 | latency_context_refresher | 1 |
+| 62 | episode_turn_progress | 1 |
+| 63 | episode_completion_fraction | 1 |
+
+Scalars use cap-and-divide normalization (`min(val, cap) / cap`), so every value is deterministically bounded to [0, 1]. The module docstring in `encoder.py` is the authoritative reference for the layout.
 
 By default, topic embeddings use a deterministic SHAKE-256 hash. For semantic embeddings, install the optional ML extra:
 
@@ -131,13 +161,20 @@ This adds `fastembed` with the `all-MiniLM-L6-v2` ONNX model (~150MB).
 ```
 src/bicameral_agent/     # Main package
 tests/                   # Test suite
-github_issues.md         # Full issue specifications
+scripts/                 # Runnable entry points (benchmarks, data collection)
+docs/                    # Design notes and dataset documentation
 pyproject.toml           # Project config (hatchling build, ruff, pytest)
 ```
 
+## Documentation
+
+- [`docs/hard_benchmark.md`](docs/hard_benchmark.md) — the harder external benchmark (FRAMES + CREPE): sources, licenses, attribution, and fetch instructions
+- [`docs/ollama_cloud.md`](docs/ollama_cloud.md) — the Ollama Cloud model backend, a drop-in alternative to Gemini
+- [`docs/benchmark_comparison_issue42.md`](docs/benchmark_comparison_issue42.md) — dataset comparison and recommendation behind the hard benchmark (#42)
+
 ## Tech Stack
 
-- **LLM**: Gemini 3 Flash Preview (conscious loop + tool internals)
+- **LLM**: Gemini 3 Flash Preview (conscious loop + tool internals), with Ollama Cloud (Gemma-class) as an alternate provider
 - **ML**: PyTorch (policy/value network, transition model, MCTS)
 - **Data**: Pydantic v2 (schemas), PyArrow (Parquet serialization)
 - **Dev**: pytest, ruff, uv

--- a/scripts/collect_latency_data.py
+++ b/scripts/collect_latency_data.py
@@ -126,6 +126,10 @@ def main(argv: list[str] | None = None) -> int:
         len(collector.api_observations), len(collector.tool_observations), elapsed,
     )
 
+    if not collector.api_observations and not collector.tool_observations:
+        logger.error("No observations collected (every cell failed); aborting.")
+        return 1
+
     # The AC evaluates predictions made by the *trained* model, so recompute
     # predictions on every observation using the now-fitted model state.
     final_api, final_tool = recompute_predictions(

--- a/src/bicameral_agent/encoder.py
+++ b/src/bicameral_agent/encoder.py
@@ -25,7 +25,7 @@ Index  Feature                                 Dims
 55     queue_max_priority (ordinal, 0 = empty)    1
 56     queue_time_since_last_drain                1
 57     queue_pending_tool_count                   1
-58     queue_estimated_next_arrival               1
+58     queue_arrival_interval_ema                 1
 59     latency_research_gap_scanner               1
 60     latency_assumption_auditor                 1
 61     latency_context_refresher                  1
@@ -69,7 +69,7 @@ _QUEUE_TOKEN_TOTAL_CAP = 10_000
 _PRIORITY_MAX = 3.0
 _TIME_SINCE_DRAIN_CAP = 60.0
 _PENDING_TOOL_COUNT_CAP = 3
-_ESTIMATED_ARRIVAL_CAP = 30.0
+_ARRIVAL_INTERVAL_EMA_CAP = 30.0
 
 # Latency caps
 _LATENCY_MS_CAP = 30_000.0
@@ -94,7 +94,7 @@ def encode_queue_state(queue_state: QueueState | None) -> np.ndarray:
     halves of the training state vector use identical caps and encoding.
 
     Indices: depth, token_total, max_priority (ordinal), time_since_last_drain,
-    pending_tool_count, estimated_next_arrival.
+    pending_tool_count, arrival_interval_ema.
 
     The priority ordinal is ``(value + 1) / (max + 1)`` so ``Priority.LOW``
     (value 0) encodes to 0.25 and 0.0 is reserved for an empty queue.
@@ -112,7 +112,7 @@ def encode_queue_state(queue_state: QueueState | None) -> np.ndarray:
     )
     out[3] = _cap_norm(queue_state.time_since_last_drain, _TIME_SINCE_DRAIN_CAP)
     out[4] = _cap_norm(queue_state.pending_tool_count, _PENDING_TOOL_COUNT_CAP)
-    out[5] = _cap_norm(queue_state.estimated_next_arrival, _ESTIMATED_ARRIVAL_CAP)
+    out[5] = _cap_norm(queue_state.arrival_interval_ema, _ARRIVAL_INTERVAL_EMA_CAP)
     return out
 
 # ---------------------------------------------------------------------------

--- a/src/bicameral_agent/hard_benchmark.py
+++ b/src/bicameral_agent/hard_benchmark.py
@@ -20,6 +20,8 @@ attribution, and for the fallback datasets to watch for.
 from __future__ import annotations
 
 import json
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -32,8 +34,17 @@ FRAMES_DATASET = "google/frames-benchmark"
 CREPE_DATASET = "tasksource/CREPE"
 
 _HF_ROWS_ENDPOINT = "https://datasets-server.huggingface.co/rows"
-_DEFAULT_CACHE = Path("data/external/hard_benchmark.json")
+# Anchored to the repo root (this file lives at src/bicameral_agent/) so the
+# cache resolves to the same place regardless of the caller's CWD.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_CACHE = _REPO_ROOT / "data" / "external" / "hard_benchmark.json"
 _USER_AGENT = "bicameral-agent/0.1 (research eval; issue-42)"
+
+# The HF datasets-server rate-limits routinely; retry transient failures
+# with exponential backoff before giving up.
+_MAX_ATTEMPTS = 4
+_RETRY_BASE_DELAY_S = 2.0
+_RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
 
 
 # --- pure mappers (offline-testable) ----------------------------------------
@@ -93,9 +104,24 @@ def crepe_row_to_task(row: dict, index: int) -> ResearchQATask:
 # --- upstream fetch ---------------------------------------------------------
 
 def _http_get_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
-        return json.loads(resp.read())
+    """GET *url* as JSON, retrying transient (rate-limit / 5xx / network) errors."""
+    last_err: Exception | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(_RETRY_BASE_DELAY_S * 2 ** (attempt - 1))
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as err:
+            if err.code not in _RETRYABLE_HTTP_CODES:
+                raise
+            last_err = err
+        except urllib.error.URLError as err:
+            last_err = err
+    raise RuntimeError(
+        f"Giving up on {url} after {_MAX_ATTEMPTS} attempts: {last_err}"
+    ) from last_err
 
 
 def _fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict]:
@@ -103,7 +129,15 @@ def _fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict
         f"{_HF_ROWS_ENDPOINT}?dataset={urllib.parse.quote(dataset)}"
         f"&config=default&split={split}&offset={offset}&length={length}"
     )
-    return [row["row"] for row in _http_get_json(url).get("rows", [])]
+    payload = _http_get_json(url)
+    if "rows" not in payload:
+        # An error payload (e.g. rate-limit body) must not read as an empty
+        # terminal page — that silently truncates the benchmark.
+        raise RuntimeError(
+            f"Unexpected datasets-server payload for {dataset} at offset {offset}: "
+            f"{payload.get('error', payload)!r}"
+        )
+    return [row["row"] for row in payload["rows"]]
 
 
 def fetch_frames(limit: int = 100, split: str = "test") -> list[ResearchQATask]:
@@ -151,8 +185,19 @@ def build_hard_benchmark(
 
     The cache file is git-ignored; it is the artifact :func:`load_hard_benchmark`
     reads. Returns the combined task list.
+
+    Raises:
+        RuntimeError: If either fetch yields fewer tasks than requested, so a
+            partial upstream response cannot produce a silent short benchmark.
     """
-    tasks = fetch_frames(frames_n) + fetch_crepe(crepe_n)
+    frames = fetch_frames(frames_n)
+    crepe = fetch_crepe(crepe_n)
+    if len(frames) != frames_n or len(crepe) != crepe_n:
+        raise RuntimeError(
+            f"Fetched {len(frames)}/{frames_n} FRAMES and {len(crepe)}/{crepe_n} "
+            "CREPE tasks; refusing to write a short benchmark cache."
+        )
+    tasks = frames + crepe
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(
         json.dumps([t.model_dump(mode="json") for t in tasks], indent=2),

--- a/src/bicameral_agent/queue.py
+++ b/src/bicameral_agent/queue.py
@@ -91,8 +91,11 @@ class QueueState:
     pending_tool_count: int
     """Number of distinct source_tool_ids with items in the queue."""
 
-    estimated_next_arrival: float
-    """Estimated seconds until the next enqueue, based on arrival rate EMA."""
+    arrival_interval_ema: float
+    """EMA of the inter-arrival interval between enqueues, in seconds.
+
+    This is the smoothed gap between recent enqueues, not a countdown to
+    the next one — it does not decrease as time passes."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -253,7 +256,7 @@ class ContextQueue:
 
         Returns:
             A QueueState snapshot with depth, token total, max priority,
-            time since last drain, pending tool count, and estimated next arrival.
+            time since last drain, pending tool count, and arrival-interval EMA.
         """
         with self._lock:
             items = list(self._items.values())
@@ -263,7 +266,7 @@ class ContextQueue:
                 max_priority=max((item.priority for item in items), default=None),
                 time_since_last_drain=time.monotonic() - self._last_drain_time,
                 pending_tool_count=len({item.source_tool_id for item in items}),
-                estimated_next_arrival=self._arrival_interval_ema,
+                arrival_interval_ema=self._arrival_interval_ema,
             )
 
     def drain_at_breakpoint(self) -> str | None:

--- a/src/bicameral_agent/serialization.py
+++ b/src/bicameral_agent/serialization.py
@@ -38,11 +38,17 @@ def episode_from_parquet(path: str) -> Episode:
         The deserialized Episode.
 
     Raises:
-        ValueError: If the file contains no rows.
+        ValueError: If the file contains no rows, or more than one row
+            (use :func:`episodes_from_parquet` for multi-episode files).
     """
     table = pq.read_table(path)
     if table.num_rows == 0:
         raise ValueError(f"Parquet file at {path} contains no episodes")
+    if table.num_rows > 1:
+        raise ValueError(
+            f"Parquet file at {path} contains {table.num_rows} episodes; "
+            "use episodes_from_parquet() for multi-episode files"
+        )
     payload = table.column("payload")[0].as_py()
     return Episode.model_validate_json(payload)
 

--- a/src/bicameral_agent/training_pipeline.py
+++ b/src/bicameral_agent/training_pipeline.py
@@ -454,7 +454,7 @@ class TrainingDataPipeline:
                 max_priority=None,
                 time_since_last_drain=0.0,
                 pending_tool_count=0,
-                estimated_next_arrival=0.0,
+                arrival_interval_ema=0.0,
             )
         max_p_int = max(inj.priority for inj in pending)
         # Time since most-recent enqueue (bounded by what we know — the
@@ -467,7 +467,7 @@ class TrainingDataPipeline:
             max_priority=Priority(max_p_int) if max_p_int <= 3 else Priority.CRITICAL,
             time_since_last_drain=time_since_last_ms / 1000.0,
             pending_tool_count=len({inj.source_tool_id for inj in pending}),
-            estimated_next_arrival=0.0,
+            arrival_interval_ema=0.0,
         )
 
     # ------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,5 +198,5 @@ def sample_queue_state():
         max_priority=Priority.MEDIUM,
         time_since_last_drain=2.5,
         pending_tool_count=2,
-        estimated_next_arrival=1.0,
+        arrival_interval_ema=1.0,
     )

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -498,7 +498,7 @@ class TestQueueStateEncoding:
         assert vec[55] == pytest.approx(2 / 4)  # MEDIUM=1, (1+1)/(3+1)
         assert vec[56] == pytest.approx(2.5 / 60)  # time_since_last_drain
         assert vec[57] == pytest.approx(2 / 3)  # pending_tool_count
-        assert vec[58] == pytest.approx(1.0 / 30)  # estimated_next_arrival
+        assert vec[58] == pytest.approx(1.0 / 30)  # arrival_interval_ema
 
     def test_low_priority_distinct_from_empty_queue(self):
         """Priority.LOW must not encode identically to an empty queue."""
@@ -508,7 +508,7 @@ class TestQueueStateEncoding:
             max_priority=Priority.LOW,
             time_since_last_drain=0.0,
             pending_tool_count=1,
-            estimated_next_arrival=0.0,
+            arrival_interval_ema=0.0,
         )
         out = encode_queue_state(qs_low)
         assert out[2] == pytest.approx(1 / 4)  # LOW=0 -> (0+1)/(3+1)
@@ -522,7 +522,7 @@ class TestQueueStateEncoding:
             max_priority=Priority.CRITICAL,
             time_since_last_drain=120.0,
             pending_tool_count=10,
-            estimated_next_arrival=60.0,
+            arrival_interval_ema=60.0,
         )
         vec = encoder.encode([], queue_state=qs)
         for i in range(53, 59):
@@ -535,7 +535,7 @@ class TestQueueStateEncoding:
             max_priority=None,
             time_since_last_drain=0.0,
             pending_tool_count=0,
-            estimated_next_arrival=0.0,
+            arrival_interval_ema=0.0,
         )
         vec = encoder.encode([], queue_state=qs)
         np.testing.assert_array_equal(vec[53:59], np.zeros(6, dtype=np.float32))
@@ -629,7 +629,7 @@ class TestBackwardCompatibility:
         qs = QueueState(
             depth=3, token_total=200, max_priority=Priority.HIGH,
             time_since_last_drain=1.0, pending_tool_count=1,
-            estimated_next_arrival=0.5,
+            arrival_interval_ema=0.5,
         )
         vec_with_ext = encoder.encode(
             msgs, events, tools,

--- a/tests/test_hard_benchmark.py
+++ b/tests/test_hard_benchmark.py
@@ -5,13 +5,18 @@ rows, and the loader against a committed author-owned fixture. No network and
 no externally-licensed data are required.
 """
 
+import urllib.error
 from pathlib import Path
 
 import pytest
 
+from bicameral_agent import hard_benchmark
 from bicameral_agent.dataset import ResearchQADataset, TaskDifficulty, TaskSplit
 from bicameral_agent.hard_benchmark import (
+    build_hard_benchmark,
     crepe_row_to_task,
+    fetch_crepe,
+    fetch_frames,
     frames_row_to_task,
     load_hard_benchmark,
 )
@@ -55,6 +60,131 @@ class TestCrepeMapper:
         row = {"question": "x", "presuppositions": [], "corrections": ["y"]}
         with pytest.raises(ValueError, match="known_assumptions"):
             crepe_row_to_task(row, 1)
+
+
+def _frames_row(i: int) -> dict:
+    return {"Prompt": f"question {i}?", "Answer": f"answer {i}"}
+
+
+def _crepe_row(i: int, *, valid: bool = True) -> dict:
+    return {
+        "question": f"question {i}?",
+        "presuppositions": [f"presup {i}"] if valid else [],
+        "corrections": [f"correction {i}"] if valid else [],
+    }
+
+
+class TestPager:
+    """Offline coverage of the fetch/pagination logic via a mocked pager."""
+
+    def test_frames_paginates_until_limit(self, monkeypatch):
+        pages = [[_frames_row(i) for i in range(3)], [_frames_row(i) for i in range(3, 6)]]
+        calls: list[tuple[int, int]] = []
+
+        def fake_fetch_page(dataset, split, offset, length):
+            calls.append((offset, length))
+            return pages.pop(0)
+
+        monkeypatch.setattr(hard_benchmark, "_fetch_page", fake_fetch_page)
+        tasks = fetch_frames(limit=5)
+        assert len(tasks) == 5
+        assert [t.task_id for t in tasks] == [f"frames_hard_{i:03d}" for i in range(1, 6)]
+        # Second page requested at the offset the first page ended at.
+        assert calls[1][0] == 3
+
+    def test_crepe_filtered_page_then_empty_terminal_page(self, monkeypatch):
+        # First page: 2 usable rows among 4; second page empty -> pager stops
+        # short of the limit instead of looping forever.
+        pages = [
+            [_crepe_row(0), _crepe_row(1, valid=False), _crepe_row(2), _crepe_row(3, valid=False)],
+            [],
+        ]
+        monkeypatch.setattr(hard_benchmark, "_fetch_page", lambda *a: pages.pop(0))
+        tasks = fetch_crepe(limit=10)
+        assert len(tasks) == 2
+        assert all(t.difficulty == TaskDifficulty.TRICKY for t in tasks)
+        assert not pages  # both pages consumed
+
+    def test_error_payload_raises_instead_of_empty_page(self, monkeypatch):
+        monkeypatch.setattr(
+            hard_benchmark, "_http_get_json", lambda url: {"error": "rate limited"}
+        )
+        with pytest.raises(RuntimeError, match="rate limited"):
+            hard_benchmark._fetch_page("some/dataset", "test", 0, 100)
+
+    def test_http_get_json_retries_transient_errors(self, monkeypatch):
+        sleeps: list[float] = []
+        monkeypatch.setattr(hard_benchmark.time, "sleep", sleeps.append)
+        attempts = iter([
+            urllib.error.HTTPError("u", 429, "rate limited", None, None),
+            urllib.error.URLError("conn reset"),
+        ])
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b'{"rows": []}'
+
+        def fake_urlopen(req, timeout):
+            try:
+                raise next(attempts)
+            except StopIteration:
+                return FakeResponse()
+
+        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", fake_urlopen)
+        assert hard_benchmark._http_get_json("http://x") == {"rows": []}
+        assert len(sleeps) == 2  # backed off before each retry
+
+    def test_http_get_json_gives_up_after_max_attempts(self, monkeypatch):
+        monkeypatch.setattr(hard_benchmark.time, "sleep", lambda s: None)
+
+        def always_503(req, timeout):
+            raise urllib.error.HTTPError("u", 503, "unavailable", None, None)
+
+        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", always_503)
+        with pytest.raises(RuntimeError, match="Giving up"):
+            hard_benchmark._http_get_json("http://x")
+
+    def test_non_retryable_http_error_raises_immediately(self, monkeypatch):
+        def not_found(req, timeout):
+            raise urllib.error.HTTPError("u", 404, "not found", None, None)
+
+        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", not_found)
+        with pytest.raises(urllib.error.HTTPError):
+            hard_benchmark._http_get_json("http://x")
+
+
+class TestBuildHardBenchmark:
+    def test_short_fetch_refuses_to_write_cache(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            hard_benchmark, "fetch_frames", lambda n: [frames_row_to_task(_frames_row(1), 1)]
+        )
+        monkeypatch.setattr(hard_benchmark, "fetch_crepe", lambda n: [])
+        cache = tmp_path / "cache.json"
+        with pytest.raises(RuntimeError, match="short benchmark"):
+            build_hard_benchmark(frames_n=5, crepe_n=5, cache_path=cache)
+        assert not cache.exists()
+
+    def test_full_fetch_writes_cache(self, monkeypatch, tmp_path):
+        frames = [frames_row_to_task(_frames_row(i), i) for i in range(1, 3)]
+        crepe = [crepe_row_to_task(_crepe_row(i), i) for i in range(1, 3)]
+        monkeypatch.setattr(hard_benchmark, "fetch_frames", lambda n: frames)
+        monkeypatch.setattr(hard_benchmark, "fetch_crepe", lambda n: crepe)
+        cache = tmp_path / "cache.json"
+        tasks = build_hard_benchmark(frames_n=2, crepe_n=2, cache_path=cache)
+        assert len(tasks) == 4
+        assert len(load_hard_benchmark(cache)) == 4
+
+    def test_default_cache_is_repo_root_anchored(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        assert hard_benchmark._DEFAULT_CACHE == (
+            repo_root / "data" / "external" / "hard_benchmark.json"
+        )
 
 
 class TestLoader:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -357,16 +357,16 @@ class TestPeek:
         assert peeked[1].content == "low"
 
 
-class TestEstimatedNextArrival:
+class TestArrivalIntervalEma:
     def test_zero_before_any_enqueue(self, empty_queue):
         state = empty_queue.get_state()
-        assert state.estimated_next_arrival == 0.0
+        assert state.arrival_interval_ema == 0.0
 
     def test_nonzero_after_multiple_enqueues(self, empty_queue, make_queue_item):
         for _ in range(5):
             empty_queue.enqueue(make_queue_item())
         state = empty_queue.get_state()
-        assert state.estimated_next_arrival >= 0.0
+        assert state.arrival_interval_ema >= 0.0
 
 
 class TestDrainAtBreakpoint:

--- a/tests/test_serialization_parquet.py
+++ b/tests/test_serialization_parquet.py
@@ -3,6 +3,7 @@
 import os
 
 import pyarrow.parquet as pq
+import pytest
 
 from bicameral_agent.schema import Episode, EpisodeOutcome
 from bicameral_agent.serialization import episodes_from_parquet, episodes_to_parquet
@@ -23,6 +24,12 @@ class TestParquetRoundTrip:
         assert len(restored) == 5
         for orig, rest in zip(five_episodes, restored):
             assert orig.model_dump() == rest.model_dump()
+
+    def test_single_read_of_multi_episode_file_raises(self, five_episodes, tmp_path):
+        path = str(tmp_path / "episodes.parquet")
+        episodes_to_parquet(five_episodes, path)
+        with pytest.raises(ValueError, match="episodes_from_parquet"):
+            Episode.from_parquet(path)
 
     def test_parquet_file_is_valid(self, make_episode, tmp_path):
         ep = make_episode()


### PR DESCRIPTION
## Summary

Addresses the docs-drift and small-fix batch from the 2026-07-06 code review: the README's stale 53-dim encoder table and missing docs/provider/status coverage, the hard-benchmark fetch path's CWD-relative cache and silent-truncation failure modes, and three small correctness guards.

## Work performed

**README**
- Replaced the 53-dim encoder layout table with the current 64-dim layout, derived from `encoder.py` (feature 0 is the user-message count, queue features 53–58, latency 59–61, progress 62–63; priority ordinal reserves 0 for an empty queue)
- Removed the dead `github_issues.md` reference; added `scripts/` and `docs/` to the project structure plus a Documentation index (`docs/hard_benchmark.md`, `docs/ollama_cloud.md`, `docs/benchmark_comparison_issue42.md`)
- Added a Model Providers section (`--provider gemini|ollama` on `scripts/run_baseline_benchmark.py`, `[model] provider` config) and noted Ollama Cloud in the tech stack
- Added a status note under Project Phases pointing at epic #41 (remediation in progress; original phase plan superseded until the #46 re-run). The existing #49 injection-persistence paragraph was left as-is.

**hard_benchmark.py** (kept minimal — #56 may absorb this code)
- `_DEFAULT_CACHE` anchored to the repo root instead of CWD
- `_http_get_json` retries transient errors (429/5xx/URLError) with exponential backoff
- `_fetch_page` raises on payloads without `rows` instead of treating an error body as an empty terminal page
- `build_hard_benchmark` raises when fetched counts fall short of the request, so a partial upstream response can't write a silent short benchmark
- New offline pager tests: mocked pagination, filtered page + empty terminal page, error payload, retry/give-up/non-retryable paths, short-fetch refusal, cache anchoring

**Small guards**
- `serialization.episode_from_parquet` raises `ValueError` on files with more than one row (pointing at `episodes_from_parquet`) instead of silently returning row 0
- `QueueState.estimated_next_arrival` renamed to `arrival_interval_ema` — it is the raw inter-arrival EMA, not a countdown. Rename chosen over computing `ema - elapsed` to keep encoder feature semantics stable after #51; `encoder.py`, `training_pipeline.py`, and tests updated mechanically
- `scripts/collect_latency_data.py` exits 1 when zero observations were collected instead of writing an empty report and exiting 0

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 989 passed, 34 skipped
- `uv run --extra dev ruff check src/ tests/` (and `scripts/`) — clean
- New tests: 9 in `tests/test_hard_benchmark.py` (pager/retry/count guards), 1 in `tests/test_serialization_parquet.py` (multi-row guard)

Closes #55