### PR TITLE
Partial: Recalibrate tool latency model to measured baseline durations

### DIFF
--- a/src/bicameral_agent/baseline_benchmark.py
+++ b/src/bicameral_agent/baseline_benchmark.py
@@ -59,6 +59,9 @@ def _latency_pairs(
     decision corresponds to the nth ToolInvocation in the episode.
     Budget-exceeded invocations are excluded explicitly (their partial
     durations are not meaningful), as are any zero-duration invocations.
+    Pairs whose invocation tool_id does not match the decision's action are
+    dropped defensively: a mismatch means the positional alignment is wrong
+    and the predicted/actual values belong to different tools.
     """
     tool_decisions = [d for d in decisions if d.action != Action.DO_NOTHING]
     pairs: list[tuple[float, float]] = []
@@ -69,6 +72,8 @@ def _latency_pairs(
         if actual <= 0:
             continue
         tool_id = TOOL_IDS[decision.action]
+        if inv.tool_id != tool_id:
+            continue
         predicted = decision.state.predicted_latencies.get(tool_id)
         if predicted is None or predicted <= 0:
             continue

--- a/src/bicameral_agent/latency.py
+++ b/src/bicameral_agent/latency.py
@@ -2,8 +2,9 @@
 
 Models total API call latency as a linear function of input and output
 token counts, using incremental OLS with Welford's variance tracking
-for percentile estimation. Uses conservative priors during cold start
-(< 20 observations) and smoothly transitions to learned parameters.
+for percentile estimation. Uses priors calibrated against measured
+baseline durations during cold start (< 20 observations) and smoothly
+transitions to learned parameters.
 """
 
 from __future__ import annotations
@@ -17,11 +18,17 @@ import numpy as np
 # Cold-start threshold: below this, blend priors with learned parameters
 _COLD_START_THRESHOLD = 20
 
-# Conservative priors (deliberately ~2x overestimate)
-_PRIOR_ALPHA = 1000.0  # TTFT intercept (ms)
+# Priors calibrated against the measured tool durations from the #23
+# baseline run (data/baseline/*.parquet): single API calls complete in
+# roughly 0.9-1.5s with recorded output token counts of ~1000-1500.
+# The old priors (alpha=1000, 25 tok/s) over-predicted 9-23x (#44).
+# Note: recorded output token counts are approximate (len/4 estimates),
+# so _PRIOR_OUTPUT_RATE is an *effective* rate on that scale, not a true
+# model decode speed.
+_PRIOR_ALPHA = 700.0  # TTFT intercept (ms)
 _PRIOR_BETA = 0.02  # ms per input token
-_PRIOR_OUTPUT_RATE = 25.0  # tokens per second (conservative; reasonable ~50)
-_PRIOR_OVERHEAD = 200.0  # fixed overhead (ms)
+_PRIOR_OUTPUT_RATE = 2500.0  # effective output tokens per second
+_PRIOR_OVERHEAD = 175.0  # fixed overhead (ms)
 _PRIOR_VARIANCE_FRAC = 0.5  # residual std as fraction of predicted mean
 
 # Normal distribution z-score for 25th percentile
@@ -52,7 +59,7 @@ class APILatencyModel:
     and Welford's algorithm for residual variance tracking.
 
     With fewer than 20 observations, predictions are blended with
-    conservative priors that overestimate by ~2x.
+    priors calibrated against the #23 baseline measurements (#44).
     """
 
     def __init__(self) -> None:

--- a/src/bicameral_agent/token_estimator.py
+++ b/src/bicameral_agent/token_estimator.py
@@ -37,26 +37,37 @@ class _ToolProfile:
 
     system_prompt_tokens: int
     default_output_per_call: int
-    fixed_calls: int | None  # None = variable (computed from context)
+    num_calls: int
 
 
+# Call counts mirror the actual tool implementations: the scanner makes
+# exactly two LLM calls (gap identification + result ranking; its searches
+# run against a local provider), the auditor makes two (assumption
+# extraction + evidence assessment), and the refresher makes one.
+# Default output-per-call values are anchored to the median recorded
+# output token counts from the #23 baseline run (#44).
 _TOOL_PROFILES: dict[str, _ToolProfile] = {
     TOOL_IDS[Action.SCANNER]: _ToolProfile(
         system_prompt_tokens=500,
-        default_output_per_call=400,
-        fixed_calls=None,
+        default_output_per_call=670,
+        num_calls=2,
     ),
     TOOL_IDS[Action.AUDITOR]: _ToolProfile(
         system_prompt_tokens=400,
-        default_output_per_call=450,
-        fixed_calls=1,
+        default_output_per_call=750,
+        num_calls=2,
     ),
     TOOL_IDS[Action.REFRESHER]: _ToolProfile(
         system_prompt_tokens=300,
-        default_output_per_call=100,
-        fixed_calls=1,
+        default_output_per_call=1100,
+        num_calls=1,
     ),
 }
+
+# Estimated input size of the scanner's second call (identified gaps plus
+# local search results) and the auditor's second call (evidence block).
+SCANNER_RANKING_INPUT_TOKENS = 1500
+AUDITOR_ASSESSMENT_INPUT_TOKENS = 1200
 
 # EMA smoothing factor
 _EMA_ALPHA = 0.3
@@ -98,8 +109,8 @@ class TokenEstimator:
         conv = context_features.conversation_length_tokens
         turns = context_features.conversation_turn_count
 
-        num_calls = self._compute_num_calls(profile, conv)
-        input_tokens = self._compute_input_tokens(tool_id, conv, turns, num_calls)
+        num_calls = profile.num_calls
+        input_tokens = self._compute_input_tokens(tool_id, conv, turns)
 
         with self._lock:
             obs = self._observations.get(tool_id)
@@ -133,9 +144,7 @@ class TokenEstimator:
         if profile is None:
             raise ValueError(f"Unknown tool: {tool_id!r}")
 
-        conv = context_features.conversation_length_tokens
-        num_calls = self._compute_num_calls(profile, conv)
-        per_call = actual_output_tokens / max(num_calls, 1)
+        per_call = actual_output_tokens / max(profile.num_calls, 1)
 
         with self._lock:
             obs = self._observations.get(tool_id)
@@ -148,21 +157,11 @@ class TokenEstimator:
                 self._observations[tool_id] = (new_mean, count + 1)
 
     @staticmethod
-    def _compute_num_calls(profile: _ToolProfile, conv: int) -> int:
-        if profile.fixed_calls is not None:
-            return profile.fixed_calls
-        gaps = min(max(1, conv // 2000), 5)
-        return 2 + gaps
-
-    @staticmethod
-    def _compute_input_tokens(
-        tool_id: str, conv: int, turns: int, num_calls: int
-    ) -> int:
+    def _compute_input_tokens(tool_id: str, conv: int, turns: int) -> int:
         if tool_id == TOOL_IDS[Action.SCANNER]:
-            gaps = num_calls - 2
-            return (500 + conv) + (gaps * 2000) + (500 + conv + gaps * 2000)
+            return (500 + conv) + SCANNER_RANKING_INPUT_TOKENS
         if tool_id == TOOL_IDS[Action.AUDITOR]:
-            return 400 + conv
+            return (400 + conv) + AUDITOR_ASSESSMENT_INPUT_TOKENS
         if tool_id == TOOL_IDS[Action.REFRESHER]:
             avg_msg = conv / max(turns, 1)
             bounded = min(4 * avg_msg, conv)

--- a/src/bicameral_agent/token_estimator.py
+++ b/src/bicameral_agent/token_estimator.py
@@ -73,6 +73,33 @@ AUDITOR_ASSESSMENT_INPUT_TOKENS = 1200
 _EMA_ALPHA = 0.3
 
 
+def sub_call_inputs(
+    tool_id: str, context_features: ContextFeatures
+) -> list[tuple[str, int]]:
+    """Per-sub-call ``(label, input_tokens)`` breakdown for a tool invocation.
+
+    Single source of truth for the sub-call input structure: TokenEstimator
+    sums it for the aggregate input estimate, and ToolLatencyModel iterates
+    it for per-sub-call latency predictions, so the two cannot drift apart.
+    """
+    conv = context_features.conversation_length_tokens
+    if tool_id == TOOL_IDS[Action.SCANNER]:
+        return [
+            ("gap_identification", 500 + conv),
+            ("result_ranking", SCANNER_RANKING_INPUT_TOKENS),
+        ]
+    if tool_id == TOOL_IDS[Action.AUDITOR]:
+        return [
+            ("assumption_extraction", 400 + conv),
+            ("evidence_assessment", AUDITOR_ASSESSMENT_INPUT_TOKENS),
+        ]
+    if tool_id == TOOL_IDS[Action.REFRESHER]:
+        avg_msg = conv / max(context_features.conversation_turn_count, 1)
+        bounded = min(4 * avg_msg, conv)
+        return [(tool_id, 300 + int(bounded))]
+    return [(tool_id, conv)]
+
+
 class TokenEstimator:
     """Per-tool token estimator with online learning.
 
@@ -106,11 +133,10 @@ class TokenEstimator:
         if profile is None:
             raise ValueError(f"Unknown tool: {tool_id!r}")
 
-        conv = context_features.conversation_length_tokens
-        turns = context_features.conversation_turn_count
-
         num_calls = profile.num_calls
-        input_tokens = self._compute_input_tokens(tool_id, conv, turns)
+        input_tokens = sum(
+            inp for _, inp in sub_call_inputs(tool_id, context_features)
+        )
 
         with self._lock:
             obs = self._observations.get(tool_id)
@@ -155,15 +181,3 @@ class TokenEstimator:
                 old_mean, count = obs
                 new_mean = (1 - _EMA_ALPHA) * old_mean + _EMA_ALPHA * per_call
                 self._observations[tool_id] = (new_mean, count + 1)
-
-    @staticmethod
-    def _compute_input_tokens(tool_id: str, conv: int, turns: int) -> int:
-        if tool_id == TOOL_IDS[Action.SCANNER]:
-            return (500 + conv) + SCANNER_RANKING_INPUT_TOKENS
-        if tool_id == TOOL_IDS[Action.AUDITOR]:
-            return (400 + conv) + AUDITOR_ASSESSMENT_INPUT_TOKENS
-        if tool_id == TOOL_IDS[Action.REFRESHER]:
-            avg_msg = conv / max(turns, 1)
-            bounded = min(4 * avg_msg, conv)
-            return 300 + int(bounded)
-        return conv

--- a/src/bicameral_agent/tool_latency.py
+++ b/src/bicameral_agent/tool_latency.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from bicameral_agent.heuristic_controller import TOOL_IDS, Action
 from bicameral_agent.latency import APILatencyModel, LatencyEstimate
 from bicameral_agent.token_estimator import (
-    AUDITOR_ASSESSMENT_INPUT_TOKENS,
-    SCANNER_RANKING_INPUT_TOKENS,
     ContextFeatures,
     TokenEstimate,
     TokenEstimator,
+    sub_call_inputs,
 )
 
 # Normal distribution z-score for 25th percentile
@@ -178,46 +176,24 @@ class ToolLatencyModel:
     ) -> tuple[SubCallPrediction, ...]:
         """Break a tool invocation into per-sub-call predictions.
 
-        Sub-call structure mirrors the actual tool implementations: the
-        scanner makes two LLM calls (gap identification + result ranking;
-        searches run against a local provider), the auditor makes two
-        (assumption extraction + evidence assessment), and the refresher
-        makes a single call.
+        The per-sub-call input breakdown comes from
+        :func:`bicameral_agent.token_estimator.sub_call_inputs`, the single
+        source of truth also summed by the TokenEstimator, so sub-call
+        inputs always add up to the aggregate estimate. Sub-call structure
+        mirrors the actual tool implementations: the scanner makes two LLM
+        calls (gap identification + result ranking; searches run against a
+        local provider), the auditor makes two (assumption extraction +
+        evidence assessment), and the refresher makes a single call.
         """
         output_per_call = token_est.output_tokens // max(token_est.num_calls, 1)
-        conv = context_features.conversation_length_tokens
-
-        calls: list[tuple[str, int]] | None = None
-        if tool_id == TOOL_IDS[Action.SCANNER]:
-            calls = [
-                ("gap_identification", 500 + conv),
-                ("result_ranking", SCANNER_RANKING_INPUT_TOKENS),
-            ]
-        elif tool_id == TOOL_IDS[Action.AUDITOR]:
-            calls = [
-                ("assumption_extraction", 400 + conv),
-                ("evidence_assessment", AUDITOR_ASSESSMENT_INPUT_TOKENS),
-            ]
-        if calls is not None:
-            return tuple(
-                SubCallPrediction(
-                    label=label,
-                    input_tokens=inp,
-                    output_tokens=output_per_call,
-                    latency=self._latency_model.predict(inp, output_per_call),
-                )
-                for label, inp in calls
-            )
-
-        return (
+        return tuple(
             SubCallPrediction(
-                label=tool_id,
-                input_tokens=token_est.input_tokens,
-                output_tokens=token_est.output_tokens,
-                latency=self._latency_model.predict(
-                    token_est.input_tokens, token_est.output_tokens
-                ),
-            ),
+                label=label,
+                input_tokens=inp,
+                output_tokens=output_per_call,
+                latency=self._latency_model.predict(inp, output_per_call),
+            )
+            for label, inp in sub_call_inputs(tool_id, context_features)
         )
 
     @staticmethod

--- a/src/bicameral_agent/tool_latency.py
+++ b/src/bicameral_agent/tool_latency.py
@@ -12,7 +12,13 @@ from dataclasses import dataclass
 
 from bicameral_agent.heuristic_controller import TOOL_IDS, Action
 from bicameral_agent.latency import APILatencyModel, LatencyEstimate
-from bicameral_agent.token_estimator import ContextFeatures, TokenEstimate, TokenEstimator
+from bicameral_agent.token_estimator import (
+    AUDITOR_ASSESSMENT_INPUT_TOKENS,
+    SCANNER_RANKING_INPUT_TOKENS,
+    ContextFeatures,
+    TokenEstimate,
+    TokenEstimator,
+)
 
 # Normal distribution z-score for 25th percentile
 _Z_25 = 0.6745
@@ -170,17 +176,29 @@ class ToolLatencyModel:
         context_features: ContextFeatures,
         token_est: TokenEstimate,
     ) -> tuple[SubCallPrediction, ...]:
-        """Break a tool invocation into per-sub-call predictions."""
+        """Break a tool invocation into per-sub-call predictions.
+
+        Sub-call structure mirrors the actual tool implementations: the
+        scanner makes two LLM calls (gap identification + result ranking;
+        searches run against a local provider), the auditor makes two
+        (assumption extraction + evidence assessment), and the refresher
+        makes a single call.
+        """
         output_per_call = token_est.output_tokens // max(token_est.num_calls, 1)
         conv = context_features.conversation_length_tokens
 
+        calls: list[tuple[str, int]] | None = None
         if tool_id == TOOL_IDS[Action.SCANNER]:
-            gaps = token_est.num_calls - 2
             calls = [
                 ("gap_identification", 500 + conv),
-                *((f"search_{i + 1}", 2000) for i in range(gaps)),
-                ("synthesis", 500 + conv + gaps * 2000),
+                ("result_ranking", SCANNER_RANKING_INPUT_TOKENS),
             ]
+        elif tool_id == TOOL_IDS[Action.AUDITOR]:
+            calls = [
+                ("assumption_extraction", 400 + conv),
+                ("evidence_assessment", AUDITOR_ASSESSMENT_INPUT_TOKENS),
+            ]
+        if calls is not None:
             return tuple(
                 SubCallPrediction(
                     label=label,

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -192,6 +192,22 @@ class TestExtractTaskMetrics:
         m = extract_task_metrics(episode, decisions)
         assert m.latency_pairs == ()
 
+    def test_latency_pairs_drop_tool_id_mismatch(self):
+        """A decision/invocation tool_id mismatch means misalignment; drop it."""
+        scanner_id = TOOL_IDS[Action.SCANNER]
+        auditor_id = TOOL_IDS[Action.AUDITOR]
+        episode = _make_episode(
+            tool_invocations=[
+                ToolInvocation(
+                    tool_id=auditor_id, invoked_at_ms=100, completed_at_ms=600,
+                    input_tokens=0, output_tokens=10,
+                ),
+            ],
+        )
+        decisions = [_decision(Action.SCANNER, predicted={scanner_id: 400.0})]
+        m = extract_task_metrics(episode, decisions)
+        assert m.latency_pairs == ()
+
     def test_task_completed_extracted(self):
         episode = _make_episode(
             user_events=[

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -50,13 +50,18 @@ class TestLatencyEstimate:
 
 
 class TestColdStart:
-    """AC1: With 0 observations, predict() returns conservative estimates (>= 2x baseline)."""
+    """AC1: With 0 observations, predict() returns calibrated prior estimates.
 
-    def test_zero_observations_returns_conservative(self):
+    Priors are calibrated against the measured single-call latencies from
+    the #23 baseline run (~0.9-1.5s per call), see #44.
+    """
+
+    def test_zero_observations_in_calibrated_range(self):
         model = APILatencyModel()
         est = model.predict(1000, 500)
-        reasonable_baseline = _TRUE_ALPHA + _TRUE_BETA * 1000 + _TRUE_GAMMA * 500
-        assert est.mean_ms >= 2 * reasonable_baseline
+        # A ~1k-input / 500-output call was measured at roughly a second;
+        # the cold-start prior must land in the same order of magnitude.
+        assert 500.0 <= est.mean_ms <= 2500.0
 
     def test_zero_observations_has_wide_spread(self):
         model = APILatencyModel()
@@ -66,14 +71,19 @@ class TestColdStart:
 
     def test_few_observations_still_biased_toward_priors(self):
         model = APILatencyModel()
+        prior_mean = model.predict(1000, 500).mean_ms
+
+        # Observe a synthetic backend that is much slower than the prior.
         rng = np.random.default_rng(42)
         for _ in range(5):
             inp, out = 1000, 500
             model.observe(inp, out, _true_duration(rng, inp, out))
 
+        learned_mean = _TRUE_ALPHA + _TRUE_BETA * 1000 + _TRUE_GAMMA * 500
         est = model.predict(1000, 500)
-        reasonable_baseline = _TRUE_ALPHA + _TRUE_BETA * 1000 + _TRUE_GAMMA * 500
-        assert est.mean_ms > 1.5 * reasonable_baseline
+        # With only 5 of 20 cold-start observations the blend should still
+        # sit closer to the prior than to the learned value.
+        assert prior_mean < est.mean_ms < (prior_mean + learned_mean) / 2
 
 
 class TestConvergence:

--- a/tests/test_token_estimator.py
+++ b/tests/test_token_estimator.py
@@ -7,6 +7,8 @@ import time
 import pytest
 
 from bicameral_agent.token_estimator import (
+    AUDITOR_ASSESSMENT_INPUT_TOKENS,
+    SCANNER_RANKING_INPUT_TOKENS,
     ContextFeatures,
     TokenEstimate,
     TokenEstimator,
@@ -26,16 +28,11 @@ _TOOL_IDS = ["research_gap_scanner", "assumption_auditor", "context_refresher"]
 
 
 def _expected_scanner_input(conv: int) -> int:
-    gaps = min(max(1, conv // 2000), 5)
-    return (500 + conv) + (gaps * 2000) + (500 + conv + gaps * 2000)
-
-
-def _expected_scanner_calls(conv: int) -> int:
-    return 2 + min(max(1, conv // 2000), 5)
+    return (500 + conv) + SCANNER_RANKING_INPUT_TOKENS
 
 
 def _expected_auditor_input(conv: int) -> int:
-    return 400 + conv
+    return (400 + conv) + AUDITOR_ASSESSMENT_INPUT_TOKENS
 
 
 def _expected_refresher_input(conv: int, turns: int) -> int:
@@ -110,11 +107,7 @@ class TestOutputTokenConvergence:
         true_output_per_call = 300
         ctx = ContextFeatures(conversation_length_tokens=3000, conversation_turn_count=10)
 
-        # Compute num_calls for this tool/context
-        profile = _TOOL_PROFILES[tool_id]
-        num_calls = estimator._compute_num_calls(
-            profile, ctx.conversation_length_tokens
-        )
+        num_calls = _TOOL_PROFILES[tool_id].num_calls
 
         # Train with 15 noisy observations
         for _ in range(15):
@@ -138,14 +131,15 @@ class TestOutputTokenConvergence:
 
 
 class TestNumCalls:
-    """AC3: num_calls is 1 for auditor/refresher, variable for scanner."""
+    """num_calls mirrors the actual tool implementations (see #44):
+    scanner and auditor make 2 LLM calls each, the refresher makes 1."""
 
     @pytest.mark.parametrize(
         "ctx", _CONV_SIZES, ids=lambda c: f"conv={c.conversation_length_tokens}"
     )
-    def test_auditor_always_one(self, token_estimator, ctx):
+    def test_auditor_always_two(self, token_estimator, ctx):
         est = token_estimator.estimate("assumption_auditor", ctx)
-        assert est.num_calls == 1
+        assert est.num_calls == 2
 
     @pytest.mark.parametrize(
         "ctx", _CONV_SIZES, ids=lambda c: f"conv={c.conversation_length_tokens}"
@@ -157,19 +151,9 @@ class TestNumCalls:
     @pytest.mark.parametrize(
         "ctx", _CONV_SIZES, ids=lambda c: f"conv={c.conversation_length_tokens}"
     )
-    def test_scanner_variable(self, token_estimator, ctx):
+    def test_scanner_always_two(self, token_estimator, ctx):
         est = token_estimator.estimate("research_gap_scanner", ctx)
-        expected = _expected_scanner_calls(ctx.conversation_length_tokens)
-        assert est.num_calls == expected
-
-    def test_scanner_increases_with_conversation(self, token_estimator):
-        small = ContextFeatures(conversation_length_tokens=500, conversation_turn_count=3)
-        large = ContextFeatures(
-            conversation_length_tokens=12000, conversation_turn_count=40
-        )
-        est_small = token_estimator.estimate("research_gap_scanner", small)
-        est_large = token_estimator.estimate("research_gap_scanner", large)
-        assert est_large.num_calls >= est_small.num_calls
+        assert est.num_calls == 2
 
 
 class TestObserveUpdates:
@@ -203,7 +187,7 @@ class TestObserveUpdates:
         estimator = TokenEstimator()
         ctx = ContextFeatures(conversation_length_tokens=3000, conversation_turn_count=10)
 
-        # Default for auditor is 450
+        # Default for auditor is 750 per call
         estimator.observe_tool("assumption_auditor", ctx, 1000)
         est = estimator.estimate("assumption_auditor", ctx)
 

--- a/tests/test_tool_latency.py
+++ b/tests/test_tool_latency.py
@@ -57,13 +57,22 @@ class TestComposition:
         assert abs(pred.latency.mean_ms - sub_mean_sum) < 1e-6
 
     @pytest.mark.parametrize("tool_id", _TOOL_IDS)
-    def test_sub_call_tokens_match_aggregate(self, tool_id):
-        """Sum of sub-call input tokens matches aggregate TokenEstimate."""
+    @pytest.mark.parametrize(
+        "ctx", _CONV_SIZES, ids=lambda c: f"conv={c.conversation_length_tokens}"
+    )
+    def test_sub_call_tokens_match_aggregate(self, tool_id, ctx):
+        """Sub-call decomposition is consistent with the aggregate TokenEstimate.
+
+        Both sides are derived from token_estimator.sub_call_inputs (the
+        single source of truth), so the sub-call input tokens must sum to
+        the aggregate input estimate and the sub-call count must match
+        the estimated num_calls.
+        """
         model = ToolLatencyModel()
-        ctx = ContextFeatures(conversation_length_tokens=4000, conversation_turn_count=15)
         pred = model.predict(tool_id, ctx)
         total_input = sum(sc.input_tokens for sc in pred.sub_calls)
         assert total_input == pred.token_estimate.input_tokens
+        assert len(pred.sub_calls) == pred.token_estimate.num_calls
 
 
 class TestScannerDecomposition:

--- a/tests/test_tool_latency.py
+++ b/tests/test_tool_latency.py
@@ -2,12 +2,19 @@
 
 import threading
 import time
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 from bicameral_agent.latency import APILatencyModel, LatencyEstimate
-from bicameral_agent.token_estimator import ContextFeatures, TokenEstimate, TokenEstimator
+from bicameral_agent.token_estimator import (
+    AUDITOR_ASSESSMENT_INPUT_TOKENS,
+    SCANNER_RANKING_INPUT_TOKENS,
+    ContextFeatures,
+    TokenEstimate,
+    TokenEstimator,
+)
 from bicameral_agent.tool_latency import (
     CostEstimate,
     SubCallPrediction,
@@ -60,22 +67,20 @@ class TestComposition:
 
 
 class TestScannerDecomposition:
-    """AC2: Scanner with predicted 2 gaps decomposes correctly."""
+    """AC2: Scanner decomposes into its two actual LLM calls (#44)."""
 
-    def test_scanner_2_gaps_structure(self):
-        """At conv=4000, gaps=2, so 4 sub-calls: gap + 2 search + synthesis."""
+    def test_scanner_structure(self):
+        """Two sub-calls: gap identification + result ranking."""
         model = ToolLatencyModel()
         ctx = ContextFeatures(conversation_length_tokens=4000, conversation_turn_count=15)
         pred = model.predict("research_gap_scanner", ctx)
 
-        assert pred.token_estimate.num_calls == 4
-        assert len(pred.sub_calls) == 4
+        assert pred.token_estimate.num_calls == 2
+        assert len(pred.sub_calls) == 2
         assert pred.sub_calls[0].label == "gap_identification"
-        assert pred.sub_calls[1].label == "search_1"
-        assert pred.sub_calls[2].label == "search_2"
-        assert pred.sub_calls[3].label == "synthesis"
+        assert pred.sub_calls[1].label == "result_ranking"
 
-    def test_scanner_2_gaps_input_tokens(self):
+    def test_scanner_input_tokens(self):
         """Verify per-call input token counts match the formulas."""
         model = ToolLatencyModel()
         conv = 4000
@@ -83,12 +88,10 @@ class TestScannerDecomposition:
         pred = model.predict("research_gap_scanner", ctx)
 
         assert pred.sub_calls[0].input_tokens == 500 + conv
-        assert pred.sub_calls[1].input_tokens == 2000
-        assert pred.sub_calls[2].input_tokens == 2000
-        assert pred.sub_calls[3].input_tokens == 500 + conv + 2 * 2000
+        assert pred.sub_calls[1].input_tokens == SCANNER_RANKING_INPUT_TOKENS
 
-    def test_scanner_2_gaps_mean_is_sum(self):
-        """Total mean latency = sum of 4 individual call means."""
+    def test_scanner_mean_is_sum(self):
+        """Total mean latency = sum of individual call means."""
         model = ToolLatencyModel()
         ctx = ContextFeatures(conversation_length_tokens=4000, conversation_turn_count=15)
         pred = model.predict("research_gap_scanner", ctx)
@@ -96,16 +99,103 @@ class TestScannerDecomposition:
         expected_mean = sum(sc.latency.mean_ms for sc in pred.sub_calls)
         assert abs(pred.latency.mean_ms - expected_mean) < 1e-6
 
-    def test_scanner_varying_gaps(self):
-        """Scanner sub-call count scales with conversation length."""
+
+class TestAuditorDecomposition:
+    """Auditor decomposes into assumption extraction + evidence assessment."""
+
+    def test_auditor_structure(self):
         model = ToolLatencyModel()
-        small = ContextFeatures(conversation_length_tokens=500, conversation_turn_count=3)
-        large = ContextFeatures(
-            conversation_length_tokens=12000, conversation_turn_count=40
+        conv = 3000
+        ctx = ContextFeatures(conversation_length_tokens=conv, conversation_turn_count=10)
+        pred = model.predict("assumption_auditor", ctx)
+
+        assert pred.token_estimate.num_calls == 2
+        assert len(pred.sub_calls) == 2
+        assert pred.sub_calls[0].label == "assumption_extraction"
+        assert pred.sub_calls[0].input_tokens == 400 + conv
+        assert pred.sub_calls[1].label == "evidence_assessment"
+        assert pred.sub_calls[1].input_tokens == AUDITOR_ASSESSMENT_INPUT_TOKENS
+
+
+class TestCalibratedColdStart:
+    """#44: cold-start predictions land in the measured latency range.
+
+    Ranges bracket the tool durations measured in the #23 baseline run
+    (data/baseline: scanner ~1.7-4.5s, auditor ~2.7-2.9s,
+    refresher ~0.9-1.3s) with headroom for larger conversations.
+    """
+
+    _RANGES = {
+        "research_gap_scanner": (1500.0, 4500.0),
+        "assumption_auditor": (1500.0, 4500.0),
+        "context_refresher": (600.0, 2200.0),
+    }
+
+    @pytest.mark.parametrize("tool_id", _TOOL_IDS)
+    @pytest.mark.parametrize(
+        "ctx", _CONV_SIZES, ids=lambda c: f"conv={c.conversation_length_tokens}"
+    )
+    def test_cold_start_within_calibrated_range(self, tool_id, ctx):
+        model = ToolLatencyModel()
+        est = model.predict_tool_duration(tool_id, ctx)
+        lo, hi = self._RANGES[tool_id]
+        assert lo <= est.mean_ms <= hi, (
+            f"{tool_id} cold-start mean {est.mean_ms:.0f}ms outside [{lo}, {hi}]"
         )
-        pred_small = model.predict("research_gap_scanner", small)
-        pred_large = model.predict("research_gap_scanner", large)
-        assert len(pred_large.sub_calls) >= len(pred_small.sub_calls)
+
+    @pytest.mark.parametrize("tool_id", _TOOL_IDS)
+    def test_monotonic_in_context_size(self, tool_id):
+        """Predicted mean is nondecreasing in conversation length."""
+        model = ToolLatencyModel()
+        means = [
+            model.predict_tool_duration(tool_id, ctx).mean_ms for ctx in _CONV_SIZES
+        ]
+        assert means == sorted(means), f"{tool_id} means not monotonic: {means}"
+
+
+_BASELINE_DIR = Path(__file__).resolve().parents[1] / "data" / "baseline"
+
+
+@pytest.mark.skipif(
+    not _BASELINE_DIR.exists(), reason="baseline episode data not available"
+)
+class TestBaselineMape:
+    """#44 AC: cold-start MAPE < 50% against measured baseline tool durations."""
+
+    def test_cold_start_mape_under_50_percent(self):
+        from bicameral_agent.serialization import episodes_from_parquet
+
+        rows: list[tuple[str, int, int, float]] = []
+        for pq_file in sorted(_BASELINE_DIR.glob("*.parquet")):
+            for episode in episodes_from_parquet(str(pq_file)):
+                for inv in episode.tool_invocations:
+                    if inv.budget_exceeded:
+                        continue
+                    actual_ms = float(inv.completed_at_ms - inv.invoked_at_ms)
+                    if actual_ms <= 0:
+                        continue
+                    prior = [
+                        m
+                        for m in episode.messages
+                        if m.timestamp_ms <= inv.invoked_at_ms
+                    ]
+                    conv_tokens = sum(m.token_count for m in prior)
+                    rows.append((inv.tool_id, conv_tokens, len(prior), actual_ms))
+
+        assert rows, "no usable tool invocations in baseline data"
+
+        model = ToolLatencyModel()
+        errors = []
+        for tool_id, conv_tokens, turns, actual_ms in rows:
+            ctx = ContextFeatures(
+                conversation_length_tokens=conv_tokens,
+                conversation_turn_count=turns,
+            )
+            predicted = model.predict_tool_duration(tool_id, ctx).mean_ms
+            errors.append(abs(predicted - actual_ms) / actual_ms)
+
+        mape = 100.0 * sum(errors) / len(errors)
+        assert mape < 50.0, f"cold-start MAPE {mape:.1f}% >= 50%"
 
 
 class TestCostEstimates:
@@ -261,7 +351,7 @@ class TestDataClasses:
 class TestSingleCallTools:
     """Single-call tools have exactly one sub-call."""
 
-    @pytest.mark.parametrize("tool_id", ["assumption_auditor", "context_refresher"])
+    @pytest.mark.parametrize("tool_id", ["context_refresher"])
     def test_single_sub_call(self, tool_id):
         model = ToolLatencyModel()
         ctx = ContextFeatures(conversation_length_tokens=3000, conversation_turn_count=10)


### PR DESCRIPTION
## Summary
Fixes the 9-23x tool-latency over-prediction from issue #44 (predicted gap_scanner ~51.7s / auditor ~19.2s / refresher ~5.2s vs ~1-3s actual, i.e. 865%/2209% MAPE in the #23 baseline run) by correcting two structural errors and recalibrating the cold-start priors against the real measured durations already on disk in `data/baseline/*.parquet`.

Titled **Partial** because no live API keys were available in this environment: the recalibration is fitted and held-out-validated against the 63 real measurements from the #23 baseline run, but a fresh collection run (`scripts/collect_latency_data.py`) and the "fresh episodes yield the improved error" acceptance check remain for the #46 re-run. Hence `Refs #44`, not `Closes`.

### Root causes fixed
1. **Phantom sub-calls.** The token estimator assumed the scanner makes 2+gaps (3-7) LLM calls and the auditor 1. The actual implementations make exactly 2 each (`_identify_gaps` + `_rank_results`; scanner searches hit a local `MockSearchProvider`, and the auditor runs `_extract_assumptions` + `_assess_evidence`). Each phantom call carried the full ~1.2s prior intercept.
2. **Mis-anchored prior units.** `_PRIOR_OUTPUT_RATE = 25` tok/s made the output term alone ~16s for a 400-token call — roughly 10x slower than the effective rate implied by the recorded output token counts — and the priors were additionally "deliberately ~2x conservative".

### Results (cold-start predictions vs measured baseline durations)
| | before | after |
|---|---|---|
| Overall MAPE (all 63 measurements) | ~1930% | 15.4% |
| **Held-out MAPE** (stratified 30-row split) | — | **15.0%** |
| gap_scanner (held-out) | 2203% | 14.6% |
| assumption_auditor (held-out) | 574% | 15.6% |
| context_refresher (held-out) | 399% | 20.8% |

## Work performed
- `token_estimator.py`: per-tool call counts now mirror the implementations (scanner 2, auditor 2, refresher 1); default output-per-call anchored to median recorded outputs (670/750/1100); scanner/auditor input formulas rebuilt around the real two-call structure.
- `latency.py`: priors re-fitted by grid search on a stratified train half of the baseline measurements (alpha 1000->700 ms, overhead 200->175 ms, output rate 25->2500 effective tok/s on the recorded len/4 token scale); docstrings updated — priors are now calibrated, not 2x-conservative.
- `tool_latency.py`: sub-call decomposition updated (scanner: `gap_identification` + `result_ranking`; auditor: `assumption_extraction` + `evidence_assessment`).
- `baseline_benchmark.py`: re-verified `_latency_pairs` — positional pairing stays aligned with the #50 `budget_exceeded` exclusion (skips happen after pairing) and every non-DO_NOTHING decision logs an invocation in order; added a defensive drop of pairs whose invocation `tool_id` does not match the decision's action.
- Tests: new `TestCalibratedColdStart` (per-tool calibrated ranges over representative `ContextFeatures` + monotonicity in conversation length), new `TestBaselineMape` regression asserting cold-start MAPE < 50% against the committed `data/baseline` episodes, new auditor-decomposition and pairing-mismatch tests; updated tests that pinned the old 2x-conservative priors and 3-7-call scanner structure to assert calibrated ranges/properties instead.
- Training/serving consistency: `training_pipeline.py` and `episode_runner.py` construct default `ToolLatencyModel()`s, so both pick up the new calibration automatically; no pinned cold-start values existed in `test_training_pipeline.py`/`test_encoder.py`. Observation save/load (`save_observations`/`load_observations` round-trip) unchanged and passing.

### Remaining for #46
- Collect fresh measurements with `scripts/collect_latency_data.py` against the live backend(s) (and Gemma via #43 if available) and re-fit/confirm; the online OLS takes over from these priors after 20 observations either way.
- Re-run the latency-MAPE computation on fresh episodes to confirm the improvement end-to-end.

## Test plan
- `uv run --extra dev --extra torch pytest -q` — 997 passed, 34 skipped.
- `uv run --extra dev ruff check src/ tests/` — clean.
- Held-out validation: stratified per-tool alternate split of the 63 baseline measurements; constants fitted on the 33-row train half only, reported MAPE from the untouched 30-row half.
- CI review jobs are currently failing repo-wide (dead OAuth token) — unrelated.

Refs #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy