### PR TITLE
Unify model-provider abstraction: registry, fail-fast pricing, shared retry base

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -27,7 +27,7 @@ from bicameral_agent.baseline_benchmark import format_report, run_benchmark
 from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
-from bicameral_agent.model_client import build_client
+from bicameral_agent.model_client import build_client, provider_names
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.schema import Episode
@@ -73,7 +73,7 @@ def main(argv: list[str] | None = None) -> int:
                         help="Hyperparameter TOML file (defaults to the bundled "
                              "config; BICAMERAL_ env overrides always apply, "
                              "CLI flags win over both).")
-    parser.add_argument("--provider", choices=["gemini", "ollama"], default=None,
+    parser.add_argument("--provider", choices=list(provider_names()), default=None,
                         help="Model backend to run the answerer against "
                              "(overrides the config file).")
     parser.add_argument("--model", default=None,

--- a/src/bicameral_agent/__init__.py
+++ b/src/bicameral_agent/__init__.py
@@ -32,6 +32,7 @@ from bicameral_agent.tool_latency import (
 )
 from bicameral_agent.conscious_loop import AssistantResponse, ConsciousLoop
 from bicameral_agent.gemini import ChatMessage, GeminiClient, GeminiResponse
+from bicameral_agent.model_client import ModelClient, ModelResponse, build_client
 from bicameral_agent.dataset import (
     ResearchQADataset,
     ResearchQATask,
@@ -196,8 +197,10 @@ __all__ = [
     "LexicalScorer",
     "MCTSConfig",
     "Message",
+    "ModelClient",
     "ModelConfig",
     "ModelPricing",
+    "ModelResponse",
     "MockSearchProvider",
     "NUM_ACTIONS",
     "Patience",
@@ -249,6 +252,7 @@ __all__ = [
     "UserEvent",
     "UserEventType",
     "ValidationResult",
+    "build_client",
     "default_conditions",
     "episode_from_parquet",
     "episode_to_parquet",

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -13,8 +13,14 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from bicameral_agent.model_client import (
+    VALID_THINKING_LEVELS,
+    default_model,
+    provider_names,
+    validate_provider_model,
+)
 from bicameral_agent.heuristic_controller import (
     DEFAULT_AUDITOR_HIGH_STOP_THRESHOLD,
     DEFAULT_AUDITOR_STOP_THRESHOLD,
@@ -30,19 +36,33 @@ _DEFAULT_TOML = files("bicameral_agent.data").joinpath("default_config.toml")
 
 
 class ModelConfig(BaseModel):
-    """LLM model configuration."""
+    """LLM model configuration.
+
+    ``name`` left unset defaults to the provider's default model from the
+    ``model_client`` registry, and is cross-checked against ``provider`` so
+    e.g. provider='ollama' with a Gemini tag is rejected at config time.
+    """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     provider: str = "gemini"
-    name: str = "gemini-3.1-flash-lite-preview"
+    name: str = ""  # empty -> the provider's default model (see below)
     thinking_level: str = "medium"
     temperature: float | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_provider_default_name(cls, data: Any) -> Any:
+        if isinstance(data, dict) and not data.get("name"):
+            provider = data.get("provider", "gemini")
+            if provider in provider_names():
+                data = {**data, "name": default_model(provider)}
+        return data
 
     @field_validator("provider")
     @classmethod
     def _validate_provider(cls, v: str) -> str:
-        allowed = {"gemini", "ollama"}
+        allowed = set(provider_names())
         if v not in allowed:
             msg = f"provider must be one of {allowed}, got {v!r}"
             raise ValueError(msg)
@@ -51,11 +71,15 @@ class ModelConfig(BaseModel):
     @field_validator("thinking_level")
     @classmethod
     def _validate_thinking_level(cls, v: str) -> str:
-        allowed = {"minimal", "low", "medium", "high"}
-        if v not in allowed:
-            msg = f"thinking_level must be one of {allowed}, got {v!r}"
+        if v not in VALID_THINKING_LEVELS:
+            msg = f"thinking_level must be one of {sorted(VALID_THINKING_LEVELS)}, got {v!r}"
             raise ValueError(msg)
         return v
+
+    @model_validator(mode="after")
+    def _cross_validate_name(self) -> ModelConfig:
+        validate_provider_model(self.provider, self.name)
+        return self
 
     @field_validator("temperature")
     @classmethod
@@ -234,6 +258,15 @@ class HyperConfig(BaseModel):
             return self
 
         current = self.model_dump()
+        # A provider override without an explicit name drops the old
+        # provider's model name so the new provider's default applies.
+        model_ov = overrides.get("model")
+        if (
+            isinstance(model_ov, dict)
+            and "name" not in model_ov
+            and model_ov.get("provider") not in (None, self.model.provider)
+        ):
+            current["model"].pop("name", None)
         _deep_merge(current, overrides)
         return HyperConfig.model_validate(current)
 

--- a/src/bicameral_agent/cost_tracker.py
+++ b/src/bicameral_agent/cost_tracker.py
@@ -1,4 +1,4 @@
-"""Cost tracking and budget enforcement for Gemini API calls.
+"""Cost tracking and budget enforcement for model API calls.
 
 Monitors API spend across all calls and enforces configurable session-level
 and episode-level budget limits. Thread-safe via ``threading.Lock``.
@@ -6,10 +6,13 @@ and episode-level budget limits. Thread-safe via ``threading.Lock``.
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass
 
-from bicameral_agent.gemini import GeminiClient, GeminiResponse
+from bicameral_agent.model_client import PROVIDERS, ModelClient, ModelResponse
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,8 +37,43 @@ MODEL_PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-# Backwards-compatible alias (the dict previously held only Gemini models).
-GEMINI_PRICING = MODEL_PRICING
+_FLAT_RATE = ModelPricing(input_cost_per_token=0.0, output_cost_per_token=0.0)
+
+# Tags already warned about, so flat-rate fallbacks log once per process.
+_warned_flat_rate: set[str] = set()
+
+
+def resolve_pricing(model: str, provider: str | None = None) -> ModelPricing:
+    """Resolve per-token pricing for *model*, failing fast on unknown tags.
+
+    Tags registered in ``MODEL_PRICING`` resolve directly. Unknown tags on a
+    flat-rate (subscription) provider fall back to $0/token with a one-time
+    warning, so any Ollama Cloud ``--model`` override works without a
+    registry edit. Unknown tags on metered providers raise, so a typo'd
+    Gemini tag is rejected at client-build time -- never after a paid call.
+
+    Raises:
+        ValueError: If *model* is unpriced and *provider* is not flat-rate.
+    """
+    pricing = MODEL_PRICING.get(model)
+    if pricing is not None:
+        return pricing
+
+    spec = PROVIDERS.get(provider) if provider is not None else None
+    if spec is not None and spec.flat_rate:
+        if model not in _warned_flat_rate:
+            _warned_flat_rate.add(model)
+            logger.warning(
+                "No pricing registered for model %r; provider %r is "
+                "subscription-flat, recording $0/token.",
+                model,
+                provider,
+            )
+        return _FLAT_RATE
+
+    raise ValueError(
+        f"Unknown model {model!r}; known models: {sorted(MODEL_PRICING)}"
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,17 +111,27 @@ class CostTracker:
         self._session_budget: float | None = None
         self._episode_budget: float | None = None
 
-    def record_call(self, input_tokens: int, output_tokens: int, model: str) -> None:
+    def record_call(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        model: str,
+        pricing: ModelPricing | None = None,
+    ) -> None:
         """Record a completed API call and accumulate costs.
 
+        Args:
+            input_tokens: Prompt tokens consumed by the call.
+            output_tokens: Completion tokens produced by the call.
+            model: Model tag the call was made against.
+            pricing: Pre-resolved pricing (skips the registry lookup).
+
         Raises:
-            ValueError: If *model* is not in ``MODEL_PRICING``.
+            ValueError: If *pricing* is omitted and *model* is not in
+                ``MODEL_PRICING``.
         """
-        pricing = MODEL_PRICING.get(model)
         if pricing is None:
-            raise ValueError(
-                f"Unknown model {model!r}; known models: {sorted(MODEL_PRICING)}"
-            )
+            pricing = resolve_pricing(model)
         input_cost = input_tokens * pricing.input_cost_per_token
         output_cost = output_tokens * pricing.output_cost_per_token
 
@@ -156,23 +204,29 @@ class CostTracker:
 
 
 class CostTrackedClient:
-    """Wraps a ``GeminiClient`` with cost tracking and budget enforcement.
+    """Wraps a model client with cost tracking and budget enforcement.
 
     Calls ``check_budget()`` before each ``generate()`` and
     ``record_call()`` after, following the same wrapper pattern as
     ``_TrackedClient`` in ``tool_primitive.py``.
+
+    Pricing for the wrapped client's model is resolved once at construction,
+    so an unpriced tag fails fast here -- never after a paid call.
     """
 
-    def __init__(self, inner: GeminiClient, tracker: CostTracker) -> None:
+    def __init__(self, inner: ModelClient, tracker: CostTracker) -> None:
         self._inner = inner
         self._tracker = tracker
+        self._pricing = resolve_pricing(
+            inner.model, provider=getattr(inner, "provider", None)
+        )
 
     @property
     def model(self) -> str:
         """Expose the underlying client's model name."""
         return self._inner.model
 
-    def generate(self, *args, **kwargs) -> GeminiResponse:
+    def generate(self, *args, **kwargs) -> ModelResponse:
         """Generate with pre-call budget check and post-call cost recording."""
         self._tracker.check_budget()
         response = self._inner.generate(*args, **kwargs)
@@ -180,5 +234,6 @@ class CostTrackedClient:
             response.input_tokens,
             response.output_tokens,
             self._inner.model,
+            pricing=self._pricing,
         )
         return response

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -5,7 +5,7 @@
 
 [model]
 provider = "gemini"        # "gemini" or "ollama"
-name = "gemini-3.1-flash-lite-preview"
+# name is unset (uses the provider's default model from the registry)
 thinking_level = "medium"  # "minimal", "low", "medium", or "high"
 # temperature is unset (uses model default)
 

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -19,9 +19,9 @@ from bicameral_agent.context_refresher import ContextRefresher
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.encoder import StateEncoder
 from bicameral_agent.gap_scanner import ResearchGapScanner
-from bicameral_agent.gemini import GeminiClient
 from bicameral_agent.heuristic_controller import Action, DecisionLog, FullState, TOOL_IDS
 from bicameral_agent.logger import ConversationLogger
+from bicameral_agent.model_client import ModelClient
 from bicameral_agent.queue import ContextQueue, InterruptConfig
 from bicameral_agent.schema import (
     Episode,
@@ -105,7 +105,7 @@ class EpisodeRunner:
 
     def __init__(
         self,
-        client: GeminiClient,
+        client: ModelClient,
         config: EpisodeConfig | None = None,
         hyper_config: HyperConfig | None = None,
         cost_tracker: CostTracker | None = None,
@@ -142,7 +142,7 @@ class EpisodeRunner:
         cfg = self._config
 
         # Cost tracking: reset episode, wrap client
-        active_client: GeminiClient | CostTrackedClient = self._client
+        active_client: ModelClient = self._client
         if self._cost_tracker is not None:
             self._cost_tracker.reset_episode()
             active_client = CostTrackedClient(self._client, self._cost_tracker)

--- a/src/bicameral_agent/gemini.py
+++ b/src/bicameral_agent/gemini.py
@@ -10,22 +10,28 @@ APILatencyModel.
 from __future__ import annotations
 
 import os
-import random
 import time
-from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types
 
-_MODEL = "gemini-3.1-flash-lite-preview"
-_MAX_RETRIES = 3
-_BASE_DELAY = 1.0
-_BACKOFF_FACTOR = 2.0
-_MAX_JITTER = 0.5
+from bicameral_agent.model_client import (
+    ChatMessage,
+    ModelResponse,
+    RetryingClientBase,
+    default_model,
+    validate_thinking_level,
+)
 
-_VALID_THINKING_LEVELS = {"minimal", "low", "medium", "high"}
+_MODEL = default_model("gemini")
+
+# Back-compat alias: the response dataclass now lives provider-neutrally in
+# model_client; existing imports of GeminiResponse keep working.
+GeminiResponse = ModelResponse
+
+__all__ = ["BlockedResponseError", "ChatMessage", "GeminiClient", "GeminiResponse"]
 
 
 class BlockedResponseError(RuntimeError):
@@ -41,35 +47,13 @@ class BlockedResponseError(RuntimeError):
         super().__init__(f"Gemini returned no usable content (reason: {reason})")
 
 
-@dataclass(frozen=True, slots=True)
-class ChatMessage:
-    """A message in the conversation for the Gemini API.
-
-    Lighter than schema.Message -- no timestamp/token_count fields,
-    since those are logging concerns, not API input concerns.
-    """
-
-    role: str
-    content: str
-
-
-@dataclass(frozen=True, slots=True)
-class GeminiResponse:
-    """Response from a Gemini API call with metadata."""
-
-    content: str
-    input_tokens: int
-    output_tokens: int
-    duration_ms: float
-    finish_reason: str
-    function_calls: list[dict[str, Any]] | None = field(default=None)
-
-
-class GeminiClient:
+class GeminiClient(RetryingClientBase):
     """Thin wrapper around the Gemini API with retry, timing, and callbacks.
 
     Thread-safe: no mutable state after __init__.
     """
+
+    provider = "gemini"
 
     def __init__(
         self,
@@ -117,22 +101,16 @@ class GeminiClient:
         Returns:
             GeminiResponse with content, token counts, timing, and finish reason.
         """
-        if thinking_level.lower() not in _VALID_THINKING_LEVELS:
-            raise ValueError(
-                f"Invalid thinking_level {thinking_level!r}; "
-                f"must be one of {sorted(_VALID_THINKING_LEVELS)}"
-            )
-
         contents = self._build_contents(messages)
         config = self._build_config(
             system_prompt=system_prompt,
-            thinking_level=thinking_level.lower(),
+            thinking_level=validate_thinking_level(thinking_level),
             temperature=temperature,
             max_output_tokens=max_output_tokens,
             tools=tools,
             response_schema=response_schema,
         )
-        return self._execute_with_retry(contents, config)
+        return self._execute_with_retry(lambda: self._attempt(contents, config))
 
     @staticmethod
     def _build_contents(
@@ -190,36 +168,20 @@ class GeminiClient:
 
         return types.GenerateContentConfig(**kwargs)
 
-    def _execute_with_retry(
+    def _attempt(
         self,
         contents: list[types.Content],
         config: types.GenerateContentConfig,
     ) -> GeminiResponse:
-        last_exc: Exception | None = None
-
-        for attempt in range(_MAX_RETRIES + 1):
-            if attempt > 0:
-                delay = _BASE_DELAY * (_BACKOFF_FACTOR ** (attempt - 1))
-                jitter = random.uniform(0, _MAX_JITTER)
-                time.sleep(delay + jitter)
-
-            try:
-                start_ns = time.monotonic_ns()
-                response = self._client.models.generate_content(
-                    model=self._model,
-                    contents=contents,
-                    config=config,
-                )
-                duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
-                return self._parse_response(response, duration_ms)
-
-            except Exception as exc:
-                if self._is_retryable(exc) and attempt < _MAX_RETRIES:
-                    last_exc = exc
-                    continue
-                raise
-
-        raise last_exc  # type: ignore[misc]
+        """One timed request/parse round trip (retried by the base class)."""
+        start_ns = time.monotonic_ns()
+        response = self._client.models.generate_content(
+            model=self._model,
+            contents=contents,
+            config=config,
+        )
+        duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+        return self._parse_response(response, duration_ms)
 
     def _parse_response(self, response: Any, duration_ms: float) -> GeminiResponse:
         usage = response.usage_metadata

--- a/src/bicameral_agent/model_client.py
+++ b/src/bicameral_agent/model_client.py
@@ -1,18 +1,214 @@
-"""Model-client factory: pick a backend by provider name (issue #43).
+"""Provider-neutral model-client layer (issues #43, #52).
 
-Single source of truth for translating a ``provider`` string into a concrete
-client (``GeminiClient`` or ``OllamaCloudClient``). Both satisfy the same
-duck-typed contract, so callers downstream are provider-agnostic.
+Single source of truth for:
+
+- the provider registry (``PROVIDERS``): provider names, per-provider default
+  model tags, and plausible-tag patterns, consumed by config validation and
+  CLI ``choices``;
+- the neutral ``ChatMessage`` / ``ModelResponse`` dataclasses that every
+  client accepts and returns (``gemini.GeminiResponse`` is a back-compat
+  alias);
+- the shared retry/backoff scaffold (``RetryingClientBase``) with a
+  per-provider ``_is_retryable`` hook;
+- the ``build_client`` factory that turns a ``provider`` string into a
+  concrete client, failing fast on unknown providers, implausible
+  provider/model pairings, and unpriced model tags -- before any paid call.
 """
 
 from __future__ import annotations
 
-from typing import Callable
+import random
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
 
-from bicameral_agent.gemini import GeminiClient
-from bicameral_agent.ollama_cloud import OllamaCloudClient
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0
+_BACKOFF_FACTOR = 2.0
+_MAX_JITTER = 0.5
 
-_PROVIDERS = ("gemini", "ollama")
+VALID_THINKING_LEVELS = frozenset({"minimal", "low", "medium", "high"})
+
+
+@dataclass(frozen=True, slots=True)
+class ChatMessage:
+    """A message in the conversation sent to a model API.
+
+    Lighter than schema.Message -- no timestamp/token_count fields,
+    since those are logging concerns, not API input concerns.
+    """
+
+    role: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class ModelResponse:
+    """Provider-neutral response from a model API call with metadata."""
+
+    content: str
+    input_tokens: int
+    output_tokens: int
+    duration_ms: float
+    finish_reason: str
+    function_calls: list[dict[str, Any]] | None = field(default=None)
+
+
+class ModelClient(Protocol):
+    """Structural contract satisfied by every model client and wrapper."""
+
+    @property
+    def model(self) -> str:
+        """The model name used for API calls."""
+        ...
+
+    def generate(
+        self,
+        messages: list[ChatMessage] | list[dict[str, str]],
+        *,
+        system_prompt: str | None = None,
+        thinking_level: str = "medium",
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+        tools: list[dict] | None = None,
+        response_schema: dict | None = None,
+    ) -> ModelResponse:
+        """Generate a response from the model API."""
+        ...
+
+
+def validate_thinking_level(thinking_level: str) -> str:
+    """Return *thinking_level* lowercased, or raise for unknown levels."""
+    lowered = thinking_level.lower()
+    if lowered not in VALID_THINKING_LEVELS:
+        raise ValueError(
+            f"Invalid thinking_level {thinking_level!r}; "
+            f"must be one of {sorted(VALID_THINKING_LEVELS)}"
+        )
+    return lowered
+
+
+class RetryingClientBase:
+    """Shared retry/backoff scaffold for concrete model clients.
+
+    Subclasses implement ``_is_retryable`` (their typed, provider-specific
+    transient-error check) and route each API call through
+    ``_execute_with_retry`` with a zero-arg attempt callable that performs
+    one timed request/parse round trip.
+    """
+
+    def _execute_with_retry(self, attempt: Callable[[], ModelResponse]) -> ModelResponse:
+        last_exc: Exception | None = None
+
+        for attempt_idx in range(_MAX_RETRIES + 1):
+            if attempt_idx > 0:
+                delay = _BASE_DELAY * (_BACKOFF_FACTOR ** (attempt_idx - 1))
+                jitter = random.uniform(0, _MAX_JITTER)
+                time.sleep(delay + jitter)
+
+            try:
+                return attempt()
+            except Exception as exc:
+                if self._is_retryable(exc) and attempt_idx < _MAX_RETRIES:
+                    last_exc = exc
+                    continue
+                raise
+
+        raise last_exc  # type: ignore[misc]
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        raise NotImplementedError
+
+
+def _load_gemini_client() -> type:
+    from bicameral_agent.gemini import GeminiClient
+
+    return GeminiClient
+
+
+def _load_ollama_client() -> type:
+    from bicameral_agent.ollama_cloud import OllamaCloudClient
+
+    return OllamaCloudClient
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSpec:
+    """Registry entry for a model provider.
+
+    Attributes:
+        default_model: Model tag used when none is configured.
+        model_pattern: Shape of this provider's model tags, used to reject
+            implausible provider/model pairings (a tag that matches another
+            provider's pattern but not this one's).
+        load_client: Lazy import of the concrete client class.
+        flat_rate: Subscription-flat pricing: unknown tags cost $0/token
+            (with a warning) instead of failing pricing validation.
+    """
+
+    default_model: str
+    model_pattern: re.Pattern[str]
+    load_client: Callable[[], type]
+    flat_rate: bool = False
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "gemini": ProviderSpec(
+        default_model="gemini-3.1-flash-lite-preview",
+        model_pattern=re.compile(r"gemini-\S+"),
+        load_client=_load_gemini_client,
+    ),
+    "ollama": ProviderSpec(
+        default_model="gemma4:31b-cloud",
+        model_pattern=re.compile(r"[^:\s]+:[^:\s]+"),
+        load_client=_load_ollama_client,
+        flat_rate=True,
+    ),
+}
+
+
+def provider_names() -> tuple[str, ...]:
+    """Known provider names, for CLI choices and config validation."""
+    return tuple(PROVIDERS)
+
+
+def _spec(provider: str) -> ProviderSpec:
+    spec = PROVIDERS.get(provider)
+    if spec is None:
+        raise ValueError(
+            f"Unknown provider {provider!r}; known providers: {sorted(PROVIDERS)}"
+        )
+    return spec
+
+
+def default_model(provider: str) -> str:
+    """The default model tag for *provider*."""
+    return _spec(provider).default_model
+
+
+def validate_provider_model(provider: str, model: str) -> None:
+    """Reject a *model* tag that plausibly belongs to a different *provider*.
+
+    Catches the config footgun of switching ``provider`` while leaving the
+    model name at another provider's tag (e.g. provider='ollama' with the
+    Gemini default name). Unrecognisable tags are allowed through; pricing
+    validation at client-build time is the backstop.
+
+    Raises:
+        ValueError: If *provider* is unknown, or *model* matches another
+            provider's tag pattern but not this provider's.
+    """
+    spec = _spec(provider)
+    if spec.model_pattern.fullmatch(model):
+        return
+    for other, other_spec in PROVIDERS.items():
+        if other != provider and other_spec.model_pattern.fullmatch(model):
+            raise ValueError(
+                f"Model {model!r} looks like a {other!r} tag but provider is "
+                f"{provider!r}; set a {provider} model or switch provider."
+            )
 
 
 def build_client(
@@ -22,11 +218,11 @@ def build_client(
     api_key: str | None = None,
     on_completion: Callable[[int, int, float], None] | None = None,
 ):
-    """Construct a model client for *provider*.
+    """Construct a model client for *provider*, failing fast on bad configs.
 
     Args:
-        provider: 'gemini' or 'ollama'.
-        model: Model id/tag; None uses the client's own default.
+        provider: A key of ``PROVIDERS`` ('gemini' or 'ollama').
+        model: Model id/tag; None uses the provider's default from the registry.
         api_key: Optional explicit API key (else read from the provider's env var).
         on_completion: Optional ``(input_tokens, output_tokens, duration_ms)`` callback.
 
@@ -34,14 +230,18 @@ def build_client(
         A ``GeminiClient`` or ``OllamaCloudClient``.
 
     Raises:
-        ValueError: If *provider* is not recognised.
+        ValueError: If *provider* is unknown, *model* is implausible for
+            *provider*, or *model* has no resolvable pricing (fail fast,
+            before any paid call could be destroyed post-hoc).
     """
-    kwargs: dict = {"api_key": api_key, "on_completion": on_completion}
-    if model is not None:
-        kwargs["model"] = model
+    from bicameral_agent.cost_tracker import resolve_pricing
 
-    if provider == "gemini":
-        return GeminiClient(**kwargs)
-    if provider == "ollama":
-        return OllamaCloudClient(**kwargs)
-    raise ValueError(f"Unknown provider {provider!r}; known providers: {list(_PROVIDERS)}")
+    spec = _spec(provider)
+    resolved_model = model if model is not None else spec.default_model
+    validate_provider_model(provider, resolved_model)
+    resolve_pricing(resolved_model, provider=provider)
+
+    client_cls = spec.load_client()
+    return client_cls(
+        api_key=api_key, on_completion=on_completion, model=resolved_model
+    )

--- a/src/bicameral_agent/ollama_cloud.py
+++ b/src/bicameral_agent/ollama_cloud.py
@@ -2,7 +2,7 @@
 
 A drop-in alternative to ``GeminiClient`` for running episodes/benchmarks
 against an open Gemma-class model. Mirrors the ``GeminiClient`` interface
-exactly -- same ``generate(...)`` signature, same ``GeminiResponse`` return
+exactly -- same ``generate(...)`` signature, same ``ModelResponse`` return
 type, same retry/timing/callback behaviour -- so it is interchangeable at every
 call site (``EpisodeRunner``, ``SimulatedUser``, ``TaskScorer``, tools).
 
@@ -18,30 +18,31 @@ from __future__ import annotations
 import http.client
 import json
 import os
-import random
 import time
 import urllib.error
 import urllib.request
 from typing import Any, Callable
 
-from bicameral_agent.gemini import ChatMessage, GeminiResponse
+from bicameral_agent.model_client import (
+    ChatMessage,
+    ModelResponse,
+    RetryingClientBase,
+    default_model,
+    validate_thinking_level,
+)
 
-_MODEL = "gemma4:31b-cloud"
+_MODEL = default_model("ollama")
 _DEFAULT_HOST = "https://ollama.com"
-_MAX_RETRIES = 3
-_BASE_DELAY = 1.0
-_BACKOFF_FACTOR = 2.0
-_MAX_JITTER = 0.5
 _TIMEOUT_S = 120.0
 
-_VALID_THINKING_LEVELS = {"minimal", "low", "medium", "high"}
 
-
-class OllamaCloudClient:
+class OllamaCloudClient(RetryingClientBase):
     """Thin wrapper around the Ollama Cloud chat API with retry, timing, callbacks.
 
     Thread-safe: no mutable state after __init__.
     """
+
+    provider = "ollama"
 
     def __init__(
         self,
@@ -75,7 +76,7 @@ class OllamaCloudClient:
         max_output_tokens: int | None = None,
         tools: list[dict] | None = None,
         response_schema: dict | None = None,
-    ) -> GeminiResponse:
+    ) -> ModelResponse:
         """Generate a response from the Ollama Cloud chat API.
 
         Args mirror ``GeminiClient.generate`` for drop-in compatibility:
@@ -91,24 +92,18 @@ class OllamaCloudClient:
             response_schema: JSON schema dict; passed through to Ollama ``format``.
 
         Returns:
-            GeminiResponse with content, token counts, timing, and finish reason.
+            ModelResponse with content, token counts, timing, and finish reason.
         """
-        if thinking_level.lower() not in _VALID_THINKING_LEVELS:
-            raise ValueError(
-                f"Invalid thinking_level {thinking_level!r}; "
-                f"must be one of {sorted(_VALID_THINKING_LEVELS)}"
-            )
-
         payload = self._build_payload(
             messages,
             system_prompt=system_prompt,
-            thinking_level=thinking_level.lower(),
+            thinking_level=validate_thinking_level(thinking_level),
             temperature=temperature,
             max_output_tokens=max_output_tokens,
             tools=tools,
             response_schema=response_schema,
         )
-        return self._execute_with_retry(payload)
+        return self._execute_with_retry(lambda: self._attempt(payload))
 
     def _build_payload(
         self,
@@ -168,28 +163,12 @@ class OllamaCloudClient:
 
         return payload
 
-    def _execute_with_retry(self, payload: dict[str, Any]) -> GeminiResponse:
-        last_exc: Exception | None = None
-
-        for attempt in range(_MAX_RETRIES + 1):
-            if attempt > 0:
-                delay = _BASE_DELAY * (_BACKOFF_FACTOR ** (attempt - 1))
-                jitter = random.uniform(0, _MAX_JITTER)
-                time.sleep(delay + jitter)
-
-            try:
-                start_ns = time.monotonic_ns()
-                data = self._post(payload)
-                duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
-                return self._parse_response(data, duration_ms)
-
-            except Exception as exc:
-                if self._is_retryable(exc) and attempt < _MAX_RETRIES:
-                    last_exc = exc
-                    continue
-                raise
-
-        raise last_exc  # type: ignore[misc]
+    def _attempt(self, payload: dict[str, Any]) -> ModelResponse:
+        """One timed request/parse round trip (retried by the base class)."""
+        start_ns = time.monotonic_ns()
+        data = self._post(payload)
+        duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+        return self._parse_response(data, duration_ms)
 
     def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
         body = json.dumps(payload).encode("utf-8")
@@ -205,7 +184,7 @@ class OllamaCloudClient:
         with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
             return json.loads(response.read().decode("utf-8"))
 
-    def _parse_response(self, data: dict[str, Any], duration_ms: float) -> GeminiResponse:
+    def _parse_response(self, data: dict[str, Any], duration_ms: float) -> ModelResponse:
         input_tokens = data.get("prompt_eval_count") or 0
         output_tokens = data.get("eval_count") or 0
         finish_reason = data.get("done_reason") or "stop"
@@ -224,7 +203,7 @@ class OllamaCloudClient:
         if self._on_completion is not None:
             self._on_completion(input_tokens, output_tokens, duration_ms)
 
-        return GeminiResponse(
+        return ModelResponse(
             content=content,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bicameral_agent.cost_tracker import (
-    GEMINI_PRICING,
+    MODEL_PRICING,
     CostBudgetExceeded,
     CostReport,
     CostTrackedClient,
@@ -16,7 +16,7 @@ from bicameral_agent.cost_tracker import (
 )
 
 _MODEL = "gemini-3.1-flash-lite-preview"
-_PRICING = GEMINI_PRICING[_MODEL]
+_PRICING = MODEL_PRICING[_MODEL]
 
 
 class TestRecordCall:
@@ -246,6 +246,39 @@ class TestCostTrackedClient:
         tracker = CostTracker()
         wrapped = CostTrackedClient(client, tracker)
         assert wrapped.model == _MODEL
+
+
+class _StubClient:
+    """Minimal ModelClient stand-in with a fixed model tag and provider."""
+
+    def __init__(self, model: str, provider: str | None = None) -> None:
+        self.model = model
+        if provider is not None:
+            self.provider = provider
+
+    def generate(self, *args, **kwargs):
+        response = MagicMock()
+        response.input_tokens = 1000
+        response.output_tokens = 500
+        return response
+
+
+class TestCostTrackedClientFailFast:
+    """Pricing is validated at construction, never after a paid call (issue #52)."""
+
+    def test_unknown_model_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            CostTrackedClient(_StubClient("not-a-real-model"), CostTracker())
+
+    def test_flat_rate_provider_unknown_tag_records_zero_cost(self):
+        tracker = CostTracker()
+        wrapped = CostTrackedClient(
+            _StubClient("qwen8:8b-cloud", provider="ollama"), tracker
+        )
+        wrapped.generate([])
+        report = tracker.get_total()
+        assert report.call_count == 1
+        assert report.total == 0.0
 
 
 class TestCostConfig:

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -12,6 +12,8 @@ from bicameral_agent.gemini import (
     ChatMessage,
     GeminiClient,
     GeminiResponse,
+)
+from bicameral_agent.model_client import (
     _BASE_DELAY,
     _BACKOFF_FACTOR,
     _MAX_RETRIES,
@@ -186,7 +188,7 @@ class TestRetryLogic:
         sdk.models.generate_content.side_effect = [
             exc_429, exc_429, _make_mock_response()
         ]
-        with patch("bicameral_agent.gemini.time.sleep"):
+        with patch("bicameral_agent.model_client.time.sleep"):
             result = client.generate([{"role": "user", "content": "hi"}])
         assert result.content == "Hello!"
         assert sdk.models.generate_content.call_count == 3
@@ -199,7 +201,7 @@ class TestRetryLogic:
         sdk.models.generate_content.side_effect = [
             exc_500, _make_mock_response()
         ]
-        with patch("bicameral_agent.gemini.time.sleep"):
+        with patch("bicameral_agent.model_client.time.sleep"):
             result = client.generate([{"role": "user", "content": "hi"}])
         assert result.content == "Hello!"
         assert sdk.models.generate_content.call_count == 2
@@ -212,7 +214,7 @@ class TestRetryLogic:
         sdk.models.generate_content.side_effect = [
             exc_429, _make_mock_response()
         ]
-        with patch("bicameral_agent.gemini.time.sleep"):
+        with patch("bicameral_agent.model_client.time.sleep"):
             result = client.generate([{"role": "user", "content": "hi"}])
         assert result.content == "Hello!"
         assert sdk.models.generate_content.call_count == 2
@@ -249,7 +251,7 @@ class TestRetryLogic:
         client, sdk = mock_client
         exc_429 = Exception("429 Too Many Requests")
         sdk.models.generate_content.side_effect = exc_429
-        with patch("bicameral_agent.gemini.time.sleep"):
+        with patch("bicameral_agent.model_client.time.sleep"):
             with pytest.raises(Exception, match="429"):
                 client.generate([{"role": "user", "content": "hi"}])
         assert sdk.models.generate_content.call_count == _MAX_RETRIES + 1
@@ -261,8 +263,8 @@ class TestRetryLogic:
             exc_429, exc_429, _make_mock_response()
         ]
         sleep_calls = []
-        with patch("bicameral_agent.gemini.time.sleep", side_effect=lambda d: sleep_calls.append(d)):
-            with patch("bicameral_agent.gemini.random.uniform", return_value=0.0):
+        with patch("bicameral_agent.model_client.time.sleep", side_effect=lambda d: sleep_calls.append(d)):
+            with patch("bicameral_agent.model_client.random.uniform", return_value=0.0):
                 client.generate([{"role": "user", "content": "hi"}])
 
         assert len(sleep_calls) == 2
@@ -746,7 +748,7 @@ class TestBlockedResponses:
             instance = MockClient.return_value
             instance.models.generate_content.return_value = response
             client = GeminiClient(api_key="key")
-            with patch("bicameral_agent.gemini.time.sleep"):
+            with patch("bicameral_agent.model_client.time.sleep"):
                 with pytest.raises(BlockedResponseError):
                     client.generate([{"role": "user", "content": "hi"}])
         assert instance.models.generate_content.call_count == 1

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1,19 +1,36 @@
-"""Tests for provider/backend selection wiring (Issue #43).
+"""Tests for provider/backend selection wiring (Issues #43, #52).
 
-Covers the ``build_client`` factory, the ``ModelConfig.provider`` field, the
-``HyperConfig.to_model_client`` adapter, and that the Ollama Gemma tag is a
-known (flat-rate) model for ``CostTracker``.
+Covers the provider registry, the ``build_client`` factory (including
+fail-fast pricing and provider/model cross-validation), the
+``ModelConfig.provider`` field, the ``HyperConfig.to_model_client``
+adapter, and that the Ollama Gemma tag is a known (flat-rate) model for
+``CostTracker``.
 """
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from bicameral_agent.config import HyperConfig, ModelConfig
-from bicameral_agent.cost_tracker import MODEL_PRICING, CostTracker
+from bicameral_agent.cost_tracker import MODEL_PRICING, CostTracker, resolve_pricing
 from bicameral_agent.gemini import GeminiClient
-from bicameral_agent.model_client import build_client
+from bicameral_agent.model_client import build_client, default_model, provider_names
 from bicameral_agent.ollama_cloud import OllamaCloudClient
+
+
+class TestProviderRegistry:
+    def test_provider_names(self):
+        assert set(provider_names()) == {"gemini", "ollama"}
+
+    def test_default_model_per_provider(self):
+        assert default_model("gemini") == "gemini-3.1-flash-lite-preview"
+        assert default_model("ollama") == "gemma4:31b-cloud"
+
+    def test_default_model_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            default_model("anthropic")
 
 
 class TestBuildClient:
@@ -35,6 +52,39 @@ class TestBuildClient:
             build_client("anthropic", api_key="k")
 
 
+class TestFailFastPricing:
+    def test_unpriced_gemini_tag_rejected_at_build_time(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            build_client("gemini", "gemini-9-ultra", api_key="k")
+
+    def test_unknown_ollama_tag_builds_with_flat_rate_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="bicameral_agent.cost_tracker"):
+            client = build_client("ollama", "qwen9:9b-cloud", api_key="k")
+        assert isinstance(client, OllamaCloudClient)
+        assert "subscription-flat" in caplog.text
+        pricing = resolve_pricing("qwen9:9b-cloud", provider="ollama")
+        assert pricing.input_cost_per_token == 0.0
+        assert pricing.output_cost_per_token == 0.0
+
+    def test_unknown_tag_without_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            resolve_pricing("not-a-real-model")
+
+
+class TestProviderModelCrossValidation:
+    def test_ollama_provider_with_gemini_tag_rejected(self):
+        with pytest.raises(ValueError, match="looks like a 'gemini' tag"):
+            build_client("ollama", "gemini-3.1-flash-lite-preview", api_key="k")
+
+    def test_gemini_provider_with_ollama_tag_rejected(self):
+        with pytest.raises(ValueError, match="looks like a 'ollama' tag"):
+            build_client("gemini", "gemma4:31b-cloud", api_key="k")
+
+    def test_model_config_rejects_mismatched_pair(self):
+        with pytest.raises(ValueError, match="looks like a 'gemini' tag"):
+            ModelConfig(provider="ollama", name="gemini-3.1-flash-lite-preview")
+
+
 class TestModelConfigProvider:
     def test_default_provider_is_gemini(self):
         assert ModelConfig().provider == "gemini"
@@ -45,6 +95,16 @@ class TestModelConfigProvider:
     def test_invalid_provider_rejected(self):
         with pytest.raises(ValueError, match="provider must be one of"):
             ModelConfig(provider="openai")
+
+    def test_name_defaults_to_provider_default(self):
+        assert ModelConfig().name == "gemini-3.1-flash-lite-preview"
+        assert ModelConfig(provider="ollama").name == "gemma4:31b-cloud"
+
+    def test_env_provider_override_switches_default_name(self, monkeypatch):
+        monkeypatch.setenv("BICAMERAL_MODEL__PROVIDER", "ollama")
+        cfg = HyperConfig().with_env_overrides()
+        assert cfg.model.provider == "ollama"
+        assert cfg.model.name == "gemma4:31b-cloud"
 
     def test_to_model_client_uses_provider(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_API_KEY", "k")

--- a/tests/test_ollama_cloud.py
+++ b/tests/test_ollama_cloud.py
@@ -15,10 +15,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bicameral_agent.gemini import ChatMessage, GeminiResponse
-from bicameral_agent.ollama_cloud import (
-    _MAX_RETRIES,
-    OllamaCloudClient,
-)
+from bicameral_agent.model_client import _MAX_RETRIES
+from bicameral_agent.ollama_cloud import OllamaCloudClient
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +278,7 @@ class TestRetry:
             return _FakeHTTPResponse(_make_response_body(content="ok"))
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep"):
+                patch("bicameral_agent.model_client.time.sleep"):
             result = OllamaCloudClient(api_key="k").generate(
                 [{"role": "user", "content": "x"}]
             )
@@ -297,7 +295,7 @@ class TestRetry:
             return _FakeHTTPResponse(_make_response_body())
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep"):
+                patch("bicameral_agent.model_client.time.sleep"):
             OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
         assert calls["n"] == 2
 
@@ -309,7 +307,7 @@ class TestRetry:
             raise _http_error(400)
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep"):
+                patch("bicameral_agent.model_client.time.sleep"):
             with pytest.raises(urllib.error.HTTPError):
                 OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
         assert calls["n"] == 1
@@ -319,7 +317,7 @@ class TestRetry:
             raise _http_error(500)
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep") as sleep:
+                patch("bicameral_agent.model_client.time.sleep") as sleep:
             with pytest.raises(urllib.error.HTTPError):
                 OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
         assert sleep.call_count == _MAX_RETRIES
@@ -356,7 +354,7 @@ class TestReadPhaseRetry:
             return _FakeHTTPResponse(_make_response_body(content="ok"))
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep"):
+                patch("bicameral_agent.model_client.time.sleep"):
             result = OllamaCloudClient(api_key="k").generate(
                 [{"role": "user", "content": "x"}]
             )
@@ -392,7 +390,7 @@ class TestReadPhaseRetry:
             return _FakeHTTPResponse(_make_response_body(content="ok"))
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep"):
+                patch("bicameral_agent.model_client.time.sleep"):
             result = OllamaCloudClient(api_key="k").generate(
                 [{"role": "user", "content": "x"}]
             )
@@ -404,7 +402,7 @@ class TestReadPhaseRetry:
             return self._FailingReadResponse(TimeoutError("read timed out"))
 
         with patch("urllib.request.urlopen", _fake), \
-                patch("bicameral_agent.ollama_cloud.time.sleep") as sleep:
+                patch("bicameral_agent.model_client.time.sleep") as sleep:
             with pytest.raises(TimeoutError):
                 OllamaCloudClient(api_key="k").generate(
                     [{"role": "user", "content": "x"}]


### PR DESCRIPTION
## Summary
Closes the seams called out in the #52 review of the multi-provider abstraction: unknown model tags no longer crash after a paid call, the provider allow-list and default model names have a single source of truth in `model_client.py`, the copy-pasted retry/backoff scaffold is a shared base class, and both providers now speak neutral `ModelResponse`/`ChatMessage` types (with back-compat aliases).

## Work performed
- **Fail-fast pricing** — `build_client()` and `CostTrackedClient.__init__` resolve pricing before any call; `CostTrackedClient.generate` records with the pre-resolved pricing so `record_call` can never raise post-call and destroy a paid response. **Pricing decision:** unknown tags on Ollama fall back to flat $0/token with a one-time warning (Ollama Cloud is subscription-flat, so any `--model` override — including the documented `gemma3:27b-cloud` fallback — works without a registry edit; registering individual tags would just recreate the crash for the next tag). Unpriced metered (Gemini) tags are rejected outright at build/config time.
- **Single provider registry** — `PROVIDERS` in `model_client.py` (default model tag, plausible-tag pattern, flat-rate flag, lazy client factory). `ModelConfig.provider` validation and the `--provider` CLI `choices` in `run_baseline_benchmark.py` both derive from it; the `{gemini, ollama}` triplication is gone.
- **Shared retry base + neutral types** — `RetryingClientBase._execute_with_retry` with a per-provider `_is_retryable` hook preserves each client's typed retryability checks (google-genai `APIError` statuses; urllib/read-phase transients incl. `IncompleteRead`/`JSONDecodeError`). Neutral `ChatMessage`/`ModelResponse` dataclasses and a `ModelClient` Protocol live in `model_client.py`; `gemini.GeminiResponse` and `gemini.ChatMessage` remain as aliases so every existing import keeps working. `CostTrackedClient` is annotated with the Protocol and stays drop-in for `episode_runner.py`.
- **Per-provider default model names, cross-validated** — `ModelConfig.name` left unset resolves to the provider's registry default; a tag that matches another provider's pattern is rejected (`provider='ollama'` + Gemini default now fails at config time instead of sending the Gemini tag to Ollama). Env overrides that switch provider re-derive the default name. `thinking_level` validation is also deduplicated into one shared helper.
- **Alias retirement** — `test_cost_tracker.py` migrated to `MODEL_PRICING`; `GEMINI_PRICING` removed.

## Test plan
- `uv run --extra dev --extra torch pytest -q` — 1100 passed, 34 skipped.
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean.
- New tests: registry contents, fail-fast unpriced-Gemini-tag rejection at build, flat-rate fallback warning for unknown Ollama tags, provider/model cross-validation (factory + `ModelConfig`), per-provider default-name fill (constructor + env override), `CostTrackedClient` construction-time pricing validation and $0 recording for flat-rate tags.
- Existing retry tests retargeted to the shared base's `time.sleep`/`random.uniform` and to importing `_MAX_RETRIES` from `model_client`.
- Manual smoke: `--help` shows registry-derived choices; `--provider anthropic` rejected; `build_client('gemini', 'gemini-9-zzz')` fails fast; `build_client('ollama', 'gemma3:27b-cloud')` warns once and builds.

Closes #52