### PR TITLE
Config layer: wire or delete every dead hyperparameter (#48)

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -24,10 +24,9 @@ import sys
 from pathlib import Path
 
 from bicameral_agent.baseline_benchmark import format_report, run_benchmark
-from bicameral_agent.cost_tracker import CostTracker
+from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
-from bicameral_agent.episode_runner import EpisodeConfig, EpisodeRunner
-from bicameral_agent.heuristic_controller import HeuristicController
+from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.model_client import build_client
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
@@ -69,10 +68,15 @@ def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default="data/baseline")
-    parser.add_argument("--provider", choices=["gemini", "ollama"], default="gemini",
-                        help="Model backend to run the answerer against.")
+    parser.add_argument("--config", default=None,
+                        help="Hyperparameter TOML file (defaults to the bundled "
+                             "config; BICAMERAL_ env overrides always apply, "
+                             "CLI flags win over both).")
+    parser.add_argument("--provider", choices=["gemini", "ollama"], default=None,
+                        help="Model backend to run the answerer against "
+                             "(overrides the config file).")
     parser.add_argument("--model", default=None,
-                        help="Model id/tag (defaults to the provider's default).")
+                        help="Model id/tag (overrides the config file).")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
@@ -90,18 +94,26 @@ def main(argv: list[str] | None = None) -> int:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    hyper = (
+        HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
+    ).with_env_overrides()
+
     dataset = ResearchQADataset()
     tasks = select_tasks(dataset, args.tasks_per_condition)
     logger.info("Selected %d tasks for benchmark", len(tasks))
 
-    cost_tracker = CostTracker()
+    cost_tracker = hyper.to_cost_tracker()
     if args.episode_budget is not None:
         cost_tracker.set_episode_budget(args.episode_budget)
 
-    client = build_client(args.provider, args.model)
+    provider = args.provider or hyper.model.provider
+    # The configured model name only applies to the configured provider.
+    model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
+    client = build_client(provider, model)
     runner = EpisodeRunner(
         client,
-        config=EpisodeConfig(max_turns=args.max_turns, score_episode=True),
+        config=hyper.to_episode_config(max_turns=args.max_turns, score_episode=True),
+        hyper_config=hyper,
         cost_tracker=cost_tracker,
     )
 
@@ -111,7 +123,7 @@ def main(argv: list[str] | None = None) -> int:
             action_probability=args.random_probability,
             seed=args.random_seed + idx,
         ),
-        "heuristic": lambda _idx: HeuristicController(),
+        "heuristic": lambda _idx: hyper.to_heuristic_controller(),
     }
 
     result = run_benchmark(client, tasks, conditions, runner=runner)

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -15,6 +15,14 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from bicameral_agent.heuristic_controller import (
+    DEFAULT_AUDITOR_HIGH_STOP_THRESHOLD,
+    DEFAULT_AUDITOR_STOP_THRESHOLD,
+    DEFAULT_QUEUE_DEPTH_GUARD,
+    DEFAULT_REFRESHER_INTERVAL,
+    DEFAULT_SCANNER_INTERVAL,
+    DEFAULT_STAGGER_TOLERANCE_MS,
+)
 from bicameral_agent.queue import InterruptConfig, Priority
 
 
@@ -102,12 +110,12 @@ class HeuristicConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    scanner_interval: int = Field(default=5, ge=1)
-    refresher_interval: int = Field(default=8, ge=1)
-    auditor_stop_threshold: int = 1
-    auditor_high_stop_threshold: int = 2
-    queue_depth_guard: int = 3
-    stagger_tolerance_ms: float = 1000.0
+    scanner_interval: int = Field(default=DEFAULT_SCANNER_INTERVAL, ge=1)
+    refresher_interval: int = Field(default=DEFAULT_REFRESHER_INTERVAL, ge=1)
+    auditor_stop_threshold: int = DEFAULT_AUDITOR_STOP_THRESHOLD
+    auditor_high_stop_threshold: int = DEFAULT_AUDITOR_HIGH_STOP_THRESHOLD
+    queue_depth_guard: int = DEFAULT_QUEUE_DEPTH_GUARD
+    stagger_tolerance_ms: float = DEFAULT_STAGGER_TOLERANCE_MS
 
 
 class TrainingConfig(BaseModel):

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -24,7 +24,7 @@ _DEFAULT_TOML = files("bicameral_agent.data").joinpath("default_config.toml")
 class ModelConfig(BaseModel):
     """LLM model configuration."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     provider: str = "gemini"
     name: str = "gemini-3.1-flash-lite-preview"
@@ -43,7 +43,7 @@ class ModelConfig(BaseModel):
     @field_validator("thinking_level")
     @classmethod
     def _validate_thinking_level(cls, v: str) -> str:
-        allowed = {"none", "low", "medium", "high"}
+        allowed = {"minimal", "low", "medium", "high"}
         if v not in allowed:
             msg = f"thinking_level must be one of {allowed}, got {v!r}"
             raise ValueError(msg)
@@ -61,20 +61,27 @@ class ModelConfig(BaseModel):
 class QueueConfig(BaseModel):
     """Context queue thresholds and injection semantics."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     count_threshold: int = 5
     priority_threshold: int = 3
     token_threshold: int = 1000
-    expiry_turns: int = 10
-    max_depth: int = 3
+    expiry_turns: int | None = None
     persistent_injection: bool = True
+
+    @field_validator("expiry_turns")
+    @classmethod
+    def _validate_expiry_turns(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            msg = f"expiry_turns must be >= 1, got {v}"
+            raise ValueError(msg)
+        return v
 
 
 class ToolBudgetConfig(BaseModel):
     """Token budget for a single tool."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     max_calls: int = 10
     max_input_tokens: int = 50_000
@@ -82,22 +89,21 @@ class ToolBudgetConfig(BaseModel):
 
 
 class ToolsConfig(BaseModel):
-    """Tool budget and priority configuration."""
+    """Tool budget configuration."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     default_budget: ToolBudgetConfig = Field(default_factory=ToolBudgetConfig)
     budgets: dict[str, ToolBudgetConfig] = Field(default_factory=dict)
-    priority_map: dict[str, int] = Field(default_factory=dict)
 
 
 class HeuristicConfig(BaseModel):
     """Heuristic controller tuning parameters."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
-    scanner_interval: int = 5
-    refresher_interval: int = 8
+    scanner_interval: int = Field(default=5, ge=1)
+    refresher_interval: int = Field(default=8, ge=1)
     auditor_stop_threshold: int = 1
     auditor_high_stop_threshold: int = 2
     queue_depth_guard: int = 3
@@ -107,7 +113,7 @@ class HeuristicConfig(BaseModel):
 class TrainingConfig(BaseModel):
     """RL training hyperparameters."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     learning_rate: float = 1e-3
     batch_size: int = 32
@@ -141,7 +147,7 @@ class TrainingConfig(BaseModel):
 class MCTSConfig(BaseModel):
     """Monte Carlo Tree Search hyperparameters."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     c_puct: float = 1.4
     dirichlet_alpha: float = 0.3
@@ -152,7 +158,7 @@ class MCTSConfig(BaseModel):
 class CostConfig(BaseModel):
     """Cost tracking and budget configuration."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     session_budget: float | None = None
     episode_budget: float | None = None
@@ -161,7 +167,7 @@ class CostConfig(BaseModel):
 class EvaluationConfig(BaseModel):
     """Evaluation run configuration."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     num_tasks: int = 10
     random_seed: int = 42
@@ -175,7 +181,7 @@ class HyperConfig(BaseModel):
     ``InterruptConfig``, ``TokenBudget``).
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     model: ModelConfig = Field(default_factory=ModelConfig)
     queue: QueueConfig = Field(default_factory=QueueConfig)
@@ -232,12 +238,27 @@ class HyperConfig(BaseModel):
 
         defaults = {
             "thinking_level": self.model.thinking_level,
+            "temperature": self.model.temperature,
             "interrupt_config": self.to_interrupt_config(),
             "tool_token_budget": self.to_token_budget(),
             "persistent_injection": self.queue.persistent_injection,
+            "queue_expiry_turns": self.queue.expiry_turns,
         }
         defaults.update(overrides)
         return EpisodeConfig(**defaults)
+
+    def to_heuristic_controller(self):
+        """Produce a ``HeuristicController`` tuned by heuristic settings."""
+        from bicameral_agent.heuristic_controller import HeuristicController
+
+        return HeuristicController(
+            scanner_interval=self.heuristic.scanner_interval,
+            refresher_interval=self.heuristic.refresher_interval,
+            auditor_stop_threshold=self.heuristic.auditor_stop_threshold,
+            auditor_high_stop_threshold=self.heuristic.auditor_high_stop_threshold,
+            queue_depth_guard=self.heuristic.queue_depth_guard,
+            stagger_tolerance_ms=self.heuristic.stagger_tolerance_ms,
+        )
 
     def to_interrupt_config(self) -> InterruptConfig:
         """Produce an ``InterruptConfig`` from queue settings."""

--- a/src/bicameral_agent/conscious_loop.py
+++ b/src/bicameral_agent/conscious_loop.py
@@ -61,6 +61,7 @@ class ConsciousLoop:
         *,
         system_prompt: str | None = None,
         thinking_level: str = "medium",
+        temperature: float | None = None,
         interrupt_config: InterruptConfig | None = None,
         on_completion: Callable[[AssistantResponse], None] | None = None,
         persistent_injection: bool = True,
@@ -69,6 +70,7 @@ class ConsciousLoop:
         self._queue = queue
         self._system_prompt = system_prompt
         self._thinking_level = thinking_level
+        self._temperature = temperature
         self._interrupt_config = interrupt_config or InterruptConfig()
         self._on_completion = on_completion
         self._persistent_injection = persistent_injection
@@ -229,6 +231,7 @@ class ConsciousLoop:
             messages,
             system_prompt=self._system_prompt,
             thinking_level=self._thinking_level,
+            temperature=self._temperature,
         )
 
 

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -6,15 +6,14 @@
 [model]
 provider = "gemini"        # "gemini" or "ollama"
 name = "gemini-3.1-flash-lite-preview"
-thinking_level = "medium"
+thinking_level = "medium"  # "minimal", "low", "medium", or "high"
 # temperature is unset (uses model default)
 
 [queue]
 count_threshold = 5        # interrupt if queue depth reaches this
 priority_threshold = 3     # interrupt if any item >= CRITICAL (3)
 token_threshold = 1000     # interrupt if total pending tokens reach this
-expiry_turns = 10          # turns before a queue item expires
-max_depth = 3              # queue depth guard for heuristic controller
+# expiry_turns = 3         # expiry applied to every tool deposit (unset = per-tool defaults: refresher 3, others 10)
 persistent_injection = true  # injected context enters history (false = transient one-generation whisper)
 
 [tools]
@@ -30,11 +29,6 @@ max_output_tokens = 20_000
 # max_calls = 5
 # max_input_tokens = 25_000
 # max_output_tokens = 10_000
-
-# Tool priority map (empty by default).
-# Example:
-# [tools.priority_map]
-# assumption_auditor = 2
 
 [heuristic]
 scanner_interval = 5            # invoke scanner every N turns

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -85,7 +85,9 @@ class EpisodeConfig:
     tool_token_budget: TokenBudget = _DEFAULT_TOKEN_BUDGET
     system_prompt: str = _DEFAULT_SYSTEM_PROMPT
     thinking_level: str = "medium"
+    temperature: float | None = None
     interrupt_config: InterruptConfig | None = None
+    queue_expiry_turns: int | None = None
     patience: Patience = Patience.MEDIUM
     strictness: Strictness = Strictness.MEDIUM
     score_episode: bool = False
@@ -153,6 +155,7 @@ class EpisodeRunner:
             queue,
             system_prompt=cfg.system_prompt,
             thinking_level=cfg.thinking_level,
+            temperature=cfg.temperature,
             interrupt_config=cfg.interrupt_config,
             persistent_injection=cfg.persistent_injection,
         )
@@ -295,8 +298,11 @@ class EpisodeRunner:
 
                     # Deposit to queue and log context injection
                     if result.queue_deposit is not None:
+                        deposit_update: dict = {"enqueued_at_turn": turn}
+                        if cfg.queue_expiry_turns is not None:
+                            deposit_update["expiry_turns"] = cfg.queue_expiry_turns
                         deposit = result.queue_deposit.model_copy(
-                            update={"enqueued_at_turn": turn}
+                            update=deposit_update
                         )
                         queue.enqueue(deposit)
                         inj_idx = log.log_context_injection(

--- a/src/bicameral_agent/heuristic_controller.py
+++ b/src/bicameral_agent/heuristic_controller.py
@@ -21,6 +21,15 @@ from bicameral_agent.followup_classifier import FollowUpType
 
 logger = logging.getLogger(__name__)
 
+# Default rule thresholds. Single source of truth shared with
+# ``config.HeuristicConfig``; override per-run via constructor kwargs.
+DEFAULT_SCANNER_INTERVAL = 5
+DEFAULT_REFRESHER_INTERVAL = 8
+DEFAULT_AUDITOR_STOP_THRESHOLD = 1
+DEFAULT_AUDITOR_HIGH_STOP_THRESHOLD = 2
+DEFAULT_QUEUE_DEPTH_GUARD = 3
+DEFAULT_STAGGER_TOLERANCE_MS = 1000.0
+
 
 class Action(str, enum.Enum):
     """Tool invocation actions the controller can select."""
@@ -83,12 +92,12 @@ class HeuristicController:
     def __init__(
         self,
         *,
-        scanner_interval: int = 5,
-        refresher_interval: int = 8,
-        auditor_stop_threshold: int = 1,
-        auditor_high_stop_threshold: int = 2,
-        queue_depth_guard: int = 3,
-        stagger_tolerance_ms: float = 1000.0,
+        scanner_interval: int = DEFAULT_SCANNER_INTERVAL,
+        refresher_interval: int = DEFAULT_REFRESHER_INTERVAL,
+        auditor_stop_threshold: int = DEFAULT_AUDITOR_STOP_THRESHOLD,
+        auditor_high_stop_threshold: int = DEFAULT_AUDITOR_HIGH_STOP_THRESHOLD,
+        queue_depth_guard: int = DEFAULT_QUEUE_DEPTH_GUARD,
+        stagger_tolerance_ms: float = DEFAULT_STAGGER_TOLERANCE_MS,
     ) -> None:
         self._scanner_interval = scanner_interval
         self._refresher_interval = refresher_interval

--- a/src/bicameral_agent/heuristic_controller.py
+++ b/src/bicameral_agent/heuristic_controller.py
@@ -74,9 +74,28 @@ class HeuristicController:
 
     Rules are evaluated in priority order (6→1) to find a candidate
     tool action, then guard rules (7–8) may suppress it.
+
+    Thresholds are constructor parameters so they can be swept as
+    hyperparameters (see ``HyperConfig.to_heuristic_controller``);
+    defaults match the original hardcoded rule set.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        scanner_interval: int = 5,
+        refresher_interval: int = 8,
+        auditor_stop_threshold: int = 1,
+        auditor_high_stop_threshold: int = 2,
+        queue_depth_guard: int = 3,
+        stagger_tolerance_ms: float = 1000.0,
+    ) -> None:
+        self._scanner_interval = scanner_interval
+        self._refresher_interval = refresher_interval
+        self._auditor_stop_threshold = auditor_stop_threshold
+        self._auditor_high_stop_threshold = auditor_high_stop_threshold
+        self._queue_depth_guard = queue_depth_guard
+        self._stagger_tolerance_ms = stagger_tolerance_ms
         self._decisions: list[DecisionLog] = []
 
     def decide(self, state: FullState) -> Action:
@@ -105,8 +124,7 @@ class HeuristicController:
         """Return all recorded decisions."""
         return list(self._decisions)
 
-    @staticmethod
-    def _evaluate(state: FullState) -> tuple[Action, int]:
+    def _evaluate(self, state: FullState) -> tuple[Action, int]:
         """Return (action, rule_number) after evaluating all rules."""
         # --- Candidate selection: rules 6→1 ---
         candidate: Action | None = None
@@ -114,13 +132,13 @@ class HeuristicController:
 
         if state.followup_type == FollowUpType.REDIRECT:
             candidate, rule = Action.REFRESHER, 6
-        elif state.turn_number % 8 == 0:
+        elif state.turn_number % self._refresher_interval == 0:
             candidate, rule = Action.REFRESHER, 5
-        elif state.stop_count >= 2:
+        elif state.stop_count >= self._auditor_high_stop_threshold:
             candidate, rule = Action.AUDITOR, 4
-        elif state.stop_count >= 1:
+        elif state.stop_count >= self._auditor_stop_threshold:
             candidate, rule = Action.AUDITOR, 3
-        elif state.turn_number % 5 == 0 and state.turn_number > 1:
+        elif state.turn_number % self._scanner_interval == 0 and state.turn_number > 1:
             candidate, rule = Action.SCANNER, 2
         elif state.turn_number == 1:
             candidate, rule = Action.SCANNER, 1
@@ -130,13 +148,13 @@ class HeuristicController:
 
         # --- Guard rules: override candidate to DO_NOTHING ---
         # Rule 7: queue depth guard
-        if state.queue_depth >= 3:
+        if state.queue_depth >= self._queue_depth_guard:
             return Action.DO_NOTHING, 7
 
         # Rule 8: stagger guard
         candidate_latency = state.predicted_latencies.get(candidate.value, 0.0)
         for tool in state.executing_tools:
-            if abs(tool.predicted_remaining_ms - candidate_latency) <= 1000:
+            if abs(tool.predicted_remaining_ms - candidate_latency) <= self._stagger_tolerance_ms:
                 return Action.DO_NOTHING, 8
 
         return candidate, rule

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import textwrap
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
 from bicameral_agent.config import (
+    HeuristicConfig,
     HyperConfig,
     ModelConfig,
     QueueConfig,
@@ -16,6 +18,8 @@ from bicameral_agent.config import (
     TrainingConfig,
 )
 from bicameral_agent.episode_runner import EpisodeConfig
+from bicameral_agent.followup_classifier import FollowUpType
+from bicameral_agent.heuristic_controller import Action, ExecutingTool, FullState
 from bicameral_agent.queue import InterruptConfig, Priority
 from bicameral_agent.tool_primitive import TokenBudget
 
@@ -38,8 +42,7 @@ class TestDefaults:
         assert cfg.queue.count_threshold == 5
         assert cfg.queue.priority_threshold == 3
         assert cfg.queue.token_threshold == 1000
-        assert cfg.queue.expiry_turns == 10
-        assert cfg.queue.max_depth == 3
+        assert cfg.queue.expiry_turns is None
         assert cfg.queue.persistent_injection is True
 
     def test_tools_defaults(self):
@@ -48,7 +51,6 @@ class TestDefaults:
         assert cfg.tools.default_budget.max_input_tokens == 50_000
         assert cfg.tools.default_budget.max_output_tokens == 20_000
         assert cfg.tools.budgets == {}
-        assert cfg.tools.priority_map == {}
 
     def test_heuristic_defaults(self):
         cfg = HyperConfig()
@@ -115,6 +117,15 @@ class TestToml:
         reconstructed = HyperConfig.model_validate(d)
         assert reconstructed.model_dump() == cfg.model_dump()
 
+    def test_from_toml_unknown_key_raises(self, tmp_path):
+        toml_file = tmp_path / "typo.toml"
+        toml_file.write_text(textwrap.dedent("""\
+            [training]
+            learning_rat = 0.01
+        """))
+        with pytest.raises(ValidationError, match="learning_rat"):
+            HyperConfig.from_toml(toml_file)
+
     def test_from_toml_with_tool_budgets(self, tmp_path):
         toml_file = tmp_path / "budgets.toml"
         toml_file.write_text(textwrap.dedent("""\
@@ -159,6 +170,17 @@ class TestEnvOverrides:
         assert cfg.model.thinking_level == "medium"
         assert cfg.queue.count_threshold == 5
 
+    def test_typo_field_raises(self, monkeypatch):
+        """A misspelled override errors instead of being silently dropped."""
+        monkeypatch.setenv("BICAMERAL_TRAINING__LEARNING_RAT", "0.01")
+        with pytest.raises(ValidationError, match="learning_rat"):
+            HyperConfig().with_env_overrides()
+
+    def test_typo_section_raises(self, monkeypatch):
+        monkeypatch.setenv("BICAMERAL_TRANING__LEARNING_RATE", "0.01")
+        with pytest.raises(ValidationError, match="traning"):
+            HyperConfig().with_env_overrides()
+
 
 class TestValidation:
     """Pydantic validation catches invalid values."""
@@ -166,6 +188,26 @@ class TestValidation:
     def test_invalid_thinking_level(self):
         with pytest.raises(ValidationError, match="thinking_level"):
             ModelConfig(thinking_level="ultra")
+
+    def test_thinking_level_none_rejected(self):
+        """'none' is not part of the client vocabulary; use 'minimal'."""
+        with pytest.raises(ValidationError, match="thinking_level"):
+            ModelConfig(thinking_level="none")
+
+    def test_thinking_level_minimal_accepted(self):
+        assert ModelConfig(thinking_level="minimal").thinking_level == "minimal"
+
+    def test_expiry_turns_below_one_rejected(self):
+        with pytest.raises(ValidationError, match="expiry_turns"):
+            QueueConfig(expiry_turns=0)
+
+    def test_scanner_interval_zero_rejected(self):
+        with pytest.raises(ValidationError, match="scanner_interval"):
+            HeuristicConfig(scanner_interval=0)
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError, match="learning_rat"):
+            TrainingConfig(learning_rat=0.01)
 
     def test_temperature_too_high(self):
         with pytest.raises(ValidationError, match="temperature"):
@@ -224,9 +266,27 @@ class TestAdapters:
         ec = cfg.to_episode_config()
         assert isinstance(ec, EpisodeConfig)
         assert ec.thinking_level == "medium"
+        assert ec.temperature is None
+        assert ec.queue_expiry_turns is None
         assert ec.tool_token_budget.max_calls == 10
         assert ec.tool_token_budget.max_input_tokens == 50_000
         assert ec.persistent_injection is True
+
+    def test_to_episode_config_carries_temperature_and_expiry(self):
+        cfg = HyperConfig(
+            model=ModelConfig(temperature=0.3),
+            queue=QueueConfig(expiry_turns=2),
+        )
+        ec = cfg.to_episode_config()
+        assert ec.temperature == pytest.approx(0.3)
+        assert ec.queue_expiry_turns == 2
+
+    def test_to_heuristic_controller(self):
+        from bicameral_agent.heuristic_controller import HeuristicController
+
+        cfg = HyperConfig()
+        ctrl = cfg.to_heuristic_controller()
+        assert isinstance(ctrl, HeuristicController)
 
     def test_to_episode_config_with_overrides(self):
         cfg = HyperConfig()
@@ -289,3 +349,220 @@ class TestEpisodeMetadata:
         hp = ep.metadata["hyperparameters"]
         assert hp["model"]["name"] == "gemini-3.1-flash-lite-preview"
         assert hp["training"]["learning_rate"] == pytest.approx(1e-3)
+
+
+_CONFIG_THINKING_LEVELS = ["minimal", "low", "medium", "high"]
+
+
+class TestThinkingLevelVocabulary:
+    """Every config-allowed thinking level is accepted end-to-end by both clients."""
+
+    @pytest.mark.parametrize("level", _CONFIG_THINKING_LEVELS)
+    def test_config_accepts_level(self, level):
+        assert ModelConfig(thinking_level=level).thinking_level == level
+
+    @pytest.mark.parametrize("level", _CONFIG_THINKING_LEVELS)
+    def test_gemini_accepts_config_level(self, level):
+        from bicameral_agent.gemini import GeminiClient
+
+        cfg = ModelConfig(thinking_level=level)
+        with patch("bicameral_agent.gemini.genai.Client"):
+            client = GeminiClient(api_key="test-key")
+        sentinel = object()
+        with patch.object(
+            client, "_execute_with_retry", return_value=sentinel
+        ) as mock_exec:
+            result = client.generate(
+                [{"role": "user", "content": "hi"}],
+                thinking_level=cfg.thinking_level,
+            )
+        assert result is sentinel
+        mock_exec.assert_called_once()
+
+    @pytest.mark.parametrize("level", _CONFIG_THINKING_LEVELS)
+    def test_ollama_accepts_config_level(self, level):
+        from bicameral_agent.ollama_cloud import OllamaCloudClient
+
+        cfg = ModelConfig(thinking_level=level)
+        client = OllamaCloudClient(api_key="test-key")
+        raw = {
+            "message": {"content": "ok"},
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+            "done_reason": "stop",
+        }
+        with patch.object(client, "_post", return_value=raw) as mock_post:
+            result = client.generate(
+                [{"role": "user", "content": "hi"}],
+                thinking_level=cfg.thinking_level,
+            )
+        assert result.content == "ok"
+        mock_post.assert_called_once()
+
+
+def _make_state(**overrides) -> FullState:
+    defaults = dict(
+        turn_number=1,
+        stop_count=0,
+        followup_type=FollowUpType.ELABORATION,
+        queue_depth=0,
+        executing_tools=(),
+        predicted_latencies={},
+    )
+    defaults.update(overrides)
+    return FullState(**defaults)
+
+
+class TestHeuristicWiring:
+    """Heuristic config values change actual controller decisions."""
+
+    def test_scanner_interval_fires_on_turn_2(self):
+        cfg = HyperConfig(heuristic=HeuristicConfig(scanner_interval=2))
+        ctrl = cfg.to_heuristic_controller()
+        assert ctrl.decide(_make_state(turn_number=2)) == Action.SCANNER
+
+    def test_default_scanner_interval_does_not_fire_on_turn_2(self):
+        ctrl = HyperConfig().to_heuristic_controller()
+        assert ctrl.decide(_make_state(turn_number=2)) == Action.DO_NOTHING
+
+    def test_refresher_interval_fires_on_turn_3(self):
+        cfg = HyperConfig(heuristic=HeuristicConfig(refresher_interval=3))
+        ctrl = cfg.to_heuristic_controller()
+        assert ctrl.decide(_make_state(turn_number=3)) == Action.REFRESHER
+
+    def test_auditor_stop_threshold_raised_suppresses_auditor(self):
+        cfg = HyperConfig(
+            heuristic=HeuristicConfig(
+                auditor_stop_threshold=3, auditor_high_stop_threshold=4
+            )
+        )
+        ctrl = cfg.to_heuristic_controller()
+        # stop_count=2 triggers the auditor at defaults but not here.
+        assert ctrl.decide(_make_state(turn_number=3, stop_count=2)) == Action.DO_NOTHING
+        default_ctrl = HyperConfig().to_heuristic_controller()
+        assert default_ctrl.decide(_make_state(turn_number=3, stop_count=2)) == Action.AUDITOR
+
+    def test_queue_depth_guard_lowered_suppresses_tool(self):
+        cfg = HyperConfig(heuristic=HeuristicConfig(queue_depth_guard=1))
+        ctrl = cfg.to_heuristic_controller()
+        # Turn 1 scanner candidate is suppressed by a queue depth of 1.
+        assert ctrl.decide(_make_state(turn_number=1, queue_depth=1)) == Action.DO_NOTHING
+        default_ctrl = HyperConfig().to_heuristic_controller()
+        assert default_ctrl.decide(_make_state(turn_number=1, queue_depth=1)) == Action.SCANNER
+
+    def test_stagger_tolerance_widened_suppresses_tool(self):
+        state = _make_state(
+            turn_number=1,
+            executing_tools=(
+                ExecutingTool(tool_id="other", predicted_remaining_ms=3000.0),
+            ),
+        )
+        cfg = HyperConfig(heuristic=HeuristicConfig(stagger_tolerance_ms=5000.0))
+        assert cfg.to_heuristic_controller().decide(state) == Action.DO_NOTHING
+        assert HyperConfig().to_heuristic_controller().decide(state) == Action.SCANNER
+
+
+class TestEpisodeWiring:
+    """Model/queue config values reach the API call and queue deposits."""
+
+    def _run_episode(self, hyper: HyperConfig, controller_action=None):
+        from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+        from bicameral_agent.episode_runner import Controller, EpisodeRunner
+        from bicameral_agent.gemini import GeminiClient, GeminiResponse
+        from bicameral_agent.simulated_user import ActionType, UserAction
+
+        client = MagicMock(spec=GeminiClient)
+        client.generate.return_value = GeminiResponse(
+            content="answer",
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=100.0,
+            finish_reason="STOP",
+        )
+
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        if controller_action is not None:
+            ctrl.decide.side_effect = controller_action
+        else:
+            ctrl.decide.return_value = Action.DO_NOTHING
+
+        task = ResearchQATask(
+            task_id="test-001",
+            difficulty=TaskDifficulty.TYPICAL,
+            split=TaskSplit.EVAL,
+            question="What is photosynthesis?",
+            gold_answer="Light energy becomes chemical energy.",
+            known_gaps=None,
+            known_assumptions=None,
+            scoring_rubric="5: Complete. 3: Partial. 1: Wrong.",
+        )
+
+        user_actions = iter([
+            UserAction(
+                action_type=ActionType.FOLLOW_UP,
+                message="Tell me more",
+                followup_type=FollowUpType.ELABORATION,
+                response_delay_ms=100,
+                confidence=0.8,
+            ),
+            UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            ),
+        ])
+
+        runner = EpisodeRunner(client, hyper_config=hyper)
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.side_effect = lambda *a, **k: next(user_actions)
+            MockSimUser.return_value = mock_sim
+            episode = runner.run_episode(task, ctrl)
+        return episode, client
+
+    def test_temperature_and_thinking_level_reach_generate(self):
+        hyper = HyperConfig(
+            model=ModelConfig(temperature=0.3, thinking_level="low")
+        )
+        _, client = self._run_episode(hyper)
+        kwargs = client.generate.call_args.kwargs
+        assert kwargs["temperature"] == pytest.approx(0.3)
+        assert kwargs["thinking_level"] == "low"
+
+    def test_default_temperature_is_none_at_generate(self):
+        _, client = self._run_episode(HyperConfig())
+        assert client.generate.call_args.kwargs["temperature"] is None
+
+    def test_queue_expiry_turns_expires_deposit(self):
+        from bicameral_agent.queue import QueueItem
+        from bicameral_agent.tool_primitive import ToolMetadata, ToolResult
+
+        hyper = HyperConfig(queue=QueueConfig(expiry_turns=1))
+        deposit = QueueItem(
+            content="a gap was found",
+            priority=Priority.LOW,
+            source_tool_id="research_gap_scanner",
+            token_count=5,
+        )
+        result = ToolResult(
+            queue_deposit=deposit,
+            metadata=ToolMetadata(
+                tool_id="research_gap_scanner",
+                action_taken="scanned",
+                confidence=0.8,
+                items_found=1,
+                estimated_relevance=0.7,
+                tokens_consumed=50,
+            ),
+        )
+        with patch("bicameral_agent.episode_runner.ResearchGapScanner") as MockScanner:
+            mock_tool = MagicMock()
+            mock_tool.execute.return_value = result
+            MockScanner.return_value = mock_tool
+            episode, _ = self._run_episode(
+                hyper,
+                controller_action=[Action.SCANNER, Action.DO_NOTHING],
+            )
+        # Deposit on turn 1 with expiry_turns=1 expires at the start of turn 2.
+        assert episode.metadata["expired_queue_items"] == 1


### PR DESCRIPTION
## Summary

Fixes the three config-layer failure modes from the 2026-07-06 code review: the incompatible `thinking_level` vocabulary that crashed at the first LLM call, five grep-verified dead config fields that validated and did nothing, and env overrides that silently swallowed typos. Every remaining field is now wired to a consumer, and every unknown key errors.

## Work performed

**thinking_level vocabulary unified** on the clients' set `{minimal, low, medium, high}`. `config.py` now validates that set; `"none"` (which passed config validation then raised `ValueError` at the first `generate()`) is gone, and `"minimal"` is now expressible via config. No client changes were needed — `gemini.py` and `ollama_cloud.py` already accepted exactly this set.

**HeuristicConfig wired** — `HeuristicController` now takes `scanner_interval`, `refresher_interval`, `auditor_stop_threshold`, `auditor_high_stop_threshold`, `queue_depth_guard`, and `stagger_tolerance_ms` as constructor parameters (defaults match the old hardcoded `% 8`, `% 5`, `>= 2`, `>= 3`, 1000 ms rules), plus a `HyperConfig.to_heuristic_controller()` adapter. `scanner_interval`/`refresher_interval` gain `ge=1` validation since 0 would be a modulo-by-zero crash.

**queue.expiry_turns wired** — now `int | None = None`. When set, `EpisodeRunner` stamps it on every tool deposit at enqueue time (one knob, all tools, sweep-able); when unset, each tool keeps its own default (refresher 3, scanner/auditor 10), so default behavior is unchanged.

**model.temperature plumbed** — `HyperConfig.to_episode_config()` → `EpisodeConfig.temperature` → `ConsciousLoop` → `client.generate(temperature=...)`. Both clients' `generate()` already accepted the parameter.

**queue.max_depth deleted** — never read anywhere, and an exact duplicate of `heuristic.queue_depth_guard` (both 3), which is now the one actually-consumed knob.

**tools.priority_map deleted** — never read; each tool derives its deposit priority from its findings at runtime (drift category, gap severity), so a static per-tool priority map contradicts the design and had no plausible consumer.

**extra="forbid" on all config models** — `BICAMERAL_TRAINING__LEARNING_RAT=0.01` and misspelled TOML keys now raise `ValidationError` naming the bad key instead of merging and vanishing.

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 1010 passed, 34 skipped
- `uv run --extra dev ruff check src/ tests/` — clean
- New end-to-end vocabulary tests: every config-allowed thinking level is accepted by `GeminiClient` and `OllamaCloudClient` `generate()` (transport mocked, validation and config/payload construction real)
- New behavioral tests (not value round-trips): `scanner_interval=2` makes the scanner fire on turn 2 (and not with defaults); refresher interval, auditor thresholds, queue depth guard, and stagger tolerance each change actual decisions; `temperature=0.3`/`thinking_level="low"` reach `client.generate()` through a full `EpisodeRunner` episode; `queue.expiry_turns=1` makes a turn-1 scanner deposit expire on turn 2 (`expired_queue_items == 1`)
- New negative tests: typo'd env override and typo'd TOML key both raise; `thinking_level="none"` rejected; `expiry_turns=0` and `scanner_interval=0` rejected

Note: CI review jobs are known-failing repo-wide (dead OAuth token), unrelated to this change.

Closes #48