### PR TITLE
Partial: Evaluation dataset factory — registry, FRAMES/CREPE adapters, CLI flags

### DIFF
--- a/docs/hard_benchmark.md
+++ b/docs/hard_benchmark.md
@@ -1,5 +1,13 @@
 # Harder benchmark integration (Issue #42)
 
+> **Note (Issue #56):** the implementation now lives in the
+> `bicameral_agent.eval_datasets` package (`frames`, `crepe`, `hf_fetch`,
+> `hard`); `bicameral_agent.hard_benchmark` remains as a re-exporting shim, so
+> everything below still works as written. Datasets are also selectable by
+> name: `scripts/fetch_dataset.py --dataset hard_benchmark` to fetch, and
+> `scripts/run_baseline_benchmark.py --dataset hard_benchmark [--metric ...]`
+> to run against it.
+
 Replaces the saturated `research_qa` evaluation pool (which a frontier answerer
 one-shots, pinning the judge at ceiling — see the RCA in #41) with two harder,
 externally-sourced task pools that map onto the existing `ResearchQATask` shape.

--- a/scripts/fetch_dataset.py
+++ b/scripts/fetch_dataset.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fetch an external evaluation dataset into a local (git-ignored) cache.
+
+Generalizes ``fetch_hard_benchmark.py`` to every dataset registered in
+``bicameral_agent.eval_datasets``. The raw data is NOT redistributed in this
+repo; this script pulls a subset from upstream into ``data/external/<name>.json``
+for local use. Stdlib-only (urllib) -- no extra dependency.
+
+Usage:
+    python scripts/fetch_dataset.py --dataset frames [--limit N] [--out PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bicameral_agent.eval_datasets import build_dataset, dataset_names
+
+# The builtin pool ships inside the package; there is nothing to fetch.
+_FETCHABLE = [name for name in dataset_names() if name != "builtin"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default="hard_benchmark", choices=_FETCHABLE,
+                        help="Dataset to fetch (default: hard_benchmark).")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Tasks to pull (default: the dataset's default_limit).")
+    parser.add_argument("--out", type=Path, default=None,
+                        help="Cache path override (default: data/external/<name>.json).")
+    args = parser.parse_args(argv)
+
+    dataset = build_dataset(args.dataset, cache_path=args.out)
+    meta = dataset.meta
+    print(f"{meta.name}: source={meta.source}")
+    print(f"  license: {meta.license}")
+    if meta.citation:
+        print(f"  cite: {meta.citation}")
+
+    tasks = dataset.build(args.limit)
+    dist = Counter(t.difficulty.value for t in tasks)
+    print(f"Wrote {len(tasks)} tasks ({dict(dist)}) to {dataset.cache_path()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -27,6 +27,7 @@ from bicameral_agent.baseline_benchmark import format_report, run_benchmark
 from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
 from bicameral_agent.model_client import build_client
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
@@ -78,6 +79,13 @@ def main(argv: list[str] | None = None) -> int:
                              "(overrides the config file).")
     parser.add_argument("--model", default=None,
                         help="Model id/tag (overrides the config file).")
+    parser.add_argument("--dataset", choices=dataset_names(), default="builtin",
+                        help="Evaluation dataset to run against. External "
+                             "datasets must be fetched first via "
+                             "scripts/fetch_dataset.py.")
+    parser.add_argument("--metric", default=None,
+                        help="Verification metric (defaults to the dataset's "
+                             "default_metric; must be in its supported_metrics).")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
@@ -99,9 +107,13 @@ def main(argv: list[str] | None = None) -> int:
         HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
     ).with_env_overrides()
 
-    dataset = ResearchQADataset()
+    eval_dataset = build_dataset(args.dataset)
+    metric = resolve_metric(eval_dataset, args.metric)
+    dataset = eval_dataset.load()
     tasks = select_tasks(dataset, args.tasks_per_condition)
-    logger.info("Selected %d tasks for benchmark", len(tasks))
+    logger.info(
+        "Selected %d tasks from dataset %r (metric %r)", len(tasks), args.dataset, metric
+    )
 
     cost_tracker = hyper.to_cost_tracker()
     if args.episode_budget is not None:
@@ -111,9 +123,16 @@ def main(argv: list[str] | None = None) -> int:
     # The configured model name only applies to the configured provider.
     model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
     client = build_client(provider, model)
+    # EpisodeRunner's internal scorer selection is a boolean today (#45 owns
+    # that wiring); the two runnable metrics map onto it. The verifier
+    # registry (bicameral_agent.verifiers) is the named superset.
     runner = EpisodeRunner(
         client,
-        config=hyper.to_episode_config(max_turns=args.max_turns, score_episode=True),
+        config=hyper.to_episode_config(
+            max_turns=args.max_turns,
+            score_episode=True,
+            use_lexical_scorer=(metric == "lexical"),
+        ),
         hyper_config=hyper,
         cost_tracker=cost_tracker,
     )
@@ -146,6 +165,8 @@ def main(argv: list[str] | None = None) -> int:
     sys.stdout.write(report_text)
 
     summary = {
+        "dataset": args.dataset,
+        "metric": metric,
         "tasks_per_condition": args.tasks_per_condition,
         "max_turns": args.max_turns,
         "conditions": {

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -36,6 +36,26 @@ from bicameral_agent.serialization import episodes_to_parquet
 
 logger = logging.getLogger(__name__)
 
+# EpisodeRunner expresses scorer choice as a boolean (use_lexical_scorer)
+# today -- #45 owns that wiring -- so only these two metrics are runnable.
+_RUNNABLE_METRICS = ("llm_judge", "lexical")
+
+
+def ensure_runnable_metric(metric: str) -> str:
+    """Refuse metrics EpisodeRunner cannot express yet.
+
+    Guards the metric -> use_lexical_scorer boolean collapse below: a future
+    verifier registered in ``bicameral_agent.verifiers`` must fail loudly here
+    rather than silently fall back to the LLM judge.
+    """
+    if metric not in _RUNNABLE_METRICS:
+        raise ValueError(
+            f"Metric {metric!r} cannot be run by EpisodeRunner yet; runnable "
+            f"metrics: {list(_RUNNABLE_METRICS)}. New verifiers need runner "
+            "wiring through bicameral_agent.verifiers.build_verifier first."
+        )
+    return metric
+
 
 def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]:
     """Stratified pick of eval tasks across typical / hard / tricky.
@@ -108,7 +128,7 @@ def main(argv: list[str] | None = None) -> int:
     ).with_env_overrides()
 
     eval_dataset = build_dataset(args.dataset)
-    metric = resolve_metric(eval_dataset, args.metric)
+    metric = ensure_runnable_metric(resolve_metric(eval_dataset, args.metric))
     dataset = eval_dataset.load()
     tasks = select_tasks(dataset, args.tasks_per_condition)
     logger.info(
@@ -123,9 +143,8 @@ def main(argv: list[str] | None = None) -> int:
     # The configured model name only applies to the configured provider.
     model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
     client = build_client(provider, model)
-    # EpisodeRunner's internal scorer selection is a boolean today (#45 owns
-    # that wiring); the two runnable metrics map onto it. The verifier
-    # registry (bicameral_agent.verifiers) is the named superset.
+    # The resolved metric passed ensure_runnable_metric, so this boolean
+    # collapse is exhaustive over _RUNNABLE_METRICS.
     runner = EpisodeRunner(
         client,
         config=hyper.to_episode_config(

--- a/src/bicameral_agent/eval_datasets/__init__.py
+++ b/src/bicameral_agent/eval_datasets/__init__.py
@@ -1,0 +1,75 @@
+"""Evaluation-dataset factory: pick a benchmark by name (Issue #56).
+
+Mirrors ``model_client.build_client``: a plain dict registry, no decorators or
+entry points. Adding a benchmark = one small adapter module + one registry
+line. The package is named ``eval_datasets`` to avoid colliding with HF's
+``datasets``.
+"""
+
+from __future__ import annotations
+
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+from bicameral_agent.eval_datasets.builtin import BuiltinPool
+from bicameral_agent.eval_datasets.crepe import Crepe
+from bicameral_agent.eval_datasets.frames import Frames
+from bicameral_agent.eval_datasets.hard import HardBenchmark
+
+__all__ = [
+    "BuiltinPool",
+    "Crepe",
+    "DatasetMeta",
+    "EvalDataset",
+    "Frames",
+    "HardBenchmark",
+    "build_dataset",
+    "dataset_names",
+    "resolve_metric",
+]
+
+_REGISTRY: dict[str, type[EvalDataset]] = {
+    "builtin": BuiltinPool,
+    "frames": Frames,
+    "crepe": Crepe,
+    "hard_benchmark": HardBenchmark,
+}
+
+
+def dataset_names() -> list[str]:
+    """Names of all registered datasets."""
+    return sorted(_REGISTRY)
+
+
+def build_dataset(name: str = "builtin", **opts) -> EvalDataset:
+    """Construct the evaluation dataset registered under *name*.
+
+    Args:
+        name: Registry key (see :func:`dataset_names`).
+        **opts: Forwarded to the adapter constructor (e.g. ``cache_path``,
+            or ``frames_n``/``crepe_n`` for ``hard_benchmark``).
+
+    Raises:
+        ValueError: If *name* is not registered.
+    """
+    try:
+        cls = _REGISTRY[name]
+    except KeyError:
+        raise ValueError(
+            f"Unknown dataset {name!r}; known datasets: {sorted(_REGISTRY)}"
+        ) from None
+    return cls(**opts)
+
+
+def resolve_metric(dataset: EvalDataset, override: str | None = None) -> str:
+    """Resolve the verification metric for *dataset*.
+
+    Returns the dataset's ``default_metric`` unless *override* is given, in
+    which case it is validated against the dataset's ``supported_metrics``.
+    """
+    if override is None:
+        return dataset.default_metric
+    if override not in dataset.supported_metrics:
+        raise ValueError(
+            f"Metric {override!r} is not supported by dataset "
+            f"{dataset.meta.name!r}; supported: {list(dataset.supported_metrics)}"
+        )
+    return override

--- a/src/bicameral_agent/eval_datasets/base.py
+++ b/src/bicameral_agent/eval_datasets/base.py
@@ -1,0 +1,102 @@
+"""Adapter base class for plug-and-play evaluation datasets (Issue #56).
+
+Each external benchmark is one small :class:`EvalDataset` subclass that maps
+upstream rows into the existing :class:`ResearchQATask` shape. The lifecycle is
+uniform across datasets:
+
+- ``build(limit)`` fetches from upstream and writes a normalized JSON cache
+  under ``data/external/<name>.json`` (git-ignored; no data is redistributed).
+- ``load()`` reads that cache into a :class:`ResearchQADataset`, raising an
+  actionable ``FileNotFoundError`` if it has not been fetched yet.
+- ``default_metric`` names the verifier the dataset should be scored with
+  (see :mod:`bicameral_agent.verifiers`), overridable within
+  ``supported_metrics``.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+from bicameral_agent.dataset import ResearchQADataset, ResearchQATask
+
+# Anchored to the repo root (this file lives at src/bicameral_agent/eval_datasets/)
+# so caches resolve to the same place regardless of the caller's CWD.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+EXTERNAL_DATA_DIR = _REPO_ROOT / "data" / "external"
+
+
+class DatasetMeta(BaseModel):
+    """Provenance and licensing record for an evaluation dataset."""
+
+    name: str
+    source: str
+    """HF repo id, GitHub URL, or packaged-data path."""
+    license: str
+    citation: str
+    requires_hf_token: bool = False
+
+
+class EvalDataset(ABC):
+    """Base adapter: fetch-at-build into a git-ignored cache, load as tasks."""
+
+    meta: ClassVar[DatasetMeta]
+    default_metric: ClassVar[str]
+    """Verifier-registry key (see bicameral_agent.verifiers.build_verifier)."""
+    supported_metrics: ClassVar[tuple[str, ...]]
+    default_limit: int
+    """Tasks fetched by ``build()`` when no explicit limit is given."""
+
+    def __init__(self, cache_path: Path | str | None = None) -> None:
+        self._cache_override = Path(cache_path) if cache_path is not None else None
+
+    def cache_path(self) -> Path:
+        """Location of the local JSON cache for this dataset."""
+        if self._cache_override is not None:
+            return self._cache_override
+        return EXTERNAL_DATA_DIR / f"{self.meta.name}.json"
+
+    @abstractmethod
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        """Pull up to *limit* tasks from upstream (network)."""
+
+    def build(self, limit: int | None = None) -> list[ResearchQATask]:
+        """Fetch from upstream and write the normalized JSON cache.
+
+        Raises:
+            RuntimeError: If the fetch yields fewer tasks than requested, so a
+                partial upstream response cannot produce a silent short benchmark.
+        """
+        n = limit if limit is not None else self.default_limit
+        tasks = self.fetch_tasks(n)
+        if len(tasks) != n:
+            raise RuntimeError(
+                f"Fetched {len(tasks)}/{n} {self.meta.name} tasks; refusing to "
+                "write a short benchmark cache."
+            )
+        path = self.cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps([t.model_dump(mode="json") for t in tasks], indent=2),
+            encoding="utf-8",
+        )
+        return tasks
+
+    def load(self) -> ResearchQADataset:
+        """Load the cached tasks into a :class:`ResearchQADataset`.
+
+        Raises ``FileNotFoundError`` with fetch instructions if the cache is
+        absent (external data is not committed to the repo).
+        """
+        path = self.cache_path()
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Dataset cache for {self.meta.name!r} not found at {path}. "
+                "External data is not committed to the repo -- run "
+                f"`python scripts/fetch_dataset.py --dataset {self.meta.name}` first."
+            )
+        return ResearchQADataset.from_path(path)

--- a/src/bicameral_agent/eval_datasets/builtin.py
+++ b/src/bicameral_agent/eval_datasets/builtin.py
@@ -1,0 +1,38 @@
+"""Adapter for the packaged built-in research QA pool.
+
+Wraps the bundled 130-task ``research_qa.json`` so the built-in pool goes
+through the same factory as external benchmarks. ``--dataset builtin`` is
+exactly today's behavior: nothing is fetched or cached.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQADataset, ResearchQATask
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+
+class BuiltinPool(EvalDataset):
+    """The packaged research QA evaluation pool."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="builtin",
+        source="bicameral_agent/data/research_qa.json (bundled)",
+        license="Project-owned",
+        citation="",
+    )
+    default_metric: ClassVar[str] = "llm_judge"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("llm_judge", "lexical")
+    default_limit = 130
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        """No network: the pool ships inside the package."""
+        return self.load().tasks[:limit]
+
+    def build(self, limit: int | None = None) -> list[ResearchQATask]:
+        """No-op fetch: bundled data needs no external cache."""
+        return self.load().tasks
+
+    def load(self) -> ResearchQADataset:
+        return ResearchQADataset()

--- a/src/bicameral_agent/eval_datasets/crepe.py
+++ b/src/bicameral_agent/eval_datasets/crepe.py
@@ -1,0 +1,84 @@
+"""CREPE adapter: false-presupposition QA mapped to the ``tricky`` tier.
+
+Pulled via the ``tasksource/CREPE`` re-host of the false-presupposition CREPE
+(arXiv:2211.17257), which carries the presuppositions/corrections annotations
+we map from. Upstream declares no license, so the data is fetch-only -- never
+redistributed. See ``docs/hard_benchmark.md``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+CREPE_DATASET = "tasksource/CREPE"
+
+
+def crepe_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one raw CREPE false-presupposition row into a ``tricky`` task.
+
+    The annotated presupposition(s) become ``known_assumptions`` and the
+    annotated correction(s) become the gold answer.
+    """
+    question = (row.get("question") or "").strip()
+    presups = [p.strip() for p in (row.get("presuppositions") or []) if p and p.strip()]
+    corrections = [c.strip() for c in (row.get("corrections") or []) if c and c.strip()]
+    gold = " ".join(corrections)
+    rubric = (
+        "5: Flags that the question rests on a false presupposition AND states "
+        "the correction. 4: Identifies the false premise but corrects it "
+        "vaguely. 3: Hedges or only partially questions the premise. 2: Answers "
+        "as asked without noticing the false premise. 1: Affirms the false "
+        "premise."
+    )
+    return ResearchQATask(
+        task_id=f"crepe_tricky_{index:03d}",
+        difficulty=TaskDifficulty.TRICKY,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=gold,
+        scoring_rubric=rubric,
+        known_assumptions=presups,
+    )
+
+
+def fetch_crepe(limit: int = 60, split: str = "test") -> list[ResearchQATask]:
+    """Scan CREPE and map false-presupposition rows to ``tricky`` tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(CREPE_DATASET, split, offset, 100)
+        if not page:
+            break
+        for raw in page:
+            presups = [p for p in (raw.get("presuppositions") or []) if p and p.strip()]
+            corrections = [c for c in (raw.get("corrections") or []) if c and c.strip()]
+            if presups and corrections:
+                tasks.append(crepe_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class Crepe(EvalDataset):
+    """CREPE false-presupposition QA (``tricky`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="crepe",
+        source=CREPE_DATASET,
+        license="None declared (NOASSERTION) -- fetch-only, do not redistribute",
+        citation=(
+            "CREPE: Open-Domain Question Answering with False Presuppositions, "
+            "Yu et al., ACL 2023 (arXiv:2211.17257)"
+        ),
+    )
+    default_metric: ClassVar[str] = "llm_judge"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("llm_judge", "lexical")
+    default_limit = 60
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_crepe(limit)

--- a/src/bicameral_agent/eval_datasets/frames.py
+++ b/src/bicameral_agent/eval_datasets/frames.py
@@ -1,0 +1,79 @@
+"""FRAMES adapter: multi-hop factual QA mapped to the ``hard`` tier.
+
+``google/frames-benchmark`` (Apache-2.0): questions requiring synthesis across
+several Wikipedia articles. See ``docs/hard_benchmark.md`` for the field
+mapping, licensing, and attribution.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+FRAMES_DATASET = "google/frames-benchmark"
+
+
+def frames_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one raw FRAMES row into a ``hard`` ResearchQATask.
+
+    FRAMES ships no rubric, so we synthesize one anchored on the gold answer
+    and the multi-hop reasoning the question demands.
+    """
+    question = (row.get("Prompt") or "").strip()
+    answer = (row.get("Answer") or "").strip()
+    rubric = (
+        f"5: States the correct answer ('{answer}') and shows the multi-hop "
+        "reasoning linking the required facts. 4: Correct answer with thin "
+        "justification. 3: Partially correct, or correct answer with no "
+        "reasoning. 2: Relevant facts but wrong final answer. 1: Incorrect."
+    )
+    return ResearchQATask(
+        task_id=f"frames_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=answer,
+        scoring_rubric=rubric,
+    )
+
+
+def fetch_frames(limit: int = 100, split: str = "test") -> list[ResearchQATask]:
+    """Pull a subset of FRAMES rows and map them to ``hard`` tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(
+            FRAMES_DATASET, split, offset, min(100, limit - len(tasks))
+        )
+        if not page:
+            break
+        for raw in page:
+            if (raw.get("Prompt") or "").strip() and (raw.get("Answer") or "").strip():
+                tasks.append(frames_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class Frames(EvalDataset):
+    """FRAMES multi-hop QA (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="frames",
+        source=FRAMES_DATASET,
+        license="Apache-2.0",
+        citation=(
+            "Fact, Fetch, and Reason: A Unified Evaluation of "
+            "Retrieval-Augmented Generation (arXiv:2409.12941)"
+        ),
+    )
+    default_metric: ClassVar[str] = "llm_judge"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("llm_judge", "lexical")
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_frames(limit)

--- a/src/bicameral_agent/eval_datasets/hard.py
+++ b/src/bicameral_agent/eval_datasets/hard.py
@@ -1,0 +1,85 @@
+"""Composite hard-benchmark adapter: FRAMES (hard) + CREPE (tricky) combined.
+
+Preserves the Issue #42 artifact: the same ``data/external/hard_benchmark.json``
+cache file, so previously fetched caches remain valid. The public
+``build_hard_benchmark`` / ``load_hard_benchmark`` functions back the
+``bicameral_agent.hard_benchmark`` compatibility shim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQADataset, ResearchQATask
+from bicameral_agent.eval_datasets import crepe as crepe_mod
+from bicameral_agent.eval_datasets import frames as frames_mod
+from bicameral_agent.eval_datasets.base import EXTERNAL_DATA_DIR, DatasetMeta, EvalDataset
+
+DEFAULT_CACHE = EXTERNAL_DATA_DIR / "hard_benchmark.json"
+
+
+class HardBenchmark(EvalDataset):
+    """FRAMES + CREPE combined pool (mixed hard/tricky difficulties)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="hard_benchmark",
+        source=f"{frames_mod.FRAMES_DATASET} + {crepe_mod.CREPE_DATASET}",
+        license=(
+            "FRAMES: Apache-2.0; CREPE: none declared -- fetch-only, "
+            "do not redistribute"
+        ),
+        citation="arXiv:2409.12941 (FRAMES); arXiv:2211.17257 (CREPE)",
+    )
+    default_metric: ClassVar[str] = "llm_judge"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("llm_judge", "lexical")
+
+    def __init__(
+        self,
+        frames_n: int = 100,
+        crepe_n: int = 60,
+        cache_path: Path | str | None = None,
+    ) -> None:
+        super().__init__(cache_path)
+        self.frames_n = frames_n
+        self.crepe_n = crepe_n
+        self.default_limit = frames_n + crepe_n
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        if limit != self.frames_n + self.crepe_n:
+            raise ValueError(
+                "hard_benchmark sizing is set via the frames_n/crepe_n options, "
+                f"not a flat limit (got limit={limit}, "
+                f"frames_n={self.frames_n} + crepe_n={self.crepe_n})"
+            )
+        frames = frames_mod.fetch_frames(self.frames_n)
+        crepe = crepe_mod.fetch_crepe(self.crepe_n)
+        if len(frames) != self.frames_n or len(crepe) != self.crepe_n:
+            raise RuntimeError(
+                f"Fetched {len(frames)}/{self.frames_n} FRAMES and "
+                f"{len(crepe)}/{self.crepe_n} CREPE tasks; refusing to write a "
+                "short benchmark cache."
+            )
+        return frames + crepe
+
+
+def build_hard_benchmark(
+    frames_n: int = 100,
+    crepe_n: int = 60,
+    cache_path: Path = DEFAULT_CACHE,
+) -> list[ResearchQATask]:
+    """Fetch subsets from upstream and write a normalized JSON cache.
+
+    The cache file is git-ignored; it is the artifact :func:`load_hard_benchmark`
+    reads. Returns the combined task list.
+
+    Raises:
+        RuntimeError: If either fetch yields fewer tasks than requested, so a
+            partial upstream response cannot produce a silent short benchmark.
+    """
+    return HardBenchmark(frames_n=frames_n, crepe_n=crepe_n, cache_path=cache_path).build()
+
+
+def load_hard_benchmark(cache_path: Path = DEFAULT_CACHE) -> ResearchQADataset:
+    """Load the cached hard-benchmark tasks into a :class:`ResearchQADataset`."""
+    return HardBenchmark(cache_path=cache_path).load()

--- a/src/bicameral_agent/eval_datasets/hf_fetch.py
+++ b/src/bicameral_agent/eval_datasets/hf_fetch.py
@@ -1,0 +1,64 @@
+"""Stdlib-only pager for the Hugging Face datasets-server rows API.
+
+Extracted from ``hard_benchmark.py`` (Issue #56) so every HF-backed dataset
+adapter shares one hardened fetch path: retries on rate-limit/5xx/network
+errors with exponential backoff, and refuses to treat an error payload as an
+empty terminal page (which would silently truncate a benchmark).
+
+No HF ``datasets``/``pandas`` dependency, per repo policy -- plain ``urllib``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HF_ROWS_ENDPOINT = "https://datasets-server.huggingface.co/rows"
+USER_AGENT = "bicameral-agent/0.1 (research eval; issue-42)"
+
+# The HF datasets-server rate-limits routinely; retry transient failures
+# with exponential backoff before giving up.
+MAX_ATTEMPTS = 4
+RETRY_BASE_DELAY_S = 2.0
+RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def http_get_json(url: str) -> dict:
+    """GET *url* as JSON, retrying transient (rate-limit / 5xx / network) errors."""
+    last_err: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(RETRY_BASE_DELAY_S * 2 ** (attempt - 1))
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as err:
+            if err.code not in RETRYABLE_HTTP_CODES:
+                raise
+            last_err = err
+        except urllib.error.URLError as err:
+            last_err = err
+    raise RuntimeError(
+        f"Giving up on {url} after {MAX_ATTEMPTS} attempts: {last_err}"
+    ) from last_err
+
+
+def fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict]:
+    """Fetch one page of raw rows from the datasets-server rows API."""
+    url = (
+        f"{HF_ROWS_ENDPOINT}?dataset={urllib.parse.quote(dataset)}"
+        f"&config=default&split={split}&offset={offset}&length={length}"
+    )
+    payload = http_get_json(url)
+    if "rows" not in payload:
+        # An error payload (e.g. rate-limit body) must not read as an empty
+        # terminal page — that silently truncates the benchmark.
+        raise RuntimeError(
+            f"Unexpected datasets-server payload for {dataset} at offset {offset}: "
+            f"{payload.get('error', payload)!r}"
+        )
+    return [row["row"] for row in payload["rows"]]

--- a/src/bicameral_agent/hard_benchmark.py
+++ b/src/bicameral_agent/hard_benchmark.py
@@ -1,224 +1,32 @@
-"""Loaders for harder external benchmark datasets (Issue #42).
+"""Back-compat shim: the hard benchmark moved into ``eval_datasets`` (Issue #56).
 
-Maps two external benchmarks into the existing :class:`ResearchQATask` shape to
-give the evaluation pool real headroom above the saturated ``research_qa`` pool
-(see the RCA in issue #41):
-
-- **FRAMES** (``google/frames-benchmark``, Apache-2.0): multi-hop factual QA
-  requiring synthesis across several Wikipedia articles -> mapped to ``hard``.
-- **CREPE** (false-presupposition QA, arXiv:2211.17257): questions built on a
-  false premise, with the presupposition and its correction annotated ->
-  mapped to ``tricky``.
-
-The raw data is **not redistributed** in this repository. :func:`build_hard_benchmark`
-pulls subsets from upstream into a local, git-ignored cache; the pure
-``*_row_to_task`` mappers are import-safe and unit-tested offline against a
-synthetic fixture. See ``docs/hard_benchmark.md`` for sources, licenses, and
-attribution, and for the fallback datasets to watch for.
+The FRAMES/CREPE mappers, the datasets-server pager, and the fetch/load
+lifecycle now live in :mod:`bicameral_agent.eval_datasets` (``frames``,
+``crepe``, ``hf_fetch``, ``hard``). This module re-exports the original public
+surface so existing callers (``scripts/fetch_hard_benchmark.py``, docs) keep
+working; new code should use ``build_dataset("hard_benchmark")``.
 """
 
 from __future__ import annotations
 
-import json
-import time
-import urllib.error
-import urllib.parse
-import urllib.request
-from pathlib import Path
+from bicameral_agent.eval_datasets.crepe import CREPE_DATASET, crepe_row_to_task, fetch_crepe
+from bicameral_agent.eval_datasets.frames import FRAMES_DATASET, fetch_frames, frames_row_to_task
+from bicameral_agent.eval_datasets.hard import (
+    DEFAULT_CACHE as _DEFAULT_CACHE,
+)
+from bicameral_agent.eval_datasets.hard import (
+    build_hard_benchmark,
+    load_hard_benchmark,
+)
 
-from .dataset import ResearchQADataset, ResearchQATask, TaskDifficulty, TaskSplit
-
-FRAMES_DATASET = "google/frames-benchmark"
-# tasksource re-host of the false-presupposition CREPE (arXiv:2211.17257);
-# carries the presuppositions/corrections annotations we map from.
-CREPE_DATASET = "tasksource/CREPE"
-
-_HF_ROWS_ENDPOINT = "https://datasets-server.huggingface.co/rows"
-# Anchored to the repo root (this file lives at src/bicameral_agent/) so the
-# cache resolves to the same place regardless of the caller's CWD.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_CACHE = _REPO_ROOT / "data" / "external" / "hard_benchmark.json"
-_USER_AGENT = "bicameral-agent/0.1 (research eval; issue-42)"
-
-# The HF datasets-server rate-limits routinely; retry transient failures
-# with exponential backoff before giving up.
-_MAX_ATTEMPTS = 4
-_RETRY_BASE_DELAY_S = 2.0
-_RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
-
-
-# --- pure mappers (offline-testable) ----------------------------------------
-
-def frames_row_to_task(row: dict, index: int) -> ResearchQATask:
-    """Map one raw FRAMES row into a ``hard`` ResearchQATask.
-
-    FRAMES ships no rubric, so we synthesize one anchored on the gold answer
-    and the multi-hop reasoning the question demands.
-    """
-    question = (row.get("Prompt") or "").strip()
-    answer = (row.get("Answer") or "").strip()
-    rubric = (
-        f"5: States the correct answer ('{answer}') and shows the multi-hop "
-        "reasoning linking the required facts. 4: Correct answer with thin "
-        "justification. 3: Partially correct, or correct answer with no "
-        "reasoning. 2: Relevant facts but wrong final answer. 1: Incorrect."
-    )
-    return ResearchQATask(
-        task_id=f"frames_hard_{index:03d}",
-        difficulty=TaskDifficulty.HARD,
-        split=TaskSplit.EVAL,
-        question=question,
-        gold_answer=answer,
-        scoring_rubric=rubric,
-    )
-
-
-def crepe_row_to_task(row: dict, index: int) -> ResearchQATask:
-    """Map one raw CREPE false-presupposition row into a ``tricky`` task.
-
-    The annotated presupposition(s) become ``known_assumptions`` and the
-    annotated correction(s) become the gold answer.
-    """
-    question = (row.get("question") or "").strip()
-    presups = [p.strip() for p in (row.get("presuppositions") or []) if p and p.strip()]
-    corrections = [c.strip() for c in (row.get("corrections") or []) if c and c.strip()]
-    gold = " ".join(corrections)
-    rubric = (
-        "5: Flags that the question rests on a false presupposition AND states "
-        "the correction. 4: Identifies the false premise but corrects it "
-        "vaguely. 3: Hedges or only partially questions the premise. 2: Answers "
-        "as asked without noticing the false premise. 1: Affirms the false "
-        "premise."
-    )
-    return ResearchQATask(
-        task_id=f"crepe_tricky_{index:03d}",
-        difficulty=TaskDifficulty.TRICKY,
-        split=TaskSplit.EVAL,
-        question=question,
-        gold_answer=gold,
-        scoring_rubric=rubric,
-        known_assumptions=presups,
-    )
-
-
-# --- upstream fetch ---------------------------------------------------------
-
-def _http_get_json(url: str) -> dict:
-    """GET *url* as JSON, retrying transient (rate-limit / 5xx / network) errors."""
-    last_err: Exception | None = None
-    for attempt in range(_MAX_ATTEMPTS):
-        if attempt > 0:
-            time.sleep(_RETRY_BASE_DELAY_S * 2 ** (attempt - 1))
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
-            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
-                return json.loads(resp.read())
-        except urllib.error.HTTPError as err:
-            if err.code not in _RETRYABLE_HTTP_CODES:
-                raise
-            last_err = err
-        except urllib.error.URLError as err:
-            last_err = err
-    raise RuntimeError(
-        f"Giving up on {url} after {_MAX_ATTEMPTS} attempts: {last_err}"
-    ) from last_err
-
-
-def _fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict]:
-    url = (
-        f"{_HF_ROWS_ENDPOINT}?dataset={urllib.parse.quote(dataset)}"
-        f"&config=default&split={split}&offset={offset}&length={length}"
-    )
-    payload = _http_get_json(url)
-    if "rows" not in payload:
-        # An error payload (e.g. rate-limit body) must not read as an empty
-        # terminal page — that silently truncates the benchmark.
-        raise RuntimeError(
-            f"Unexpected datasets-server payload for {dataset} at offset {offset}: "
-            f"{payload.get('error', payload)!r}"
-        )
-    return [row["row"] for row in payload["rows"]]
-
-
-def fetch_frames(limit: int = 100, split: str = "test") -> list[ResearchQATask]:
-    """Pull a subset of FRAMES rows and map them to ``hard`` tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = _fetch_page(FRAMES_DATASET, split, offset, min(100, limit - len(tasks)))
-        if not page:
-            break
-        for raw in page:
-            if (raw.get("Prompt") or "").strip() and (raw.get("Answer") or "").strip():
-                tasks.append(frames_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
-
-
-def fetch_crepe(limit: int = 60, split: str = "test") -> list[ResearchQATask]:
-    """Scan CREPE and map false-presupposition rows to ``tricky`` tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = _fetch_page(CREPE_DATASET, split, offset, 100)
-        if not page:
-            break
-        for raw in page:
-            presups = [p for p in (raw.get("presuppositions") or []) if p and p.strip()]
-            corrections = [c for c in (raw.get("corrections") or []) if c and c.strip()]
-            if presups and corrections:
-                tasks.append(crepe_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
-
-
-def build_hard_benchmark(
-    frames_n: int = 100,
-    crepe_n: int = 60,
-    cache_path: Path = _DEFAULT_CACHE,
-) -> list[ResearchQATask]:
-    """Fetch subsets from upstream and write a normalized JSON cache.
-
-    The cache file is git-ignored; it is the artifact :func:`load_hard_benchmark`
-    reads. Returns the combined task list.
-
-    Raises:
-        RuntimeError: If either fetch yields fewer tasks than requested, so a
-            partial upstream response cannot produce a silent short benchmark.
-    """
-    frames = fetch_frames(frames_n)
-    crepe = fetch_crepe(crepe_n)
-    if len(frames) != frames_n or len(crepe) != crepe_n:
-        raise RuntimeError(
-            f"Fetched {len(frames)}/{frames_n} FRAMES and {len(crepe)}/{crepe_n} "
-            "CREPE tasks; refusing to write a short benchmark cache."
-        )
-    tasks = frames + crepe
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(
-        json.dumps([t.model_dump(mode="json") for t in tasks], indent=2),
-        encoding="utf-8",
-    )
-    return tasks
-
-
-# --- read path --------------------------------------------------------------
-
-def load_hard_benchmark(cache_path: Path = _DEFAULT_CACHE) -> ResearchQADataset:
-    """Load the cached hard-benchmark tasks into a :class:`ResearchQADataset`.
-
-    Raises ``FileNotFoundError`` with fetch instructions if the cache is absent
-    (the data is not committed to the repo).
-    """
-    cache_path = Path(cache_path)
-    if not cache_path.exists():
-        raise FileNotFoundError(
-            f"Hard benchmark cache not found at {cache_path}. The data is not "
-            "committed to the repo -- run `python scripts/fetch_hard_benchmark.py` "
-            "first. See docs/hard_benchmark.md for sources and attribution."
-        )
-    return ResearchQADataset.from_path(cache_path)
+__all__ = [
+    "CREPE_DATASET",
+    "FRAMES_DATASET",
+    "_DEFAULT_CACHE",
+    "build_hard_benchmark",
+    "crepe_row_to_task",
+    "fetch_crepe",
+    "fetch_frames",
+    "frames_row_to_task",
+    "load_hard_benchmark",
+]

--- a/src/bicameral_agent/verifiers.py
+++ b/src/bicameral_agent/verifiers.py
@@ -1,0 +1,57 @@
+"""Verifier registry: pick a scoring backend by metric name (Issue #56).
+
+Formalizes the contract that ``TaskScorer`` / ``LexicalScorer`` already
+duck-type -- ``score(task, answer) -> TaskScore`` -- as a plain dict registry
+mirroring ``model_client.build_client``. Datasets declare a ``default_metric``
+(overridable within their ``supported_metrics``); callers turn the resolved
+metric name into a concrete verifier here. Future deterministic/rubric
+verifiers (exact match, multiple choice, rubric coverage, ...) register the
+same way.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Protocol, runtime_checkable
+
+from bicameral_agent.dataset import ResearchQATask
+from bicameral_agent.scorer import LexicalScorer, TaskScore, TaskScorer
+
+
+@runtime_checkable
+class Verifier(Protocol):
+    """Anything that scores an agent answer against a task."""
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore: ...
+
+
+# client -> verifier factories; ``client`` is any model client satisfying the
+# build_client contract (only LLM-backed verifiers use it).
+_VERIFIERS: dict[str, Callable[[object | None], Verifier]] = {
+    "llm_judge": lambda client: TaskScorer(client=client),
+    "lexical": lambda client: LexicalScorer(),
+}
+
+
+def verifier_names() -> list[str]:
+    """Names of all registered verification metrics."""
+    return sorted(_VERIFIERS)
+
+
+def build_verifier(metric: str = "llm_judge", client: object | None = None) -> Verifier:
+    """Construct the verifier registered under *metric*.
+
+    Args:
+        metric: Registry key (see :func:`verifier_names`).
+        client: Model client for LLM-backed verifiers; None uses the
+            verifier's own default. Ignored by deterministic verifiers.
+
+    Raises:
+        ValueError: If *metric* is not registered.
+    """
+    try:
+        factory = _VERIFIERS[metric]
+    except KeyError:
+        raise ValueError(
+            f"Unknown metric {metric!r}; known metrics: {sorted(_VERIFIERS)}"
+        ) from None
+    return factory(client)

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -116,3 +116,25 @@ class TestAdapterLifecycle:
     def test_hard_benchmark_rejects_flat_limit(self):
         with pytest.raises(ValueError, match="frames_n/crepe_n"):
             HardBenchmark(frames_n=2, crepe_n=2).build(limit=3)
+
+
+class TestRunnableMetricGuard:
+    """The benchmark script's metric -> use_lexical_scorer collapse must fail
+    loudly for any future verifier the runner cannot express yet."""
+
+    @pytest.fixture()
+    def ensure_runnable_metric(self, monkeypatch):
+        monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
+        from run_baseline_benchmark import ensure_runnable_metric
+
+        return ensure_runnable_metric
+
+    def test_runnable_metrics_pass_through(self, ensure_runnable_metric):
+        assert ensure_runnable_metric("llm_judge") == "llm_judge"
+        assert ensure_runnable_metric("lexical") == "lexical"
+
+    def test_unwired_metric_raises_instead_of_llm_judge_fallback(
+        self, ensure_runnable_metric
+    ):
+        with pytest.raises(ValueError, match="build_verifier"):
+            ensure_runnable_metric("exact_match")

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -1,0 +1,118 @@
+"""Tests for the evaluation-dataset factory (Issue #56).
+
+Fully offline: adapters are exercised against monkeypatched pagers and tmp
+caches; no network and no externally-licensed data are required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from bicameral_agent.dataset import ResearchQADataset, TaskDifficulty
+from bicameral_agent.eval_datasets import (
+    BuiltinPool,
+    Crepe,
+    Frames,
+    HardBenchmark,
+    _REGISTRY,
+    build_dataset,
+    dataset_names,
+    resolve_metric,
+)
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import EXTERNAL_DATA_DIR
+from bicameral_agent.verifiers import verifier_names
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _frames_page(start: int, n: int) -> list[dict]:
+    return [{"Prompt": f"q {i}?", "Answer": f"a {i}"} for i in range(start, start + n)]
+
+
+class TestRegistry:
+    def test_known_names(self):
+        assert dataset_names() == ["builtin", "crepe", "frames", "hard_benchmark"]
+
+    def test_build_dataset_dispatches(self):
+        assert isinstance(build_dataset("builtin"), BuiltinPool)
+        assert isinstance(build_dataset("frames"), Frames)
+        assert isinstance(build_dataset("crepe"), Crepe)
+        assert isinstance(build_dataset("hard_benchmark"), HardBenchmark)
+
+    def test_unknown_name_lists_known(self):
+        with pytest.raises(ValueError, match="builtin"):
+            build_dataset("nope")
+
+    def test_opts_forwarded_to_adapter(self):
+        ds = build_dataset("hard_benchmark", frames_n=2, crepe_n=3)
+        assert ds.default_limit == 5
+
+    def test_every_adapter_declares_meta_and_metrics(self):
+        for name, cls in _REGISTRY.items():
+            assert cls.meta.name == name  # cache path derives from meta.name
+            assert cls.meta.license
+            assert cls.default_metric in cls.supported_metrics
+            # Every declared metric must be constructible via the verifier registry.
+            for metric in cls.supported_metrics:
+                assert metric in verifier_names()
+
+
+class TestResolveMetric:
+    def test_defaults_to_dataset_metric(self):
+        assert resolve_metric(BuiltinPool()) == "llm_judge"
+
+    def test_valid_override_wins(self):
+        assert resolve_metric(BuiltinPool(), "lexical") == "lexical"
+
+    def test_unsupported_override_rejected(self):
+        with pytest.raises(ValueError, match="not supported"):
+            resolve_metric(BuiltinPool(), "multiple_choice")
+
+
+class TestBuiltinPool:
+    def test_load_is_the_packaged_pool(self):
+        ds = BuiltinPool().load()
+        assert isinstance(ds, ResearchQADataset)
+        assert len(ds) == len(ResearchQADataset())
+
+    def test_build_writes_no_cache(self, tmp_path):
+        cache = tmp_path / "builtin.json"
+        tasks = BuiltinPool(cache_path=cache).build()
+        assert tasks  # returns the bundled tasks...
+        assert not cache.exists()  # ...without materializing a cache file
+
+
+class TestAdapterLifecycle:
+    def test_default_cache_is_repo_root_anchored(self):
+        assert EXTERNAL_DATA_DIR == REPO_ROOT / "data" / "external"
+        assert Frames().cache_path() == EXTERNAL_DATA_DIR / "frames.json"
+        assert Crepe().cache_path() == EXTERNAL_DATA_DIR / "crepe.json"
+        assert HardBenchmark().cache_path() == EXTERNAL_DATA_DIR / "hard_benchmark.json"
+
+    def test_build_then_load_round_trip(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda ds, split, offset, length: _frames_page(offset, length)
+        )
+        cache = tmp_path / "frames.json"
+        built = Frames(cache_path=cache).build(limit=3)
+        assert len(built) == 3
+        loaded = Frames(cache_path=cache).load()
+        assert [t.task_id for t in loaded] == [t.task_id for t in built]
+        assert all(t.difficulty == TaskDifficulty.HARD for t in loaded)
+
+    def test_short_fetch_refuses_to_write_cache(self, monkeypatch, tmp_path):
+        pages = [_frames_page(0, 2), []]
+        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a: pages.pop(0))
+        cache = tmp_path / "frames.json"
+        with pytest.raises(RuntimeError, match="short benchmark"):
+            Frames(cache_path=cache).build(limit=5)
+        assert not cache.exists()
+
+    def test_load_missing_cache_is_actionable(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="fetch_dataset.py --dataset frames"):
+            Frames(cache_path=tmp_path / "nope.json").load()
+
+    def test_hard_benchmark_rejects_flat_limit(self):
+        with pytest.raises(ValueError, match="frames_n/crepe_n"):
+            HardBenchmark(frames_n=2, crepe_n=2).build(limit=3)

--- a/tests/test_hard_benchmark.py
+++ b/tests/test_hard_benchmark.py
@@ -3,6 +3,11 @@
 Runs fully offline: the upstream mappers are exercised against synthetic raw
 rows, and the loader against a committed author-owned fixture. No network and
 no externally-licensed data are required.
+
+Since Issue #56 the implementation lives in ``bicameral_agent.eval_datasets``;
+everything here imports through the ``bicameral_agent.hard_benchmark`` shim to
+prove the original surface still works, while monkeypatches target the modules
+that now own the code (``hf_fetch``, ``frames``, ``crepe``).
 """
 
 import urllib.error
@@ -10,9 +15,12 @@ from pathlib import Path
 
 import pytest
 
-from bicameral_agent import hard_benchmark
+from bicameral_agent.eval_datasets import crepe as crepe_mod
+from bicameral_agent.eval_datasets import frames as frames_mod
+from bicameral_agent.eval_datasets import hf_fetch
 from bicameral_agent.dataset import ResearchQADataset, TaskDifficulty, TaskSplit
 from bicameral_agent.hard_benchmark import (
+    _DEFAULT_CACHE,
     build_hard_benchmark,
     crepe_row_to_task,
     fetch_crepe,
@@ -85,7 +93,7 @@ class TestPager:
             calls.append((offset, length))
             return pages.pop(0)
 
-        monkeypatch.setattr(hard_benchmark, "_fetch_page", fake_fetch_page)
+        monkeypatch.setattr(hf_fetch, "fetch_page", fake_fetch_page)
         tasks = fetch_frames(limit=5)
         assert len(tasks) == 5
         assert [t.task_id for t in tasks] == [f"frames_hard_{i:03d}" for i in range(1, 6)]
@@ -99,7 +107,7 @@ class TestPager:
             [_crepe_row(0), _crepe_row(1, valid=False), _crepe_row(2), _crepe_row(3, valid=False)],
             [],
         ]
-        monkeypatch.setattr(hard_benchmark, "_fetch_page", lambda *a: pages.pop(0))
+        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a: pages.pop(0))
         tasks = fetch_crepe(limit=10)
         assert len(tasks) == 2
         assert all(t.difficulty == TaskDifficulty.TRICKY for t in tasks)
@@ -107,14 +115,14 @@ class TestPager:
 
     def test_error_payload_raises_instead_of_empty_page(self, monkeypatch):
         monkeypatch.setattr(
-            hard_benchmark, "_http_get_json", lambda url: {"error": "rate limited"}
+            hf_fetch, "http_get_json", lambda url: {"error": "rate limited"}
         )
         with pytest.raises(RuntimeError, match="rate limited"):
-            hard_benchmark._fetch_page("some/dataset", "test", 0, 100)
+            hf_fetch.fetch_page("some/dataset", "test", 0, 100)
 
     def test_http_get_json_retries_transient_errors(self, monkeypatch):
         sleeps: list[float] = []
-        monkeypatch.setattr(hard_benchmark.time, "sleep", sleeps.append)
+        monkeypatch.setattr(hf_fetch.time, "sleep", sleeps.append)
         attempts = iter([
             urllib.error.HTTPError("u", 429, "rate limited", None, None),
             urllib.error.URLError("conn reset"),
@@ -136,35 +144,35 @@ class TestPager:
             except StopIteration:
                 return FakeResponse()
 
-        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", fake_urlopen)
-        assert hard_benchmark._http_get_json("http://x") == {"rows": []}
+        monkeypatch.setattr(hf_fetch.urllib.request, "urlopen", fake_urlopen)
+        assert hf_fetch.http_get_json("http://x") == {"rows": []}
         assert len(sleeps) == 2  # backed off before each retry
 
     def test_http_get_json_gives_up_after_max_attempts(self, monkeypatch):
-        monkeypatch.setattr(hard_benchmark.time, "sleep", lambda s: None)
+        monkeypatch.setattr(hf_fetch.time, "sleep", lambda s: None)
 
         def always_503(req, timeout):
             raise urllib.error.HTTPError("u", 503, "unavailable", None, None)
 
-        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", always_503)
+        monkeypatch.setattr(hf_fetch.urllib.request, "urlopen", always_503)
         with pytest.raises(RuntimeError, match="Giving up"):
-            hard_benchmark._http_get_json("http://x")
+            hf_fetch.http_get_json("http://x")
 
     def test_non_retryable_http_error_raises_immediately(self, monkeypatch):
         def not_found(req, timeout):
             raise urllib.error.HTTPError("u", 404, "not found", None, None)
 
-        monkeypatch.setattr(hard_benchmark.urllib.request, "urlopen", not_found)
+        monkeypatch.setattr(hf_fetch.urllib.request, "urlopen", not_found)
         with pytest.raises(urllib.error.HTTPError):
-            hard_benchmark._http_get_json("http://x")
+            hf_fetch.http_get_json("http://x")
 
 
 class TestBuildHardBenchmark:
     def test_short_fetch_refuses_to_write_cache(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            hard_benchmark, "fetch_frames", lambda n: [frames_row_to_task(_frames_row(1), 1)]
+            frames_mod, "fetch_frames", lambda n: [frames_row_to_task(_frames_row(1), 1)]
         )
-        monkeypatch.setattr(hard_benchmark, "fetch_crepe", lambda n: [])
+        monkeypatch.setattr(crepe_mod, "fetch_crepe", lambda n: [])
         cache = tmp_path / "cache.json"
         with pytest.raises(RuntimeError, match="short benchmark"):
             build_hard_benchmark(frames_n=5, crepe_n=5, cache_path=cache)
@@ -173,8 +181,8 @@ class TestBuildHardBenchmark:
     def test_full_fetch_writes_cache(self, monkeypatch, tmp_path):
         frames = [frames_row_to_task(_frames_row(i), i) for i in range(1, 3)]
         crepe = [crepe_row_to_task(_crepe_row(i), i) for i in range(1, 3)]
-        monkeypatch.setattr(hard_benchmark, "fetch_frames", lambda n: frames)
-        monkeypatch.setattr(hard_benchmark, "fetch_crepe", lambda n: crepe)
+        monkeypatch.setattr(frames_mod, "fetch_frames", lambda n: frames)
+        monkeypatch.setattr(crepe_mod, "fetch_crepe", lambda n: crepe)
         cache = tmp_path / "cache.json"
         tasks = build_hard_benchmark(frames_n=2, crepe_n=2, cache_path=cache)
         assert len(tasks) == 4
@@ -182,7 +190,7 @@ class TestBuildHardBenchmark:
 
     def test_default_cache_is_repo_root_anchored(self):
         repo_root = Path(__file__).resolve().parents[1]
-        assert hard_benchmark._DEFAULT_CACHE == (
+        assert _DEFAULT_CACHE == (
             repo_root / "data" / "external" / "hard_benchmark.json"
         )
 
@@ -201,5 +209,5 @@ class TestLoader:
 
     def test_load_hard_benchmark_missing_cache_is_actionable(self, tmp_path):
         missing = tmp_path / "nope.json"
-        with pytest.raises(FileNotFoundError, match="fetch_hard_benchmark"):
+        with pytest.raises(FileNotFoundError, match="fetch_dataset"):
             load_hard_benchmark(missing)

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -1,0 +1,43 @@
+"""Tests for the verifier registry (Issue #56). No LLM calls."""
+
+import pytest
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.scorer import LexicalScorer, TaskScorer
+from bicameral_agent.verifiers import Verifier, build_verifier, verifier_names
+
+
+def _task() -> ResearchQATask:
+    return ResearchQATask(
+        task_id="t1",
+        difficulty=TaskDifficulty.TYPICAL,
+        split=TaskSplit.EVAL,
+        question="What color is the sky?",
+        gold_answer="The sky is blue.",
+        scoring_rubric="5: correct. 1: incorrect.",
+    )
+
+
+class TestBuildVerifier:
+    def test_known_metrics(self):
+        assert verifier_names() == ["lexical", "llm_judge"]
+
+    def test_lexical_is_deterministic_scorer(self):
+        verifier = build_verifier("lexical")
+        assert isinstance(verifier, LexicalScorer)
+        score = verifier.score(_task(), "The sky is blue.")
+        assert score.overall == 1.0  # exact match, no LLM involved
+
+    def test_llm_judge_receives_client(self):
+        sentinel = object()
+        verifier = build_verifier("llm_judge", client=sentinel)
+        assert isinstance(verifier, TaskScorer)
+        assert verifier._client is sentinel
+
+    def test_unknown_metric_lists_known(self):
+        with pytest.raises(ValueError, match="lexical"):
+            build_verifier("exact_match")
+
+    def test_registry_entries_satisfy_protocol(self):
+        for metric in verifier_names():
+            assert isinstance(build_verifier(metric, client=object()), Verifier)


### PR DESCRIPTION
## Summary

Implements the first slice of the Issue #56 dataset factory (steps 1, 5, and part of 3; see the issue comment for the remaining steps): external benchmarks now plug into the harness uniformly via `build_dataset(name, **opts)` (mirroring `model_client.build_client`), with a thin `EvalDataset` adapter base, a verifier registry with dataset-declared (overridable) metrics, and `--dataset`/`--metric` flags on the baseline benchmark runner. FRAMES/CREPE (previously unwired in `hard_benchmark.py`) become the first adapters; `--dataset builtin` is exactly today's behavior.

## Work performed

- **`src/bicameral_agent/eval_datasets/` package** (named to avoid HF `datasets` collision):
  - `base.py` — `DatasetMeta` (name/source/license/citation/`requires_hf_token`) + `EvalDataset` ABC: `fetch_tasks(limit)` (abstract, network), `build(limit)` (fetch + write git-ignored `data/external/<name>.json`, refusing short caches), `load()` (actionable `FileNotFoundError` with the fetch command), repo-root-anchored `cache_path()`.
  - `hf_fetch.py` — the datasets-server pager extracted from `hard_benchmark.py`, preserving all #55 hardening: repo-root cache anchoring, 429/5xx/network retries with exponential backoff, error-payload-vs-empty-page detection, count assertions.
  - `builtin.py` / `frames.py` / `crepe.py` / `hard.py` — adapters. `BuiltinPool` wraps the packaged 130-task pool (no fetch, no cache); `HardBenchmark` is the FRAMES+CREPE composite keeping the same `hard_benchmark.json` cache file, so existing fetch artifacts remain valid.
  - `__init__.py` — plain dict `_REGISTRY` + `build_dataset(name, **opts)` + `resolve_metric(dataset, override)` (CLI override validated against `supported_metrics`, else the dataset's `default_metric`).
- **`src/bicameral_agent/verifiers.py`** — metric-name registry behind a `Verifier` protocol (`score(task, answer) -> TaskScore`): `llm_judge -> TaskScorer`, `lexical -> LexicalScorer`. `build_verifier(metric, client)` mirrors the same dict-registry pattern; future deterministic/rubric verifiers register the same way.
- **`src/bicameral_agent/hard_benchmark.py`** — now a re-exporting shim (`FRAMES_DATASET`, mappers, fetchers, `build_hard_benchmark`, `load_hard_benchmark`, `_DEFAULT_CACHE`), so `scripts/fetch_hard_benchmark.py` and the docs keep working unchanged.
- **CLI** — `scripts/fetch_dataset.py` (generalized fetch; prints license/citation from `DatasetMeta` on every fetch); `scripts/run_baseline_benchmark.py` gains `--dataset` (default `builtin`) and `--metric`, records both in `summary.json`. Edits confined to dataset/metric selection; `select_tasks` stratification is untouched (single-tier pools fall through its existing fill-from-pool path — verified).
- **Tests** — `test_hard_benchmark.py` adapted: still imports through the shim (proving back-compat) with monkeypatches retargeted at the owning modules; new `test_eval_datasets.py` (registry dispatch, opts passthrough, metric resolution, build/load round-trip, short-fetch refusal, cache anchoring, per-adapter meta/metric invariants) and `test_verifiers.py` (deterministic lexical scoring, client passthrough, unknown-metric error) — all offline.
- **Docs** — short note at the top of `docs/hard_benchmark.md` pointing at the new package and flags; everything documented there still works via the shim.

### Deviations from the issue's proposed design (with rationale)

- **`EpisodeConfig.metric` / `TaskScore.detail` / `EvalReport` / task-schema extensions (steps 2–4) not included**: `episode_runner.py` and `scorer.py` are owned by the concurrent #45 scorer work, and `run_baseline_benchmark.py`'s summary/provider plumbing is concurrently edited by #52 — this PR confines itself to dataset/metric selection to avoid conflicts. The two runnable metrics (`llm_judge`/`lexical`) map onto the existing `EpisodeConfig.use_lexical_scorer` knob; `build_verifier` is the named superset for the follow-up wiring. `choices`/`rubric_items`/`abstention_expected` serve only the future adapters (issue steps 6–8, explicitly out of scope here).
- **Adapter waves 1–3 (simpleqa_verified, hle, healthbench_hard, researchqa, supergpqa, bbeh, abstentionbench) deferred** per the issue's independently-landable breakdown — the registry makes each a one-module + one-line addition.
- **`load()` missing-cache error now points at `scripts/fetch_dataset.py --dataset <name>`** (generic base message) instead of `fetch_hard_benchmark.py`; the old script still works and is kept as-is rather than reduced to a 3-line shim (it already just delegates through the module shim — smaller diff, same behavior).
- **`HardBenchmark` sizing** stays on `frames_n`/`crepe_n` constructor options (matching #55's per-source count assertions and error message) rather than a flat `--limit`; a flat limit on the composite raises an actionable `ValueError`.

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 1137 passed, 34 skipped.
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean.
- Offline smoke: `--dataset builtin` resolves the packaged 130-task pool with `llm_judge` (byte-identical selection path to before); unknown dataset/metric raise actionable errors; missing external cache raises the fetch instruction; `fetch_hard_benchmark.py` + `fetch_dataset.py` import and parse args; frames-only pool flows through `select_tasks`'s fill-from-pool path.

Part of #56
