### PR TITLE
Multi-turn episodes + discriminating scorer

### DIFF
--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -200,6 +200,13 @@ class EpisodeRunner:
             # (c) Expire stale queue items
             expired_count += len(queue.expire_stale(turn))
 
+            # (c2) Snapshot queue state before run_turn's breakpoint drain.
+            # Taken after the drain it is always empty, which made the
+            # controller's queue_depth feature and the avg_queue_depth
+            # metric structurally zero (issue #45); pre-drain it reflects
+            # deposits pending from earlier turns.
+            queue_snapshot = queue.get_state()
+
             # (d) Run conscious loop turn
             try:
                 response: AssistantResponse = loop.run_turn(user_message)
@@ -255,8 +262,6 @@ class EpisodeRunner:
                 tool_id: latency_model.predict_tool_duration(tool_id, ctx_features).mean_ms
                 for tool_id in tools
             }
-
-            queue_snapshot = queue.get_state()
 
             state = FullState(
                 turn_number=turn,

--- a/src/bicameral_agent/scorer.py
+++ b/src/bicameral_agent/scorer.py
@@ -50,10 +50,14 @@ class TaskScore(BaseModel):
 
 
 _JUDGE_SYSTEM_PROMPT = (
-    "You are an expert evaluator scoring research question answers against a "
-    "reference answer and rubric. Your scores must be strict, consistent, and "
-    "justified solely by the rubric criteria. Do not give the benefit of the "
-    "doubt — score only what is explicitly present in the answer."
+    "You are a demanding expert evaluator scoring research question answers "
+    "against a reference answer and rubric. Use the full 1-5 range: a merely "
+    "reasonable answer earns 3, and 5 is reserved for flawless answers that "
+    "cover every key point of the reference with no errors. Score only what "
+    "is explicitly present in the answer — never give the benefit of the "
+    "doubt, and when torn between two adjacent scores, choose the lower one. "
+    "Justify your scores against specific reference key points before giving "
+    "them."
 )
 
 _JUDGE_USER_TEMPLATE = """\
@@ -69,23 +73,47 @@ Question: {question}
 ## Agent Answer to Score
 {agent_answer}
 
-Rate the agent answer on each dimension using an integer from 1 to 5:
-- quality: Overall quality according to the scoring rubric above. \
-Match the agent answer to the closest rubric level.
-- completeness: How thoroughly the answer covers the key points from the \
-reference answer (5 = all key points, 1 = none).
-- accuracy: Factual correctness compared to the reference answer \
-(5 = fully correct, 1 = major errors or fabrications)."""
+First, in "justification", state concretely which key points of the \
+reference answer the agent answer covers, which it misses, and any factual \
+errors (1-3 sentences).
 
+Then rate the agent answer on each dimension using an integer from 1 to 5, \
+anchored as follows:
+- 5 = flawless: every key point of the reference covered accurately; top \
+rubric level; nothing missing, nothing wrong. This should be rare.
+- 4 = strong: at most one minor omission or imprecision; no factual errors.
+- 3 = adequate: the central idea is right but key points are missing, \
+vague, or shallow. This is the expected score for a merely reasonable answer.
+- 2 = weak: touches the topic but misses most key points, or contains a \
+significant factual error.
+- 1 = failing: wrong, off-topic, empty, or fabricated.
+
+Dimensions:
+- quality: overall quality according to the scoring rubric above.
+- completeness: coverage of the reference answer's key points.
+- accuracy: factual correctness relative to the reference answer.
+
+Hard caps: if any key point is missing, completeness is at most 3. If there \
+is any factual error, accuracy is at most 3; if the error is major or \
+fabricated, at most 2."""
+
+# "justification" is deliberately first: the judge must commit to a concrete
+# coverage/error analysis before emitting scores (rationale-first scoring),
+# which is what breaks the reflexive 5/5/5 ceiling.
 _JUDGE_RESPONSE_SCHEMA = {
     "type": "object",
     "properties": {
+        "justification": {"type": "string"},
         "quality": {"type": "integer"},
         "completeness": {"type": "integer"},
         "accuracy": {"type": "integer"},
     },
-    "required": ["quality", "completeness", "accuracy"],
+    "required": ["justification", "quality", "completeness", "accuracy"],
 }
+
+# The old cap of 100 tokens left no room for any reasoning before the
+# scores; 400 accommodates the rationale-first justification.
+_JUDGE_MAX_OUTPUT_TOKENS = 400
 
 
 class TaskScorer:
@@ -194,7 +222,7 @@ class TaskScorer:
             system_prompt=_JUDGE_SYSTEM_PROMPT,
             thinking_level="minimal",
             temperature=0,
-            max_output_tokens=100,
+            max_output_tokens=_JUDGE_MAX_OUTPUT_TOKENS,
             response_schema=_JUDGE_RESPONSE_SCHEMA,
         )
         # Malformed/truncated judge output degrades to a neutral mid-scale

--- a/src/bicameral_agent/simulated_user.py
+++ b/src/bicameral_agent/simulated_user.py
@@ -57,6 +57,27 @@ _MAX_TURNS: dict[Patience, int] = {
     Patience.HIGH: 25,
 }
 
+# Earliest turn at which task_complete is accepted, keyed by strictness.
+# A premature completion below this floor is converted into a probing
+# follow-up, so default (medium+) episodes are multi-turn and a tool
+# deposit at turn N can be consumed at turn N+1 (issue #45). Beyond the
+# floor the LLM decides, so episode length is a distribution, not fixed.
+_MIN_TURNS_BEFORE_COMPLETE: dict[Strictness, int] = {
+    Strictness.LOW: 1,
+    Strictness.MEDIUM: 2,
+    Strictness.HIGH: 3,
+}
+
+# Probing follow-ups used when a premature task_complete is converted.
+_PROBE_MESSAGES: tuple[str, ...] = (
+    "Before I accept that, double-check your key claims — how confident "
+    "are you in each of them?",
+    "That sounds plausible, but can you verify the main facts and flag "
+    "anything you are unsure about?",
+    "Walk me through the evidence behind your central claim before we "
+    "wrap up.",
+)
+
 
 class UserAction(BaseModel):
     """An action taken by the simulated user."""
@@ -91,15 +112,20 @@ class UserAction(BaseModel):
 _SYSTEM_PROMPT_TEMPLATE = """\
 You are simulating a user interacting with an AI research assistant. You are \
 evaluating whether the assistant's response adequately answers your research \
-question. You have access to the gold-standard answer and scoring rubric.
+question. You have private evaluation notes (a reference answer and scoring \
+rubric) that the assistant cannot see.
 
 Your persona:
 - Patience: {patience}. {patience_desc}
 - Strictness: {strictness}. {strictness_desc}
 
 Guidelines:
-- If the assistant's answer is substantially correct and complete per the \
-rubric, choose "task_complete".
+- Treat the assistant's first answer as a draft: you have not verified its \
+claims yourself, so a careful user probes or challenges at least one \
+specific point before accepting it.
+- Choose "task_complete" only when the answer has held up under your \
+follow-up scrutiny AND covers every key point of the reference answer per \
+the rubric. Do not accept an answer merely because it sounds plausible.
 - If the answer is clearly wrong, off-topic, or the assistant is going in \
 circles, choose "stop".
 - Otherwise, choose "follow_up" with an appropriate follow-up message.
@@ -129,7 +155,7 @@ _USER_PROMPT_TEMPLATE = """\
 ## Research Question
 {question}
 
-## Gold-Standard Answer
+## Private Reference Answer (the assistant cannot see this; never reveal it)
 {gold_answer}
 
 ## Scoring Rubric
@@ -144,8 +170,9 @@ _USER_PROMPT_TEMPLATE = """\
 ## Turn Number
 This is turn {turn_number}.
 
-Decide your next action. Consider whether the agent has adequately addressed \
-the research question according to the rubric and gold answer."""
+Decide your next action. Check the latest response against the private \
+reference answer point by point: if any key point is missing, vague, or \
+unverified, follow up on it rather than completing the task."""
 
 _RESPONSE_SCHEMA = {
     "type": "object",
@@ -190,6 +217,10 @@ class SimulatedUser:
 
     Uses Gemini Flash to decide next actions based on configurable patience
     and strictness personas. Each call to respond() makes a single LLM call.
+
+    Strictness also sets a completion floor (_MIN_TURNS_BEFORE_COMPLETE):
+    task_complete before that turn is converted into a probing follow-up,
+    so medium/high-strictness episodes are always multi-turn.
     """
 
     def __init__(
@@ -266,7 +297,19 @@ class SimulatedUser:
         raw = safe_parse_json(
             response, context="SimulatedUser.respond", default=None
         )
-        return self._parse_response(raw)
+        action = self._parse_response(raw)
+
+        # Completion floor: a task_complete before the strictness-dependent
+        # minimum turn is converted into a probing follow-up. This prevents
+        # the turn-1 collapse where the sim-user (holding the reference
+        # answer) accepts the first plausible draft, which made tool deposits
+        # unconsumable (issue #45).
+        if (
+            action.action_type == ActionType.TASK_COMPLETE
+            and turn_number < _MIN_TURNS_BEFORE_COMPLETE[self._strictness]
+        ):
+            return _probe_action(turn_number, action)
+        return action
 
     @staticmethod
     def _parse_response(raw: dict | None) -> UserAction:
@@ -303,6 +346,18 @@ class SimulatedUser:
             kwargs["followup_type"] = followup_type
 
         return UserAction(**kwargs)
+
+
+def _probe_action(turn_number: int, premature: UserAction) -> UserAction:
+    """Probing follow-up replacing a task_complete below the completion floor."""
+    message = _PROBE_MESSAGES[(turn_number - 1) % len(_PROBE_MESSAGES)]
+    return UserAction(
+        action_type=ActionType.FOLLOW_UP,
+        message=message,
+        followup_type=FollowUpType.ELABORATION,
+        response_delay_ms=premature.response_delay_ms,
+        confidence=premature.confidence,
+    )
 
 
 def _fallback_action() -> UserAction:

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -19,7 +19,7 @@ from bicameral_agent.followup_classifier import FollowUpType
 from bicameral_agent.gemini import GeminiClient, GeminiResponse
 from bicameral_agent.heuristic_controller import Action, FullState, HeuristicController
 from bicameral_agent.schema import Episode, UserEventType
-from bicameral_agent.simulated_user import ActionType, UserAction
+from bicameral_agent.simulated_user import ActionType, Strictness, UserAction
 from bicameral_agent.cost_tracker import CostBudgetExceeded
 from bicameral_agent.tool_primitive import BudgetExceededError
 
@@ -856,6 +856,186 @@ class TestInjectionModes:
         """EpisodeConfig accepts custom injection mode."""
         cfg = EpisodeConfig(injection_mode=InjectionMode.SYNCHRONOUS)
         assert cfg.injection_mode == InjectionMode.SYNCHRONOUS
+
+
+# ---------------------------------------------------------------------------
+# TestMultiTurnQueueIntegration (issue #45)
+# ---------------------------------------------------------------------------
+
+_COMPLETE_ACTION = {
+    "action_type": "task_complete",
+    "response_delay_ms": 100,
+    "confidence": 0.9,
+}
+
+_SECRET = "SECRET-FINDING-XYZ"
+
+
+def _scripted_client(sim_actions: list[dict]) -> MagicMock:
+    """Mock GeminiClient transport routing sim-user calls vs answerer calls.
+
+    Calls from the real SimulatedUser are identified by their response_schema
+    (it has an "action_type" property) and consume the scripted actions; all
+    other calls are answerer generations, whose content reflects whether the
+    injected tool context is visible in the prompt.
+    """
+    import json
+
+    actions = iter(sim_actions)
+
+    def generate(messages, **kwargs):
+        schema = kwargs.get("response_schema")
+        if schema is not None and "action_type" in schema.get("properties", {}):
+            return GeminiResponse(
+                content=json.dumps(next(actions)),
+                input_tokens=5,
+                output_tokens=5,
+                duration_ms=10.0,
+                finish_reason="STOP",
+            )
+        joined = " ".join(
+            m["content"] if isinstance(m, dict) else m.content for m in messages
+        )
+        if _SECRET in joined:
+            return _mock_gemini_response(content=f"Refined answer using {_SECRET}.")
+        return _mock_gemini_response(content="Preliminary answer without tool context.")
+
+    client = MagicMock(spec=GeminiClient)
+    client.generate.side_effect = generate
+    return client
+
+
+def _deposit_tool() -> MagicMock:
+    """Mock tool that deposits a recognizable context item into the queue."""
+    from bicameral_agent.queue import Priority, QueueItem
+    from bicameral_agent.tool_primitive import ToolMetadata, ToolResult
+
+    mock_tool = MagicMock()
+    mock_tool.execute.return_value = ToolResult(
+        queue_deposit=QueueItem(
+            content=f"{_SECRET}: key evidence found.",
+            priority=Priority.HIGH,
+            source_tool_id="research_gap_scanner",
+            token_count=12,
+        ),
+        metadata=ToolMetadata(
+            tool_id="research_gap_scanner",
+            action_taken="scanned",
+            confidence=0.8,
+            items_found=1,
+            estimated_relevance=0.9,
+            tokens_consumed=30,
+        ),
+    )
+    return mock_tool
+
+
+class TestMultiTurnQueueIntegration:
+    """Multi-turn wiring tests with the real SimulatedUser, queue, and loop.
+
+    Only the LLM transport and the tools are mocked; EpisodeRunner,
+    ConsciousLoop, ContextQueue, and SimulatedUser run for real. The
+    sim-user LLM is scripted to say task_complete on every turn, so any
+    extra turns come from the strictness completion floor (issue #45).
+    """
+
+    def _run(self, config=None, decide=None):
+        client = _scripted_client([_COMPLETE_ACTION] * 8)
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        if decide is None:
+            ctrl.decide.return_value = Action.DO_NOTHING
+        else:
+            ctrl.decide.side_effect = decide
+        runner = EpisodeRunner(client, config or EpisodeConfig(max_turns=8))
+        with patch("bicameral_agent.episode_runner.ResearchGapScanner") as MockScanner:
+            MockScanner.return_value = _deposit_tool()
+            episode = runner.run_episode(_make_task(), ctrl)
+        return episode
+
+    def test_completion_floor_makes_default_episode_multiturn(self):
+        """Default (medium) strictness: turn-1 task_complete becomes a probe."""
+        episode = self._run()
+        assert episode.outcome.total_turns == 2
+        followups = [
+            e for e in episode.user_events if e.event_type == UserEventType.FOLLOW_UP
+        ]
+        assert len(followups) == 1
+        assert any(
+            e.event_type == UserEventType.TASK_COMPLETE for e in episode.user_events
+        )
+
+    def test_high_strictness_floor_gives_three_turns(self):
+        episode = self._run(
+            config=EpisodeConfig(max_turns=8, strictness=Strictness.HIGH)
+        )
+        assert episode.outcome.total_turns == 3
+
+    def test_turn1_deposit_consumed_turn2_and_changes_scored_answer(self):
+        recorded: list[FullState] = []
+
+        def decide(state):
+            recorded.append(state)
+            return Action.SCANNER if state.turn_number == 1 else Action.DO_NOTHING
+
+        episode = self._run(decide=decide)
+
+        assert episode.outcome.total_turns == 2
+        # The turn-1 deposit was drained and consumed at turn 2
+        assert len(episode.context_injections) == 1
+        inj = episode.context_injections[0]
+        assert inj.consumed is True
+        assert inj.consumed_at_turn == 2
+        # Pre-drain snapshot: the turn-2 decision saw the pending item
+        assert recorded[0].queue_depth == 0
+        assert recorded[1].queue_depth == 1
+        # The final (scored) answer reflects the turn-1 tool deposit
+        final = [m for m in episode.messages if m.role == "assistant"][-1]
+        assert _SECRET in final.content
+
+    def test_without_tools_final_answer_lacks_injected_context(self):
+        episode = self._run()
+        assert len(episode.context_injections) == 0
+        final = [m for m in episode.messages if m.role == "assistant"][-1]
+        assert _SECRET not in final.content
+        assert "Preliminary answer" in final.content
+
+    def test_short_expiry_expires_deposit_before_consumption(self):
+        def decide(state):
+            return Action.SCANNER if state.turn_number == 1 else Action.DO_NOTHING
+
+        episode = self._run(
+            config=EpisodeConfig(max_turns=8, queue_expiry_turns=1),
+            decide=decide,
+        )
+
+        assert episode.metadata["expired_queue_items"] == 1
+        assert episode.context_injections[0].consumed is False
+        final = [m for m in episode.messages if m.role == "assistant"][-1]
+        assert _SECRET not in final.content
+
+    def test_queue_metrics_nontrivial_with_real_controller(self):
+        """avg_queue_depth and drain_count are non-zero in a multi-turn run."""
+        from bicameral_agent.baseline_benchmark import extract_task_metrics
+
+        client = _scripted_client([_COMPLETE_ACTION] * 8)
+        ctrl = RandomController(action_probability=1.0, seed=7)
+        runner = EpisodeRunner(client, EpisodeConfig(max_turns=8))
+        with (
+            patch("bicameral_agent.episode_runner.ResearchGapScanner") as MockScanner,
+            patch("bicameral_agent.episode_runner.AssumptionAuditor") as MockAuditor,
+            patch("bicameral_agent.episode_runner.ContextRefresher") as MockRefresher,
+        ):
+            MockScanner.return_value = _deposit_tool()
+            MockAuditor.return_value = _deposit_tool()
+            MockRefresher.return_value = _deposit_tool()
+            episode = runner.run_episode(_make_task(), ctrl)
+
+        metrics = extract_task_metrics(episode, ctrl.decisions)
+        assert metrics.total_turns >= 2
+        assert metrics.drain_count >= 1
+        assert metrics.avg_queue_depth > 0
+        assert metrics.task_completed == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -570,6 +570,79 @@ class TestCorrelation:
 
 
 # ---------------------------------------------------------------------------
+# TestJudgeDiscrimination (issue #45: break the 5/5/5 ceiling)
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeDiscrimination:
+    def test_schema_requires_justification_first(self):
+        """Rationale-first scoring: justification precedes the score fields."""
+        scorer, mock_client = _make_scorer_with_mock()
+        scorer.score(_make_task(), "answer")
+        schema = mock_client.generate.call_args.kwargs["response_schema"]
+        assert "justification" in schema["required"]
+        assert list(schema["properties"])[0] == "justification"
+
+    def test_output_token_cap_allows_justification(self):
+        """The old 100-token cap left no room for reasoning before scores."""
+        scorer, mock_client = _make_scorer_with_mock()
+        scorer.score(_make_task(), "answer")
+        assert mock_client.generate.call_args.kwargs["max_output_tokens"] == 400
+
+    def test_prompt_contains_anchored_scale(self):
+        scorer, mock_client = _make_scorer_with_mock()
+        scorer.score(_make_task(), "answer")
+        user_msg = mock_client.generate.call_args[0][0][0]["content"]
+        for anchor in ("5 = flawless", "4 = strong", "3 = adequate",
+                       "2 = weak", "1 = failing"):
+            assert anchor in user_msg, f"missing anchor: {anchor}"
+        assert "This should be rare" in user_msg
+        assert "Hard caps" in user_msg
+
+    def test_system_prompt_forces_full_range(self):
+        scorer, mock_client = _make_scorer_with_mock()
+        scorer.score(_make_task(), "answer")
+        system = mock_client.generate.call_args.kwargs["system_prompt"]
+        assert "full 1-5 range" in system
+        assert "choose the lower" in system
+
+    def test_justification_in_response_is_handled(self):
+        """The judge now returns a justification; scoring must ignore it."""
+        response = MagicMock()
+        response.content = json.dumps({
+            "justification": "Covers points A and B; misses C.",
+            "quality": 4,
+            "completeness": 3,
+            "accuracy": 5,
+        })
+        scorer, _ = _make_scorer_with_mock(response=response)
+        score = scorer.score(_make_task(), "answer")
+        assert score.quality == pytest.approx(0.75)
+        assert score.completeness == pytest.approx(0.5)
+        assert score.accuracy == pytest.approx(1.0)
+
+    def test_mixed_quality_answers_produce_spread(self):
+        """Judge outputs at each rubric level map to distinct scores, not 1.0."""
+        levels = [5, 4, 3, 2, 1]
+        responses = [
+            _mock_gemini_response(quality=v, completeness=v, accuracy=v)
+            for v in levels
+        ]
+        mock_client = MagicMock()
+        mock_client.generate.side_effect = responses
+        scorer = TaskScorer(client=mock_client, max_workers=1)
+
+        tasks = [_make_task(task_id=f"spread_{i}") for i in range(len(levels))]
+        answers = [f"answer of quality level {v}" for v in levels]
+        scores = [s.overall for s in scorer.score_batch(tasks, answers)]
+
+        assert len(set(scores)) == len(levels)  # all distinct
+        assert not all(s == 1.0 for s in scores)  # no ceiling pin
+        assert max(scores) - min(scores) == pytest.approx(1.0)
+        assert float(np.std(scores)) > 0.3  # meaningful variance
+
+
+# ---------------------------------------------------------------------------
 # TestMalformedJudgeOutput (issue #47)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_simulated_user.py
+++ b/tests/test_simulated_user.py
@@ -16,6 +16,7 @@ from bicameral_agent.simulated_user import (
     Strictness,
     UserAction,
     _MAX_TURNS,
+    _MIN_TURNS_BEFORE_COMPLETE,
     _format_conversation,
 )
 
@@ -408,10 +409,87 @@ class TestStopAndComplete:
             response=_mock_gemini_response(action_type="task_complete")
         )
         task = _make_task()
-        action = user.respond(task, "response", [], turn_number=1)
+        # Turn 2 is at the medium-strictness completion floor, so the
+        # task_complete is accepted rather than converted to a probe.
+        action = user.respond(task, "response", _make_history(1), turn_number=2)
         assert action.action_type == ActionType.TASK_COMPLETE
         assert action.message is None
         assert action.followup_type is None
+
+
+# ---------------------------------------------------------------------------
+# TestCompletionFloor (issue #45: no trivial turn-1 task_complete)
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionFloor:
+    def _complete_at_turn(self, turn_number, strictness):
+        user, _ = _make_simulated_user(
+            response=_mock_gemini_response(
+                action_type="task_complete", response_delay_ms=250, confidence=0.9
+            ),
+            strictness=strictness,
+        )
+        history = _make_history(turn_number - 1)
+        return user.respond(_make_task(), "response", history, turn_number=turn_number)
+
+    def test_medium_strictness_converts_turn1_complete_to_probe(self):
+        action = self._complete_at_turn(1, Strictness.MEDIUM)
+        assert action.action_type == ActionType.FOLLOW_UP
+        assert action.message
+        assert action.followup_type == FollowUpType.ELABORATION
+
+    def test_medium_strictness_accepts_complete_at_turn2(self):
+        action = self._complete_at_turn(2, Strictness.MEDIUM)
+        assert action.action_type == ActionType.TASK_COMPLETE
+
+    def test_high_strictness_converts_turns_below_three(self):
+        for turn in (1, 2):
+            action = self._complete_at_turn(turn, Strictness.HIGH)
+            assert action.action_type == ActionType.FOLLOW_UP, f"turn {turn}"
+
+    def test_high_strictness_accepts_complete_at_turn3(self):
+        action = self._complete_at_turn(3, Strictness.HIGH)
+        assert action.action_type == ActionType.TASK_COMPLETE
+
+    def test_low_strictness_accepts_turn1_complete(self):
+        action = self._complete_at_turn(1, Strictness.LOW)
+        assert action.action_type == ActionType.TASK_COMPLETE
+
+    def test_stop_is_not_converted(self):
+        user, _ = _make_simulated_user(
+            response=_mock_gemini_response(action_type="stop"),
+            strictness=Strictness.HIGH,
+        )
+        action = user.respond(_make_task(), "response", [], turn_number=1)
+        assert action.action_type == ActionType.STOP
+
+    def test_probe_preserves_delay_and_confidence(self):
+        action = self._complete_at_turn(1, Strictness.MEDIUM)
+        assert action.response_delay_ms == 250
+        assert action.confidence == pytest.approx(0.9)
+
+    def test_floor_values(self):
+        assert _MIN_TURNS_BEFORE_COMPLETE[Strictness.LOW] == 1
+        assert _MIN_TURNS_BEFORE_COMPLETE[Strictness.MEDIUM] == 2
+        assert _MIN_TURNS_BEFORE_COMPLETE[Strictness.HIGH] == 3
+
+    def test_floor_below_all_patience_limits(self):
+        """The completion floor must be reachable before any forced STOP."""
+        assert max(_MIN_TURNS_BEFORE_COMPLETE.values()) < min(_MAX_TURNS.values())
+
+    def test_system_prompt_requires_probing(self):
+        user, mock_client = _make_simulated_user()
+        user.respond(_make_task(), "response", [], turn_number=1)
+        system = mock_client.generate.call_args.kwargs["system_prompt"]
+        assert "draft" in system.lower()
+        assert "probe" in system.lower()
+
+    def test_user_prompt_marks_reference_private(self):
+        user, mock_client = _make_simulated_user()
+        user.respond(_make_task(), "response", [], turn_number=1)
+        user_msg = mock_client.generate.call_args[0][0][0]["content"]
+        assert "Private Reference Answer" in user_msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the two structural causes of the #41 no-signal baseline: single-turn episode collapse (tool deposits at turn N were never consumable at turn N+1) and the LLM-judge quality ceiling (scores pinned at 1.0). Also fixes a loop-ordering issue that made `queue_depth`/`avg_queue_depth` structurally zero.

## Work performed

**Multi-turn (`simulated_user.py`)**
- Added a strictness-keyed completion floor (`_MIN_TURNS_BEFORE_COMPLETE`: low=1, medium=2, high=3). A `task_complete` below the floor is converted into a probing follow-up (delay/confidence preserved), so default (medium) episodes are always >= 2 turns and a turn-N deposit can be consumed at turn N+1. Beyond the floor the LLM decides, so episode length remains a distribution, not a forced fixed length.
- Hardened prompts: the gold answer is now framed as private evaluation notes the assistant cannot see; the persona treats the first answer as an unverified draft and must probe at least one point; completion requires a point-by-point check against the reference, not plausibility.

**Discriminating scorer (`scorer.py`)** — diagnosis: the judge ran with `max_output_tokens=100` (no room for any reasoning before emitting three integers), an unanchored 1-5 scale (defaults drift to 4-5), and a "strict" instruction with no operational counterweight to leniency. Fixes:
- Rationale-first scoring: the response schema now requires a `justification` (listed first) naming covered/missed key points and errors before the scores.
- Anchored scale in the prompt (5 = flawless/rare ... 1 = failing) with hard caps (missing key point => completeness <= 3; factual error => accuracy <= 3, major error <= 2) and a tie-break-downward rule; system prompt demands full-range usage.
- `max_output_tokens` 100 -> 400. The #47 safe-parse neutral-degradation path is untouched (extra `justification` key was already ignored by the parser; covered by tests).

**Loop ordering (`episode_runner.py`)**
- The queue snapshot was taken after `run_turn`'s breakpoint drain, so the controller's `queue_depth` feature, the controllers' depth guards, and the `avg_queue_depth` benchmark metric were structurally always 0 in every mode. Moved the snapshot to before the drain (after expiry), so pending deposits from earlier turns are visible. The turn-N-deposit -> turn-N+1-consumption path itself was verified correct; no other ordering change was needed. Compatible with #49 persistent injection and #50 event ordering.

## Test plan

All via `uv run --extra dev --extra torch pytest -q` (1140 passed) and `ruff check src/ tests/` (clean).

- `tests/test_simulated_user.py`: completion floor per strictness (conversion below floor, acceptance at floor, STOP not converted, delay/confidence preserved), floor < all patience limits, prompt hardening assertions.
- `tests/test_scorer.py`: rationale-first schema (justification required and first), token cap raised, anchored-scale and full-range prompt assertions, judge responses at rubric levels 5..1 map to 5 distinct overall scores spanning [0,1] with std > 0.3 (no longer pinned at 1.0), justification-bearing responses parse cleanly.
- `tests/test_episode_runner.py` (`TestMultiTurnQueueIntegration`): mocked LLM transport + mocked tools, but real `EpisodeRunner`/`ConsciousLoop`/`ContextQueue`/`SimulatedUser` wiring. With the sim-user LLM scripted to complete on turn 1: default episodes run 2 turns (3 under high strictness); a turn-1 deposit is consumed at turn 2 (`consumed_at_turn == 2`) and the final scored answer demonstrably changes (contains the injected finding; control run without tools does not); `queue_expiry_turns=1` produces non-zero expiry and an unconsumed injection; with a real `RandomController`, `extract_task_metrics` reports `avg_queue_depth > 0` and `drain_count >= 1`.

**Deferred to the #46 re-run (needs live API keys):**
- Realistic turn-length distribution (clear majority > 1 turn) on real model runs — mocked tests only prove the floor and the wiring, not the LLM's organic follow-up behavior.
- Judge score variance/spread on a real mixed-quality answer set — the anchoring/rationale-first fix is prompt-level and can only be validated against the live judge.
- Tool invocations demonstrably changing scored answers (and quality separation across conditions) on real runs.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy