### PR TITLE
Harden benchmark runs against malformed LLM output and budget trips

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -31,6 +31,7 @@ from bicameral_agent.heuristic_controller import HeuristicController
 from bicameral_agent.model_client import build_client
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
+from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
 
 logger = logging.getLogger(__name__)
@@ -114,10 +115,19 @@ def main(argv: list[str] | None = None) -> int:
         "heuristic": lambda _idx: HeuristicController(),
     }
 
-    result = run_benchmark(client, tasks, conditions, runner=runner)
+    # Persist episodes incrementally: rewrite the condition's parquet after
+    # every completed episode so a late crash keeps all prior results.
+    completed: dict[str, list[Episode]] = {}
 
-    for condition, episodes in result.episodes.items():
-        episodes_to_parquet(episodes, str(output_dir / f"{condition}.parquet"))
+    def persist_episode(condition: str, _idx: int, episode: Episode) -> None:
+        completed.setdefault(condition, []).append(episode)
+        episodes_to_parquet(
+            completed[condition], str(output_dir / f"{condition}.parquet")
+        )
+
+    result = run_benchmark(
+        client, tasks, conditions, runner=runner, on_episode=persist_episode
+    )
 
     report_text = format_report(result)
     (output_dir / "report.txt").write_text(report_text)

--- a/src/bicameral_agent/assumption_auditor.py
+++ b/src/bicameral_agent/assumption_auditor.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 
 import enum
 import hashlib
-import json
 from dataclasses import dataclass
 
 from bicameral_agent.gap_scanner import MockSearchProvider, SearchProvider, SearchResult
+from bicameral_agent.llm_output import safe_parse_json
 from bicameral_agent.queue import Priority, QueueItem
 from bicameral_agent.schema import Message, estimate_text_tokens
 from bicameral_agent.tool_primitive import (
@@ -313,9 +313,15 @@ def _extract_assumptions(conv_text: str, client) -> list[IdentifiedAssumption]:
         response_schema=_ASSUMPTION_EXTRACTION_SCHEMA,
     )
 
-    parsed = json.loads(response.content)
+    parsed = safe_parse_json(
+        response,
+        context="assumption_auditor._extract_assumptions",
+        default={"assumptions": []},
+    )
     assumptions = []
     for item in parsed.get("assumptions", []):
+        if not isinstance(item, dict) or not item.get("description"):
+            continue
         try:
             risk = RiskLevel(item["risk_level"])
         except (ValueError, KeyError):
@@ -359,9 +365,15 @@ def _assess_evidence(
         response_schema=_EVIDENCE_ASSESSMENT_SCHEMA,
     )
 
-    parsed = json.loads(response.content)
+    parsed = safe_parse_json(
+        response,
+        context="assumption_auditor._assess_evidence",
+        default={"assessments": []},
+    )
     evidence_map: dict[str, EvidenceResult] = {}
     for item in parsed.get("assessments", []):
+        if not isinstance(item, dict) or not item.get("assumption_description"):
+            continue
         try:
             verdict = EvidenceVerdict(item["verdict"])
             action = SuggestedAction(item["suggested_action"])

--- a/src/bicameral_agent/baseline_benchmark.py
+++ b/src/bicameral_agent/baseline_benchmark.py
@@ -175,16 +175,23 @@ class BenchmarkResult:
 
 ControllerFactory = Callable[[int], Controller]
 
+EpisodeCallback = Callable[[str, int, Episode], None]
+"""Called with (condition, episode_index, episode) as each episode completes."""
+
 
 def run_condition(
     runner: EpisodeRunner,
     tasks: list[ResearchQATask],
     controller_factory: ControllerFactory,
+    condition: str = "",
+    on_episode: EpisodeCallback | None = None,
 ) -> tuple[list[Episode], list[TaskMetrics]]:
     """Run one controller condition over the task pool.
 
     A fresh controller is constructed per episode (via ``controller_factory(idx)``)
-    so that decision logs are scoped to a single episode.
+    so that decision logs are scoped to a single episode. ``on_episode`` (if
+    given) fires after each completed episode, letting callers persist results
+    incrementally so a late crash keeps prior episodes.
     """
     episodes: list[Episode] = []
     metrics: list[TaskMetrics] = []
@@ -193,6 +200,8 @@ def run_condition(
         episode = runner.run_episode(task, controller)
         episodes.append(episode)
         metrics.append(extract_task_metrics(episode, list(controller.decisions)))
+        if on_episode is not None:
+            on_episode(condition, idx, episode)
     return episodes, metrics
 
 
@@ -208,13 +217,20 @@ def run_benchmark(
     tasks: list[ResearchQATask],
     conditions: dict[str, ControllerFactory],
     runner: EpisodeRunner | None = None,
+    on_episode: EpisodeCallback | None = None,
 ) -> BenchmarkResult:
-    """Run all conditions over the task pool and aggregate."""
+    """Run all conditions over the task pool and aggregate.
+
+    ``on_episode`` is forwarded to :func:`run_condition` for incremental
+    persistence of completed episodes.
+    """
     runner = runner or EpisodeRunner(client)
     result = BenchmarkResult()
     for condition, factory in conditions.items():
         logger.info("Running %d episodes for condition %r", len(tasks), condition)
-        episodes, metrics = run_condition(runner, tasks, factory)
+        episodes, metrics = run_condition(
+            runner, tasks, factory, condition=condition, on_episode=on_episode
+        )
         result.episodes[condition] = episodes
         result.metrics[condition] = metrics
         result.reports[condition] = aggregate(condition, metrics)

--- a/src/bicameral_agent/coherence_judge.py
+++ b/src/bicameral_agent/coherence_judge.py
@@ -7,13 +7,13 @@ coherence using Gemini Flash. Thread-safe with caching and batch support.
 from __future__ import annotations
 
 import hashlib
-import json
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pydantic import BaseModel, Field
 
 from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.llm_output import coerce_int, safe_parse_json
 from bicameral_agent.schema import Message
 from bicameral_agent.scorer import _normalize_score
 
@@ -153,8 +153,14 @@ class CoherenceJudge:
             max_output_tokens=100,
             response_schema=_JUDGE_RESPONSE_SCHEMA,
         )
-        parsed = json.loads(response.content)
-        return CoherenceScore.from_raw(**parsed)
+        # Malformed/truncated judge output degrades to a neutral mid-scale
+        # score (3 normalizes to 0.5); extra keys are ignored, not splatted.
+        parsed = safe_parse_json(response, context="CoherenceJudge", default={})
+        return CoherenceScore.from_raw(
+            logical_flow=coerce_int(parsed.get("logical_flow"), 3),
+            consistency=coerce_int(parsed.get("consistency"), 3),
+            overall=coerce_int(parsed.get("overall"), 3),
+        )
 
 
 def _format_transcript(messages: list[Message]) -> str:

--- a/src/bicameral_agent/context_refresher.py
+++ b/src/bicameral_agent/context_refresher.py
@@ -171,6 +171,20 @@ class ContextRefresher(ToolPrimitive):
         words = reminder.split()[:100]
         reminder = " ".join(words)
 
+        # Drift with a null/empty reminder would deposit a blank QueueItem,
+        # injecting an empty context update; skip the deposit instead.
+        if not reminder:
+            return ToolResult(
+                queue_deposit=None,
+                metadata=ToolMetadata(
+                    tool_id=self.tool_id,
+                    action_taken="detected drift but no reminder produced",
+                    confidence=0.3,
+                    items_found=len(drifts),
+                    estimated_relevance=0.0,
+                ),
+            )
+
         max_priority = max((_drift_priority(cat) for cat, _ in drifts), default=Priority.MEDIUM)
         dedup_key = _make_dedup_key(drifts)
 

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -267,6 +267,10 @@ class EpisodeRunner:
             # (i) Controller decides
             action = controller.decide(state)
 
+            # Set when a cost-budget trip mid-turn must end the episode after
+            # the assistant message is recorded (mirrors the run_turn path).
+            end_episode = False
+
             # (j) Execute tool if action != DO_NOTHING
             if action != Action.DO_NOTHING:
                 tool_id = TOOL_IDS[action]
@@ -344,6 +348,16 @@ class EpisodeRunner:
                     log.log_tool_completion(
                         inv_idx, 0, result_deposited=False, budget_exceeded=True
                     )
+                except CostBudgetExceeded:
+                    logger.warning(
+                        "CostBudgetExceeded in tool %s on turn %d, ending episode",
+                        tool_id,
+                        turn,
+                    )
+                    log.log_tool_completion(
+                        inv_idx, 0, result_deposited=False, budget_exceeded=True
+                    )
+                    end_episode = True
 
             schema_messages.append(
                 Message(
@@ -354,11 +368,21 @@ class EpisodeRunner:
                 )
             )
 
+            if end_episode:
+                break
+
             # (k) Simulated user responds. schema_messages already contains
             # the current exchange, so the runner's turn is passed explicitly.
-            user_action = sim_user.respond(
-                task, response.content, schema_messages, turn_number=turn
-            )
+            try:
+                user_action = sim_user.respond(
+                    task, response.content, schema_messages, turn_number=turn
+                )
+            except CostBudgetExceeded:
+                logger.warning(
+                    "CostBudgetExceeded in simulated user on turn %d, ending episode",
+                    turn,
+                )
+                break
 
             # (l) STOP
             if user_action.action_type == ActionType.STOP:

--- a/src/bicameral_agent/gap_scanner.py
+++ b/src/bicameral_agent/gap_scanner.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import enum
 import hashlib
-import json
 import re
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+from bicameral_agent.llm_output import clamp, safe_parse_json
 from bicameral_agent.queue import Priority, QueueItem
 from bicameral_agent.schema import Message, estimate_text_tokens
 from bicameral_agent.tool_primitive import ToolMetadata, ToolPrimitive, ToolResult
@@ -270,13 +270,18 @@ class ResearchGapScanner(ToolPrimitive):
                 ),
             )
 
-        # Call 2: Rank results
+        # Call 2: Rank results. Clamp LLM-supplied numerics before they reach
+        # Pydantic ToolMetadata fields (models occasionally emit 1-5 scales).
         ranked = _rank_results(gaps, all_search_results, client)
-        overall_confidence = ranked.get("overall_confidence", 0.5)
-        ranked_results = ranked.get("ranked_results", [])
+        overall_confidence = clamp(ranked.get("overall_confidence"), 0.0, 1.0, 0.5)
+        ranked_results = [
+            {**r, "relevance_score": clamp(r.get("relevance_score"), 0.0, 1.0, 0.0)}
+            for r in ranked.get("ranked_results", [])
+            if isinstance(r, dict)
+        ]
 
         # Filter to relevant results
-        relevant = [r for r in ranked_results if r.get("relevance_score", 0) >= 0.3]
+        relevant = [r for r in ranked_results if r["relevance_score"] >= 0.3]
 
         if not relevant:
             gaps_content = _format_gaps_only(gaps)
@@ -344,12 +349,18 @@ def _identify_gaps(conv_text: str, client) -> list[IdentifiedGap]:
         response_schema=_GAP_IDENTIFICATION_SCHEMA,
     )
 
-    parsed = json.loads(response.content)
+    parsed = safe_parse_json(
+        response,
+        context="gap_scanner._identify_gaps",
+        default={"has_gaps": False, "gaps": []},
+    )
     if not parsed.get("has_gaps", False):
         return []
 
     gaps = []
     for gap_data in parsed.get("gaps", []):
+        if not isinstance(gap_data, dict) or not gap_data.get("description"):
+            continue
         try:
             category = GapCategory(gap_data["category"])
         except (ValueError, KeyError):
@@ -358,7 +369,7 @@ def _identify_gaps(conv_text: str, client) -> list[IdentifiedGap]:
             IdentifiedGap(
                 description=gap_data["description"],
                 category=category,
-                search_query=gap_data["search_query"],
+                search_query=gap_data.get("search_query", ""),
             )
         )
     return gaps
@@ -392,10 +403,11 @@ def _rank_results(
         response_schema=_RANKING_SCHEMA,
     )
 
-    try:
-        return json.loads(response.content)
-    except json.JSONDecodeError:
-        return {"overall_confidence": 0.0, "ranked_results": []}
+    return safe_parse_json(
+        response,
+        context="gap_scanner._rank_results",
+        default={"overall_confidence": 0.0, "ranked_results": []},
+    )
 
 
 def _max_priority(gaps: list[IdentifiedGap]) -> Priority:
@@ -425,8 +437,8 @@ def _format_ranked_content(ranked: list[dict]) -> str:
     for r in ranked:
         lines.append(
             f"\n**{r.get('gap_description', 'Unknown gap')}**\n"
-            f"  {r['title']} (relevance: {r['relevance_score']:.1f})\n"
-            f"  {r['snippet']}\n"
-            f"  Source: {r['source']}"
+            f"  {r.get('title', '')} (relevance: {r['relevance_score']:.1f})\n"
+            f"  {r.get('snippet', '')}\n"
+            f"  Source: {r.get('source', '')}"
         )
     return "\n".join(lines)

--- a/src/bicameral_agent/gemini.py
+++ b/src/bicameral_agent/gemini.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 import os
 import random
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from google import genai
+from google.genai import errors as genai_errors
 from google.genai import types
 
 _MODEL = "gemini-3.1-flash-lite-preview"
@@ -26,6 +26,19 @@ _BACKOFF_FACTOR = 2.0
 _MAX_JITTER = 0.5
 
 _VALID_THINKING_LEVELS = {"minimal", "low", "medium", "high"}
+
+
+class BlockedResponseError(RuntimeError):
+    """Raised when Gemini returns no usable content, naming the block reason.
+
+    Covers documented response shapes that would otherwise crash parsing:
+    empty ``candidates`` (prompt blocked, e.g. safety) and ``content.parts``
+    of ``None`` (MAX_TOKENS hit during thinking, SAFETY, RECITATION).
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"Gemini returned no usable content (reason: {reason})")
 
 
 @dataclass(frozen=True, slots=True)
@@ -213,15 +226,26 @@ class GeminiClient:
         input_tokens = usage.prompt_token_count or 0
         output_tokens = usage.candidates_token_count or 0
 
+        if not response.candidates:
+            feedback = getattr(response, "prompt_feedback", None)
+            block_reason = getattr(feedback, "block_reason", None)
+            raise BlockedResponseError(
+                str(block_reason) if block_reason else "no candidates returned"
+            )
+
         candidate = response.candidates[0]
         finish_reason = (
             str(candidate.finish_reason) if candidate.finish_reason else "STOP"
         )
 
+        parts = candidate.content.parts if candidate.content is not None else None
+        if parts is None:
+            raise BlockedResponseError(finish_reason)
+
         text_parts: list[str] = []
         fc_parts: list[dict[str, Any]] = []
 
-        for part in candidate.content.parts:
+        for part in parts:
             if part.function_call is not None:
                 fc = part.function_call
                 fc_parts.append({
@@ -245,10 +269,13 @@ class GeminiClient:
 
     @staticmethod
     def _is_retryable(exc: Exception) -> bool:
+        # Typed google-genai exceptions carry the HTTP status in .code.
+        if isinstance(exc, genai_errors.APIError):
+            return exc.code == 429 or (
+                isinstance(exc.code, int) and 500 <= exc.code < 600
+            )
         status = getattr(exc, "code", None) or getattr(exc, "status", None)
         if isinstance(status, int):
             return status == 429 or 500 <= status < 600
         exc_str = str(exc).lower()
-        if "429" in exc_str or "too many requests" in exc_str:
-            return True
-        return bool(re.search(r"5\d{2}", exc_str))
+        return "429" in exc_str or "too many requests" in exc_str

--- a/src/bicameral_agent/llm_output.py
+++ b/src/bicameral_agent/llm_output.py
@@ -1,0 +1,77 @@
+"""Safe parsing and sanitization of structured LLM output (issue #47).
+
+LLM responses routinely come back malformed: truncated at the
+``max_output_tokens`` cap (``finish_reason=MAX_TOKENS``), wrapped in prose
+preamble, or carrying out-of-range numerics. A single such response must not
+crash an episode -- callers degrade to a no-op result or neutral score instead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def safe_parse_json(response: Any, *, context: str, default: dict | None = None) -> dict | None:
+    """Parse a structured-output LLM response into a dict, degrading on failure.
+
+    Tries ``json.loads`` on ``response.content``, then falls back to extracting
+    the first balanced JSON object (handles prose preamble). On failure -- or if
+    the parsed value is not a dict -- logs a warning that includes the
+    response's ``finish_reason`` (which flags truncation at the output-token
+    cap) and returns *default* instead of raising.
+
+    Args:
+        response: A ``GeminiResponse``-shaped object with ``content`` and
+            ``finish_reason`` attributes.
+        context: Caller name for the warning log.
+        default: Value returned when no dict can be recovered.
+
+    Returns:
+        The parsed dict, or *default*.
+    """
+    text = getattr(response, "content", None) or ""
+    parsed: Any = None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        if start != -1:
+            try:
+                parsed, _ = json.JSONDecoder().raw_decode(text, start)
+            except json.JSONDecodeError:
+                pass
+
+    if isinstance(parsed, dict):
+        return parsed
+
+    logger.warning(
+        "%s: unparseable structured LLM output (finish_reason=%s, %d chars); "
+        "degrading to default",
+        context,
+        getattr(response, "finish_reason", "unknown"),
+        len(text),
+    )
+    return default
+
+
+def clamp(value: Any, low: float, high: float, default: float) -> float:
+    """Coerce *value* to a float clamped to [low, high]; *default* if non-numeric."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return default
+    if v != v:  # NaN
+        return default
+    return max(low, min(high, v))
+
+
+def coerce_int(value: Any, default: int) -> int:
+    """Coerce *value* to an int; *default* if non-numeric."""
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return default

--- a/src/bicameral_agent/ollama_cloud.py
+++ b/src/bicameral_agent/ollama_cloud.py
@@ -15,6 +15,7 @@ simulated user already parse with ``json.loads(response.content)``.
 
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import random
@@ -236,5 +237,17 @@ class OllamaCloudClient:
     def _is_retryable(exc: Exception) -> bool:
         if isinstance(exc, urllib.error.HTTPError):
             return exc.code == 429 or 500 <= exc.code < 600
-        # Network-level failures (timeouts, connection resets) are transient.
-        return isinstance(exc, urllib.error.URLError)
+        # Network-level failures are transient, whether they hit at connect
+        # time (URLError) or mid-read: timeouts and connection resets during
+        # response.read(), truncated chunked bodies (IncompleteRead), and a
+        # 200 whose truncated body fails JSON decoding.
+        return isinstance(
+            exc,
+            (
+                urllib.error.URLError,
+                TimeoutError,
+                ConnectionResetError,
+                http.client.HTTPException,
+                json.JSONDecodeError,
+            ),
+        )

--- a/src/bicameral_agent/scorer.py
+++ b/src/bicameral_agent/scorer.py
@@ -7,7 +7,6 @@ for evaluating agent answers against research QA tasks with scoring rubrics.
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -16,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.llm_output import coerce_int, safe_parse_json
 
 
 def _normalize_score(v: int) -> float:
@@ -197,7 +197,15 @@ class TaskScorer:
             max_output_tokens=100,
             response_schema=_JUDGE_RESPONSE_SCHEMA,
         )
-        return TaskScore.from_raw(**json.loads(response.content))
+        # Malformed/truncated judge output degrades to a neutral mid-scale
+        # score; missing or non-integer dimensions default to 3 (from_raw
+        # normalizes 3 -> 0.5). Extra keys are ignored rather than splatted.
+        parsed = safe_parse_json(response, context="TaskScorer", default={})
+        return TaskScore.from_raw(
+            quality=coerce_int(parsed.get("quality"), 3),
+            completeness=coerce_int(parsed.get("completeness"), 3),
+            accuracy=coerce_int(parsed.get("accuracy"), 3),
+        )
 
 
 def _tokenize(text: str) -> list[str]:

--- a/src/bicameral_agent/simulated_user.py
+++ b/src/bicameral_agent/simulated_user.py
@@ -8,13 +8,13 @@ objects with simulated timing metadata for episode construction.
 from __future__ import annotations
 
 import enum
-import json
 
 from pydantic import BaseModel, Field, model_validator
 
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.followup_classifier import FollowUpType
 from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.llm_output import clamp, coerce_int, safe_parse_json
 from bicameral_agent.schema import Message
 
 
@@ -263,24 +263,54 @@ class SimulatedUser:
             response_schema=_RESPONSE_SCHEMA,
         )
 
-        raw = json.loads(response.content)
+        raw = safe_parse_json(
+            response, context="SimulatedUser.respond", default=None
+        )
         return self._parse_response(raw)
 
     @staticmethod
-    def _parse_response(raw: dict) -> UserAction:
-        """Parse the LLM's structured response into a UserAction."""
-        action_type = ActionType(raw["action_type"])
+    def _parse_response(raw: dict | None) -> UserAction:
+        """Parse the LLM's structured response into a UserAction.
+
+        Malformed/truncated output degrades to a neutral follow-up rather than
+        crashing; the patience guardrail still bounds episode length.
+        """
+        if raw is None:
+            return _fallback_action()
+        try:
+            action_type = ActionType(raw["action_type"])
+        except (KeyError, ValueError):
+            return _fallback_action()
 
         # The LLM occasionally treats confidence as a 1-5 scale; clamp to [0, 1].
-        confidence = max(0.0, min(1.0, float(raw.get("confidence", 0.8))))
+        confidence = clamp(raw.get("confidence"), 0.0, 1.0, 0.8)
+        # response_delay_ms feeds Field(ge=0); clamp negatives/non-numerics.
+        response_delay_ms = max(0, coerce_int(raw.get("response_delay_ms"), 500))
         kwargs: dict = {
             "action_type": action_type,
-            "response_delay_ms": raw.get("response_delay_ms", 500),
+            "response_delay_ms": response_delay_ms,
             "confidence": confidence,
         }
 
         if action_type == ActionType.FOLLOW_UP:
-            kwargs["message"] = raw.get("message", "Can you elaborate?")
-            kwargs["followup_type"] = FollowUpType(raw.get("followup_type", "elaboration"))
+            kwargs["message"] = raw.get("message") or "Can you elaborate?"
+            try:
+                followup_type = FollowUpType(raw.get("followup_type", "elaboration"))
+            except ValueError:
+                followup_type = FollowUpType.ELABORATION
+            if followup_type not in _VALID_FOLLOWUP_TYPES:
+                followup_type = FollowUpType.ELABORATION
+            kwargs["followup_type"] = followup_type
 
         return UserAction(**kwargs)
+
+
+def _fallback_action() -> UserAction:
+    """Neutral action used when the LLM's structured output is unusable."""
+    return UserAction(
+        action_type=ActionType.FOLLOW_UP,
+        message="Can you elaborate?",
+        followup_type=FollowUpType.ELABORATION,
+        response_delay_ms=500,
+        confidence=0.5,
+    )

--- a/tests/test_assumption_auditor.py
+++ b/tests/test_assumption_auditor.py
@@ -476,3 +476,50 @@ class TestIntegration:
 
         rate = identified_count / len(assumption_tasks)
         assert rate >= 0.6, f"Assumption detection rate {rate:.0%} < 60%"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Malformed LLM output hardening (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedOutput:
+    def test_truncated_extraction_json_degrades_to_noop(self):
+        """Truncated call-1 output (MAX_TOKENS) yields a no-op result, not a crash."""
+        truncated = GeminiResponse(
+            content='{"assumptions": [{"description": "LK-99',
+            input_tokens=50,
+            output_tokens=100,
+            duration_ms=50.0,
+            finish_reason="MAX_TOKENS",
+        )
+        auditor = AssumptionAuditor()
+        client = _mock_client(truncated)
+        result = auditor.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is None
+        assert result.metadata.items_found == 0
+        assert client.generate.call_count == 1
+
+    def test_truncated_evidence_json_proceeds_without_evidence(self):
+        """Truncated call-2 output degrades to flagging without evidence."""
+        truncated = _fake_response('{"assessments": [{"assumption_desc')
+        auditor = AssumptionAuditor()
+        client = _mock_client([_assumption_response(), truncated])
+        result = auditor.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is not None
+        # No evidence assessed -> lower confidence branch
+        assert result.metadata.confidence == 0.5
+
+    def test_assumption_items_missing_keys_skipped(self):
+        assumptions = [
+            {"description": "valid", "risk_level": "moderate", "basis": "b"},
+            {"risk_level": "high"},  # no description
+            "not a dict",
+        ]
+        auditor = AssumptionAuditor()
+        client = _mock_client(_assumption_response(assumptions=assumptions))
+        result = auditor.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.metadata.items_found == 1

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -345,3 +345,55 @@ class TestRunCondition:
         assert set(result.episodes) == {"heuristic", "random"}
         assert all(len(eps) == 2 for eps in result.episodes.values())
         assert result.reports["heuristic"].n_episodes == 2
+
+
+class TestIncrementalPersistence:
+    """on_episode fires per completed episode so a late crash keeps prior results."""
+
+    def test_on_episode_called_per_episode(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = lambda task, ctrl: _make_episode()
+
+        seen: list[tuple[str, int, str]] = []
+        run_condition(
+            runner,
+            [_task(), _task()],
+            lambda _idx: _StubController(),
+            condition="heuristic",
+            on_episode=lambda cond, idx, ep: seen.append((cond, idx, ep.episode_id)),
+        )
+        assert [(c, i) for c, i, _ in seen] == [("heuristic", 0), ("heuristic", 1)]
+
+    def test_completed_episodes_persisted_before_crash(self):
+        """Episodes completed before a mid-run crash have already been reported."""
+        runner = MagicMock(spec=EpisodeRunner)
+        episode = _make_episode()
+        runner.run_episode.side_effect = [episode, RuntimeError("API meltdown")]
+
+        seen: list[Episode] = []
+        with pytest.raises(RuntimeError, match="API meltdown"):
+            run_condition(
+                runner,
+                [_task(), _task()],
+                lambda _idx: _StubController(),
+                condition="random",
+                on_episode=lambda cond, idx, ep: seen.append(ep),
+            )
+        assert seen == [episode]
+
+    def test_run_benchmark_forwards_callback_with_condition(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = lambda task, ctrl: _make_episode()
+
+        seen: list[str] = []
+        run_benchmark(
+            client=MagicMock(),
+            tasks=[_task()],
+            conditions={
+                "heuristic": lambda _idx: _StubController(),
+                "random": lambda _idx: _StubController(),
+            },
+            runner=runner,
+            on_episode=lambda cond, idx, ep: seen.append(cond),
+        )
+        assert seen == ["heuristic", "random"]

--- a/tests/test_coherence_judge.py
+++ b/tests/test_coherence_judge.py
@@ -160,3 +160,40 @@ class TestIntegration:
         assert 0.0 <= result.logical_flow <= 1.0
         assert 0.0 <= result.consistency <= 1.0
         assert 0.0 <= result.overall <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# TestMalformedJudgeOutput (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedJudgeOutput:
+    def _score_with_content(self, content, finish_reason="MAX_TOKENS"):
+        client = MagicMock(spec=GeminiClient)
+        client.generate.return_value = GeminiResponse(
+            content=content,
+            input_tokens=50,
+            output_tokens=20,
+            duration_ms=100.0,
+            finish_reason=finish_reason,
+        )
+        judge = CoherenceJudge(client=client)
+        return judge.score(_make_messages(("user", "q"), ("assistant", "a")))
+
+    def test_truncated_json_degrades_to_neutral_score(self):
+        score = self._score_with_content('{"logical_flow": 4, "consis')
+        assert score.overall == 0.5
+        assert score.logical_flow == 0.5
+        assert score.consistency == 0.5
+
+    def test_extra_keys_ignored(self):
+        score = self._score_with_content(json.dumps({
+            "logical_flow": 5, "consistency": 5, "overall": 5, "notes": "x",
+        }))
+        assert score.overall == 1.0
+
+    def test_missing_dimension_defaults_neutral(self):
+        score = self._score_with_content(json.dumps({"logical_flow": 5}))
+        assert score.logical_flow == 1.0
+        assert score.consistency == 0.5
+        assert score.overall == 0.5

--- a/tests/test_context_refresher.py
+++ b/tests/test_context_refresher.py
@@ -594,3 +594,26 @@ class TestIntegration:
             if result.queue_deposit is not None:
                 word_count = len(result.queue_deposit.content.split())
                 assert word_count <= 100, f"Reminder too long: {word_count} words"
+
+
+# ---------------------------------------------------------------------------
+# TestNullReminderDrift (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestNullReminderDrift:
+    def test_drift_with_null_reminder_deposits_nothing(self):
+        """Drift + null reminder must not enqueue an empty QueueItem."""
+        client = _mock_client(_drift_response(reminder=None))
+        refresher = ContextRefresher()
+        result = refresher.execute(_make_history(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is None
+        assert result.metadata.items_found >= 1
+
+    def test_drift_with_empty_reminder_deposits_nothing(self):
+        client = _mock_client(_drift_response(reminder="   "))
+        refresher = ContextRefresher()
+        result = refresher.execute(_make_history(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is None

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -20,6 +20,7 @@ from bicameral_agent.gemini import GeminiClient, GeminiResponse
 from bicameral_agent.heuristic_controller import Action, FullState, HeuristicController
 from bicameral_agent.schema import Episode, UserEventType
 from bicameral_agent.simulated_user import ActionType, UserAction
+from bicameral_agent.cost_tracker import CostBudgetExceeded
 from bicameral_agent.tool_primitive import BudgetExceededError
 
 
@@ -944,3 +945,67 @@ class TestIntegrationControllerSwap:
         ep_r = runner.run_episode(task, RandomController(seed=42))
         assert isinstance(ep_h, Episode)
         assert isinstance(ep_r, Episode)
+
+
+# ---------------------------------------------------------------------------
+# TestCostBudgetHandling (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestCostBudgetHandling:
+    def test_budget_trip_in_tool_ends_episode_gracefully(self):
+        """CostBudgetExceeded from a tool call ends the episode, not the run."""
+        client = _make_mock_client()
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.SCANNER
+
+        runner = EpisodeRunner(client, EpisodeConfig(max_turns=5))
+
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.return_value = UserAction(
+                action_type=ActionType.FOLLOW_UP,
+                message="More?",
+                followup_type=FollowUpType.ELABORATION,
+                response_delay_ms=100,
+                confidence=0.8,
+            )
+            MockSimUser.return_value = mock_sim
+
+            with patch(
+                "bicameral_agent.episode_runner.ResearchGapScanner"
+            ) as MockScanner:
+                mock_tool = MagicMock()
+                mock_tool.execute.side_effect = CostBudgetExceeded("episode budget")
+                MockScanner.return_value = mock_tool
+
+                episode = runner.run_episode(_make_task(), ctrl)
+
+        assert isinstance(episode, Episode)
+        # Episode ended on the first turn (no sim-user follow-ups consumed)
+        assert episode.outcome.total_turns == 1
+        assert len(episode.tool_invocations) == 1
+        assert episode.tool_invocations[0].budget_exceeded is True
+        # Sim user never reached: episode ended before the respond() call
+        mock_sim.respond.assert_not_called()
+
+    def test_budget_trip_in_sim_user_ends_episode_gracefully(self):
+        """CostBudgetExceeded from the sim-user call ends the episode, not the run."""
+        client = _make_mock_client()
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+
+        runner = EpisodeRunner(client, EpisodeConfig(max_turns=5))
+
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.side_effect = CostBudgetExceeded("episode budget")
+            MockSimUser.return_value = mock_sim
+
+            episode = runner.run_episode(_make_task(), ctrl)
+
+        assert isinstance(episode, Episode)
+        assert episode.outcome.total_turns == 1
+        assert mock_sim.respond.call_count == 1

--- a/tests/test_gap_scanner.py
+++ b/tests/test_gap_scanner.py
@@ -444,3 +444,92 @@ class TestIntegration:
 
         assert elapsed < 5.0, f"Execution took {elapsed:.1f}s, expected <5s"
         assert result.metadata.tokens_consumed > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Malformed LLM output hardening (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedOutput:
+    def test_truncated_gap_json_degrades_to_noop(self):
+        """Truncated call-1 output (MAX_TOKENS) yields a no-op result, not a crash."""
+        truncated = GeminiResponse(
+            content='{"has_gaps": true, "gaps": [{"description": "LK-99',
+            input_tokens=50,
+            output_tokens=100,
+            duration_ms=50.0,
+            finish_reason="MAX_TOKENS",
+        )
+        scanner = ResearchGapScanner()
+        client = _mock_client(truncated)
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is None
+        assert result.metadata.items_found == 0
+        assert client.generate.call_count == 1
+
+    def test_truncated_ranking_json_degrades(self):
+        """Truncated call-2 output falls back to gaps-only deposit."""
+        truncated = _fake_response('{"overall_confidence": 0.9, "ranked_results": [{"ti')
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(), truncated])
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.queue_deposit is not None
+        assert "Research gaps identified" in result.queue_deposit.content
+
+    def test_gap_items_missing_keys_skipped(self):
+        gaps = [
+            {"description": "valid gap", "category": "core_claim", "search_query": "q"},
+            {"category": "core_claim"},  # no description
+            "not a dict",
+        ]
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(gaps=gaps), _ranking_response()])
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.metadata.items_found >= 1
+
+    def test_out_of_range_confidence_clamped(self):
+        """A 1-5-scale overall_confidence must not crash ToolMetadata validation."""
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(), _ranking_response(overall_confidence=4.0)])
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert result.metadata.confidence == 1.0
+
+    def test_out_of_range_relevance_clamped(self):
+        """A 1-5-scale relevance_score is clamped before ToolMetadata validation."""
+        ranked = [
+            {
+                "gap_description": "gap",
+                "title": "t",
+                "snippet": "s",
+                "relevance_score": 3.0,
+                "source": "src",
+            },
+        ]
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(), _ranking_response(ranked_results=ranked)])
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        assert 0.0 <= result.metadata.estimated_relevance <= 1.0
+
+    def test_non_numeric_relevance_treated_as_irrelevant(self):
+        ranked = [
+            {
+                "gap_description": "gap",
+                "title": "t",
+                "snippet": "s",
+                "relevance_score": "very relevant",
+                "source": "src",
+            },
+        ]
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(), _ranking_response(ranked_results=ranked)])
+        result = scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        # Non-numeric score coerces to 0.0 -> filtered out -> gaps-only deposit
+        assert result.queue_deposit is not None
+        assert "Research gaps identified" in result.queue_deposit.content

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -5,8 +5,10 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.genai import errors as genai_errors
 
 from bicameral_agent.gemini import (
+    BlockedResponseError,
     ChatMessage,
     GeminiClient,
     GeminiResponse,
@@ -191,7 +193,9 @@ class TestRetryLogic:
 
     def test_retry_on_5xx(self, mock_client):
         client, sdk = mock_client
-        exc_500 = Exception("500 Internal Server Error")
+        exc_500 = genai_errors.ServerError(
+            500, {"error": {"message": "Internal Server Error"}}
+        )
         sdk.models.generate_content.side_effect = [
             exc_500, _make_mock_response()
         ]
@@ -199,6 +203,38 @@ class TestRetryLogic:
             result = client.generate([{"role": "user", "content": "hi"}])
         assert result.content == "Hello!"
         assert sdk.models.generate_content.call_count == 2
+
+    def test_retry_on_typed_429(self, mock_client):
+        client, sdk = mock_client
+        exc_429 = genai_errors.ClientError(
+            429, {"error": {"message": "Resource exhausted"}}
+        )
+        sdk.models.generate_content.side_effect = [
+            exc_429, _make_mock_response()
+        ]
+        with patch("bicameral_agent.gemini.time.sleep"):
+            result = client.generate([{"role": "user", "content": "hi"}])
+        assert result.content == "Hello!"
+        assert sdk.models.generate_content.call_count == 2
+
+    def test_no_retry_on_typed_4xx(self, mock_client):
+        client, sdk = mock_client
+        exc_400 = genai_errors.ClientError(
+            400, {"error": {"message": "Bad Request"}}
+        )
+        sdk.models.generate_content.side_effect = exc_400
+        with pytest.raises(genai_errors.ClientError):
+            client.generate([{"role": "user", "content": "hi"}])
+        assert sdk.models.generate_content.call_count == 1
+
+    def test_no_retry_on_5xx_lookalike_message(self, mock_client):
+        """A 3-digit number in the message must not trigger retries (was `5\\d{2}` regex)."""
+        client, sdk = mock_client
+        exc = Exception("your quota is 500 requests per day")
+        sdk.models.generate_content.side_effect = exc
+        with pytest.raises(Exception, match="quota"):
+            client.generate([{"role": "user", "content": "hi"}])
+        assert sdk.models.generate_content.call_count == 1
 
     def test_no_retry_on_400(self, mock_client):
         client, sdk = mock_client
@@ -627,3 +663,90 @@ class TestIntegration:
         assert recorded[0][0] == result.input_tokens
         assert recorded[0][1] == result.output_tokens
         assert recorded[0][2] == result.duration_ms
+
+
+# ---------------------------------------------------------------------------
+# TestBlockedResponses (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedResponses:
+    def test_empty_candidates_raises_typed_error_with_block_reason(self):
+        response = MagicMock()
+        response.candidates = []
+        response.usage_metadata.prompt_token_count = 10
+        response.usage_metadata.candidates_token_count = 0
+        response.prompt_feedback.block_reason = "SAFETY"
+
+        with patch("bicameral_agent.gemini.genai.Client") as MockClient:
+            instance = MockClient.return_value
+            instance.models.generate_content.return_value = response
+            client = GeminiClient(api_key="key")
+            with pytest.raises(BlockedResponseError, match="SAFETY") as exc_info:
+                client.generate([{"role": "user", "content": "hi"}])
+        assert exc_info.value.reason == "SAFETY"
+
+    def test_none_candidates_raises_typed_error(self):
+        response = MagicMock()
+        response.candidates = None
+        response.usage_metadata.prompt_token_count = 10
+        response.usage_metadata.candidates_token_count = 0
+        response.prompt_feedback = None
+
+        with patch("bicameral_agent.gemini.genai.Client") as MockClient:
+            instance = MockClient.return_value
+            instance.models.generate_content.return_value = response
+            client = GeminiClient(api_key="key")
+            with pytest.raises(BlockedResponseError, match="no candidates"):
+                client.generate([{"role": "user", "content": "hi"}])
+
+    def test_none_parts_raises_typed_error_with_finish_reason(self):
+        """MAX_TOKENS hit during thinking yields content.parts=None."""
+        candidate = MagicMock()
+        candidate.finish_reason = "MAX_TOKENS"
+        candidate.content.parts = None
+
+        response = MagicMock()
+        response.candidates = [candidate]
+        response.usage_metadata.prompt_token_count = 10
+        response.usage_metadata.candidates_token_count = 0
+
+        with patch("bicameral_agent.gemini.genai.Client") as MockClient:
+            instance = MockClient.return_value
+            instance.models.generate_content.return_value = response
+            client = GeminiClient(api_key="key")
+            with pytest.raises(BlockedResponseError, match="MAX_TOKENS"):
+                client.generate([{"role": "user", "content": "hi"}])
+
+    def test_none_content_raises_typed_error(self):
+        candidate = MagicMock()
+        candidate.finish_reason = "SAFETY"
+        candidate.content = None
+
+        response = MagicMock()
+        response.candidates = [candidate]
+        response.usage_metadata.prompt_token_count = 10
+        response.usage_metadata.candidates_token_count = 0
+
+        with patch("bicameral_agent.gemini.genai.Client") as MockClient:
+            instance = MockClient.return_value
+            instance.models.generate_content.return_value = response
+            client = GeminiClient(api_key="key")
+            with pytest.raises(BlockedResponseError, match="SAFETY"):
+                client.generate([{"role": "user", "content": "hi"}])
+
+    def test_blocked_response_not_retried(self):
+        response = MagicMock()
+        response.candidates = []
+        response.usage_metadata.prompt_token_count = 10
+        response.usage_metadata.candidates_token_count = 0
+        response.prompt_feedback.block_reason = "SAFETY"
+
+        with patch("bicameral_agent.gemini.genai.Client") as MockClient:
+            instance = MockClient.return_value
+            instance.models.generate_content.return_value = response
+            client = GeminiClient(api_key="key")
+            with patch("bicameral_agent.gemini.time.sleep"):
+                with pytest.raises(BlockedResponseError):
+                    client.generate([{"role": "user", "content": "hi"}])
+        assert instance.models.generate_content.call_count == 1

--- a/tests/test_llm_output.py
+++ b/tests/test_llm_output.py
@@ -1,0 +1,81 @@
+"""Tests for safe parsing of structured LLM output (issue #47)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bicameral_agent.gemini import GeminiResponse
+from bicameral_agent.llm_output import clamp, coerce_int, safe_parse_json
+
+
+def _response(content: str, finish_reason: str = "STOP") -> GeminiResponse:
+    return GeminiResponse(
+        content=content,
+        input_tokens=10,
+        output_tokens=10,
+        duration_ms=1.0,
+        finish_reason=finish_reason,
+    )
+
+
+class TestSafeParseJson:
+    def test_valid_json(self):
+        parsed = safe_parse_json(_response('{"a": 1}'), context="t")
+        assert parsed == {"a": 1}
+
+    def test_json_with_preamble(self):
+        parsed = safe_parse_json(
+            _response('Here is the JSON:\n{"a": 1} trailing'), context="t"
+        )
+        assert parsed == {"a": 1}
+
+    def test_truncated_json_returns_default(self):
+        truncated = json.dumps({"has_gaps": True, "gaps": [{"description": "x"}]})[:-8]
+        parsed = safe_parse_json(
+            _response(truncated, finish_reason="MAX_TOKENS"),
+            context="t",
+            default={"has_gaps": False},
+        )
+        assert parsed == {"has_gaps": False}
+
+    def test_empty_content_returns_default(self):
+        assert safe_parse_json(_response(""), context="t", default=None) is None
+
+    def test_non_dict_json_returns_default(self):
+        parsed = safe_parse_json(_response("[1, 2]"), context="t", default={})
+        assert parsed == {}
+
+    def test_logs_finish_reason(self, caplog):
+        with caplog.at_level("WARNING"):
+            safe_parse_json(
+                _response('{"broken', finish_reason="MAX_TOKENS"), context="my_tool"
+            )
+        assert "MAX_TOKENS" in caplog.text
+        assert "my_tool" in caplog.text
+
+
+class TestClamp:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(0.5, 0.5), (-1, 0.0), (4, 1.0), ("0.7", 0.7), (0, 0.0), (1, 1.0)],
+    )
+    def test_numeric_values(self, value, expected):
+        assert clamp(value, 0.0, 1.0, 0.5) == expected
+
+    @pytest.mark.parametrize("value", [None, "high", {}, float("nan")])
+    def test_non_numeric_returns_default(self, value):
+        assert clamp(value, 0.0, 1.0, 0.5) == 0.5
+
+
+class TestCoerceInt:
+    @pytest.mark.parametrize(
+        ("value", "expected"), [(4, 4), (4.7, 4), ("4", 4), ("4.2", 4), (-2, -2)]
+    )
+    def test_numeric_values(self, value, expected):
+        assert coerce_int(value, 3) == expected
+
+    @pytest.mark.parametrize("value", [None, "good", [], float("nan")])
+    def test_non_numeric_returns_default(self, value):
+        assert coerce_int(value, 3) == 3

--- a/tests/test_ollama_cloud.py
+++ b/tests/test_ollama_cloud.py
@@ -6,6 +6,7 @@ so no live calls and no API key are required.
 
 from __future__ import annotations
 
+import http.client
 import io
 import json
 import urllib.error
@@ -321,4 +322,91 @@ class TestRetry:
                 patch("bicameral_agent.ollama_cloud.time.sleep") as sleep:
             with pytest.raises(urllib.error.HTTPError):
                 OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        assert sleep.call_count == _MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Read-phase failure retry (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestReadPhaseRetry:
+    class _FailingReadResponse:
+        """Context-manager response whose read() raises *exc*."""
+
+        def __init__(self, exc: Exception) -> None:
+            self._exc = exc
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            raise self._exc
+
+    def _generate_with_first_call_failing(self, exc: Exception):
+        calls = {"n": 0}
+
+        def _fake(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return self._FailingReadResponse(exc)
+            return _FakeHTTPResponse(_make_response_body(content="ok"))
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep"):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}]
+            )
+        return result, calls["n"]
+
+    def test_timeout_during_read_retried(self):
+        result, n = self._generate_with_first_call_failing(TimeoutError("read timed out"))
+        assert result.content == "ok"
+        assert n == 2
+
+    def test_connection_reset_during_read_retried(self):
+        result, n = self._generate_with_first_call_failing(
+            ConnectionResetError(54, "Connection reset by peer")
+        )
+        assert result.content == "ok"
+        assert n == 2
+
+    def test_incomplete_read_retried(self):
+        result, n = self._generate_with_first_call_failing(
+            http.client.IncompleteRead(b"partial")
+        )
+        assert result.content == "ok"
+        assert n == 2
+
+    def test_truncated_200_body_retried(self):
+        """A 200 whose body is truncated mid-JSON is retried, not raised."""
+        calls = {"n": 0}
+
+        def _fake(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _FakeHTTPResponse(_make_response_body()[:20])
+            return _FakeHTTPResponse(_make_response_body(content="ok"))
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep"):
+            result = OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}]
+            )
+        assert result.content == "ok"
+        assert calls["n"] == 2
+
+    def test_persistent_read_failure_raises_after_max_retries(self):
+        def _fake(request, timeout=None):
+            return self._FailingReadResponse(TimeoutError("read timed out"))
+
+        with patch("urllib.request.urlopen", _fake), \
+                patch("bicameral_agent.ollama_cloud.time.sleep") as sleep:
+            with pytest.raises(TimeoutError):
+                OllamaCloudClient(api_key="k").generate(
+                    [{"role": "user", "content": "x"}]
+                )
         assert sleep.call_count == _MAX_RETRIES

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -567,3 +567,54 @@ class TestCorrelation:
 
         r = np.corrcoef(lex_scores, human_scores)[0, 1]
         assert r > 0.4, f"Lexical scorer correlation {r:.3f} below threshold 0.4"
+
+
+# ---------------------------------------------------------------------------
+# TestMalformedJudgeOutput (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedJudgeOutput:
+    @staticmethod
+    def _raw_response(content, finish_reason="MAX_TOKENS"):
+        response = MagicMock()
+        response.content = content
+        response.finish_reason = finish_reason
+        return response
+
+    def test_truncated_json_degrades_to_neutral_score(self):
+        scorer, _ = _make_scorer_with_mock(
+            response=self._raw_response('{"quality": 4, "complet')
+        )
+        score = scorer.score(_make_task(), "answer")
+        assert score.overall == 0.5
+
+    def test_extra_keys_ignored(self):
+        """An extra key from the LLM must not TypeError from_raw(**parsed)."""
+        response = MagicMock()
+        response.content = json.dumps({
+            "quality": 5, "completeness": 5, "accuracy": 5, "justification": "good",
+        })
+        scorer, _ = _make_scorer_with_mock(response=response)
+        score = scorer.score(_make_task(), "answer")
+        assert score.overall == 1.0
+
+    def test_missing_dimension_defaults_neutral(self):
+        response = MagicMock()
+        response.content = json.dumps({"quality": 5})
+        scorer, _ = _make_scorer_with_mock(response=response)
+        score = scorer.score(_make_task(), "answer")
+        assert score.quality == 1.0
+        assert score.completeness == 0.5
+        assert score.accuracy == 0.5
+
+    def test_non_integer_scores_coerced(self):
+        response = MagicMock()
+        response.content = json.dumps({
+            "quality": "5", "completeness": 4.6, "accuracy": "bad",
+        })
+        scorer, _ = _make_scorer_with_mock(response=response)
+        score = scorer.score(_make_task(), "answer")
+        assert score.quality == 1.0
+        assert score.completeness == 0.75
+        assert score.accuracy == 0.5

--- a/tests/test_simulated_user.py
+++ b/tests/test_simulated_user.py
@@ -635,3 +635,60 @@ def _count_corrections(task: ResearchQATask, strictness: Strictness, n_responses
                 and action.followup_type == FollowUpType.CORRECTION):
             count += 1
     return count
+
+
+# ---------------------------------------------------------------------------
+# TestMalformedOutput (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedOutput:
+    def _respond(self, response):
+        user, _ = _make_simulated_user(response=response)
+        return user.respond(_make_task(), "Some answer.", [], turn_number=1)
+
+    @staticmethod
+    def _raw_response(content, finish_reason="MAX_TOKENS"):
+        response = MagicMock()
+        response.content = content
+        response.finish_reason = finish_reason
+        return response
+
+    def test_truncated_json_degrades_to_neutral_followup(self):
+        action = self._respond(self._raw_response('{"action_type": "follo'))
+        assert action.action_type == ActionType.FOLLOW_UP
+        assert action.followup_type == FollowUpType.ELABORATION
+        assert action.message
+
+    def test_empty_content_degrades_to_neutral_followup(self):
+        action = self._respond(self._raw_response(""))
+        assert action.action_type == ActionType.FOLLOW_UP
+
+    def test_invalid_action_type_degrades(self):
+        action = self._respond(self._raw_response(json.dumps({
+            "action_type": "give_up", "response_delay_ms": 100, "confidence": 0.5,
+        })))
+        assert action.action_type == ActionType.FOLLOW_UP
+
+    def test_negative_response_delay_clamped(self):
+        action = self._respond(
+            _mock_gemini_response(action_type="task_complete", response_delay_ms=-200)
+        )
+        assert action.response_delay_ms == 0
+
+    def test_non_numeric_response_delay_defaults(self):
+        action = self._respond(
+            _mock_gemini_response(action_type="task_complete", response_delay_ms="fast")
+        )
+        assert action.response_delay_ms == 500
+
+    def test_invalid_followup_type_degrades_to_elaboration(self):
+        action = self._respond(self._raw_response(json.dumps({
+            "action_type": "follow_up",
+            "message": "And?",
+            "followup_type": "new_task",
+            "response_delay_ms": 100,
+            "confidence": 0.5,
+        })))
+        assert action.action_type == ActionType.FOLLOW_UP
+        assert action.followup_type == FollowUpType.ELABORATION


### PR DESCRIPTION
## Summary

A single truncated/malformed LLM response or a mid-episode cost-budget trip crashed entire paid benchmark runs, and because parquet/report files were written only at the end of `main()`, all completed episodes were lost. This PR makes every structured-output parse site degrade instead of crash, contains budget trips to the episode that hit them, retries transient read-phase transport failures, and persists episodes incrementally so a late crash keeps prior results.

## Work performed

- **finish_reason-aware safe parsing**: new `llm_output.py` with `safe_parse_json` (falls back to balanced-brace extraction, logs `finish_reason` on failure — flagging truncation at the `max_output_tokens` cap) plus `clamp`/`coerce_int`. Used at every bare `json.loads` site: `gap_scanner` (both calls), `assumption_auditor` (both calls), `simulated_user` (degrades to a neutral follow-up; patience guardrail still bounds episodes), `scorer` and `coherence_judge` (degrade to a neutral mid-scale score; extra keys no longer splat into `from_raw`).
- **Numeric clamping before Pydantic**: `gap_scanner` `overall_confidence` and per-result `relevance_score` clamped to [0, 1] (a 1-5-scale emission no longer kills the episode); `simulated_user` `response_delay_ms` clamped to >= 0, mirroring the existing confidence clamp.
- **Typed Gemini block errors**: `gemini._parse_response` now raises `BlockedResponseError` naming the block reason for empty `candidates` (safety block) and `content`/`parts=None` (MAX_TOKENS during thinking, SAFETY) instead of opaque `IndexError`/`TypeError`.
- **Budget containment in `episode_runner`**: `CostBudgetExceeded` is caught around the tool-execution block (including synchronous/interrupt regeneration) and the sim-user call, ending the episode gracefully exactly like the existing `run_turn` path; the tool invocation is flagged `budget_exceeded`.
- **Transport retries**: `OllamaCloudClient._is_retryable` now retries read-phase timeouts, `ConnectionResetError`, `IncompleteRead`, and JSON-decode failures on truncated 200 bodies; Gemini's `5\d{2}` regex fallback (false-positived on e.g. "quota is 500 requests") replaced with typed `google.genai.errors.APIError` status checks.
- **Incremental persistence**: `run_condition`/`run_benchmark` accept an `on_episode` callback; `scripts/run_baseline_benchmark.py` rewrites each condition's parquet after every completed episode.
- **context_refresher**: drift with a null/empty reminder no longer deposits a blank `QueueItem`.
- **Tests**: malformed/truncated output for each parse site, out-of-range numeric clamping, blocked Gemini responses, typed retry classification, read-phase Ollama retries, budget trips from both tool and sim-user paths, null-reminder drift, and per-episode persistence (including callback-fires-before-crash).

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 1046 passed, 34 skipped (integration tests requiring API keys).
- `uv run --extra dev --extra torch ruff check src/ tests/` — clean.
- End-to-end offline verification: drove `run_benchmark` through the real `EpisodeRunner` with a hostile client returning truncated `MAX_TOKENS` JSON for every structured call and a cost tracker that trips mid-run — all 3 episodes completed gracefully (tool budget flag set, sim-user degraded, scorer returned neutral), and the incrementally written parquet round-tripped all episodes.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy