### PR TITLE
Per-role model selection: hold judge and sim-user fixed while the answerer varies

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -28,7 +28,7 @@ from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
-from bicameral_agent.model_client import build_client, provider_names
+from bicameral_agent.model_client import build_client, default_model, provider_names
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.schema import Episode
@@ -99,6 +99,15 @@ def main(argv: list[str] | None = None) -> int:
                              "(overrides the config file).")
     parser.add_argument("--model", default=None,
                         help="Model id/tag (overrides the config file).")
+    parser.add_argument("--judge-provider", choices=list(provider_names()),
+                        default=None,
+                        help="Model backend for the measurement roles (LLM "
+                             "judge and simulated user), held fixed while "
+                             "--provider varies. Defaults to the config's "
+                             "[measurement_model], else gemini.")
+    parser.add_argument("--judge-model", default=None,
+                        help="Measurement model id/tag (overrides the config "
+                             "file; unset uses the judge provider's default).")
     parser.add_argument("--dataset", choices=dataset_names(), default="builtin",
                         help="Evaluation dataset to run against. External "
                              "datasets must be fetched first via "
@@ -143,6 +152,29 @@ def main(argv: list[str] | None = None) -> int:
     # The configured model name only applies to the configured provider.
     model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
     client = build_client(provider, model)
+
+    # Measurement roles (LLM judge + simulated user) are pinned independently
+    # of the answerer so cross-model comparisons stay on one judging scale
+    # (issue #53). Precedence mirrors the answerer's: CLI > config > gemini.
+    measurement = hyper.measurement_model
+    judge_provider = args.judge_provider or (
+        measurement.provider if measurement is not None else "gemini"
+    )
+    judge_model = args.judge_model or (
+        measurement.name
+        if measurement is not None and judge_provider == measurement.provider
+        else None
+    )
+    resolved_judge_model = judge_model or default_model(judge_provider)
+    if judge_provider == provider and resolved_judge_model == client.model:
+        judge_client = client
+    else:
+        judge_client = build_client(judge_provider, judge_model)
+    logger.info(
+        "Answerer: %s/%s; measurement (judge + sim-user): %s/%s",
+        provider, client.model, judge_provider, judge_client.model,
+    )
+
     # The resolved metric passed ensure_runnable_metric, so this boolean
     # collapse is exhaustive over _RUNNABLE_METRICS.
     runner = EpisodeRunner(
@@ -154,6 +186,8 @@ def main(argv: list[str] | None = None) -> int:
         ),
         hyper_config=hyper,
         cost_tracker=cost_tracker,
+        judge_client=judge_client,
+        sim_user_client=judge_client,
     )
 
     conditions = {
@@ -186,6 +220,8 @@ def main(argv: list[str] | None = None) -> int:
     summary = {
         "dataset": args.dataset,
         "metric": metric,
+        "answerer": {"provider": provider, "model": client.model},
+        "measurement": {"provider": judge_provider, "model": judge_client.model},
         "tasks_per_condition": args.tasks_per_condition,
         "max_turns": args.max_turns,
         "conditions": {

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -216,6 +216,16 @@ class HyperConfig(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     model: ModelConfig = Field(default_factory=ModelConfig)
+    measurement_model: ModelConfig | None = None
+    """Model pinned for the measurement roles (LLM judge and simulated user).
+
+    A single section rather than per-role ones: judge and sim-user together
+    form the measurement apparatus, which issue #53 requires held fixed as
+    one unit while ``[model]`` (the answerer) varies. ``None`` means the
+    measurement roles use the answerer's client (back-compat). Only
+    ``provider``/``name`` are consumed; the measurement roles manage their
+    own generation settings.
+    """
     queue: QueueConfig = Field(default_factory=QueueConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     heuristic: HeuristicConfig = Field(default_factory=HeuristicConfig)

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -9,6 +9,13 @@ provider = "gemini"        # "gemini" or "ollama"
 thinking_level = "medium"  # "minimal", "low", "medium", or "high"
 # temperature is unset (uses model default)
 
+# [measurement_model]
+# Model held fixed for the measurement roles (LLM judge + simulated user) so
+# cross-model answerer comparisons stay on one judging scale (issue #53).
+# Unset = measurement roles use [model]. Only provider/name are consumed.
+# provider = "gemini"
+# name is unset (uses the provider's default model from the registry)
+
 [queue]
 count_threshold = 5        # interrupt if queue depth reaches this
 priority_threshold = 3     # interrupt if any item >= CRITICAL (3)

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -163,16 +163,15 @@ class EpisodeRunner:
         if self._cost_tracker is not None:
             self._cost_tracker.reset_episode()
             active_client = CostTrackedClient(self._client, self._cost_tracker)
-            judge_client = (
-                active_client
-                if self._judge_client is self._client
-                else CostTrackedClient(self._judge_client, self._cost_tracker)
-            )
-            sim_user_client = (
-                active_client
-                if self._sim_user_client is self._client
-                else CostTrackedClient(self._sim_user_client, self._cost_tracker)
-            )
+
+            def _tracked(role_client: ModelClient) -> ModelClient:
+                """Reuse the answerer's wrapper when the role shares its client."""
+                if role_client is self._client:
+                    return active_client
+                return CostTrackedClient(role_client, self._cost_tracker)
+
+            judge_client = _tracked(self._judge_client)
+            sim_user_client = _tracked(self._sim_user_client)
 
         # Initialize components
         queue = ContextQueue()

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -101,6 +101,14 @@ class EpisodeRunner:
 
     Wires together ConsciousLoop, Controller, SimulatedUser, SignalClassifier,
     ConversationLogger, tool primitives, and ContextQueue.
+
+    Per-role clients (issue #53): ``client`` drives the system under test --
+    the answerer (ConsciousLoop) *and* the subconscious tools, which are part
+    of that system and deliberately follow the answerer. ``judge_client`` and
+    ``sim_user_client`` drive the measurement apparatus (TaskScorer LLM judge
+    and SimulatedUser); hold them fixed while ``client`` varies so
+    cross-model comparisons stay on one judging scale. Both default to
+    ``client`` for back-compat.
     """
 
     def __init__(
@@ -109,8 +117,14 @@ class EpisodeRunner:
         config: EpisodeConfig | None = None,
         hyper_config: HyperConfig | None = None,
         cost_tracker: CostTracker | None = None,
+        judge_client: ModelClient | None = None,
+        sim_user_client: ModelClient | None = None,
     ) -> None:
         self._client = client
+        self._judge_client = judge_client if judge_client is not None else client
+        self._sim_user_client = (
+            sim_user_client if sim_user_client is not None else client
+        )
         if config is not None:
             self._config = config
         elif hyper_config is not None:
@@ -141,11 +155,24 @@ class EpisodeRunner:
         """
         cfg = self._config
 
-        # Cost tracking: reset episode, wrap client
+        # Cost tracking: reset episode, wrap every role's client so judge and
+        # sim-user calls hit the same budget and accounting as the answerer.
         active_client: ModelClient = self._client
+        judge_client: ModelClient = self._judge_client
+        sim_user_client: ModelClient = self._sim_user_client
         if self._cost_tracker is not None:
             self._cost_tracker.reset_episode()
             active_client = CostTrackedClient(self._client, self._cost_tracker)
+            judge_client = (
+                active_client
+                if self._judge_client is self._client
+                else CostTrackedClient(self._judge_client, self._cost_tracker)
+            )
+            sim_user_client = (
+                active_client
+                if self._sim_user_client is self._client
+                else CostTrackedClient(self._sim_user_client, self._cost_tracker)
+            )
 
         # Initialize components
         queue = ContextQueue()
@@ -160,7 +187,7 @@ class EpisodeRunner:
             persistent_injection=cfg.persistent_injection,
         )
         sim_user = SimulatedUser(
-            client=active_client,
+            client=sim_user_client,
             patience=cfg.patience,
             strictness=cfg.strictness,
         )
@@ -423,6 +450,25 @@ class EpisodeRunner:
         log.set_metadata("injection_mode", cfg.injection_mode.value)
         if self._hyper_config is not None:
             log.set_metadata("hyperparameters", self._hyper_config.to_dict())
+
+        # Score if requested. The LLM judge uses the (cost-tracked) judge
+        # client, so its calls count toward budgets and episode cost.
+        quality_score: float | None = None
+        if cfg.score_episode:
+            last_assistant = next(
+                (m.content for m in reversed(schema_messages) if m.role == "assistant"),
+                None,
+            )
+            if last_assistant is not None:
+                scorer = LexicalScorer() if cfg.use_lexical_scorer else TaskScorer(client=judge_client)
+                try:
+                    quality_score = scorer.score(task, last_assistant).overall
+                except CostBudgetExceeded:
+                    logger.warning(
+                        "CostBudgetExceeded while scoring, leaving quality_score unset"
+                    )
+
+        # Capture episode cost after scoring so judge calls are included.
         if self._cost_tracker is not None:
             episode_cost = self._cost_tracker.get_episode_cost()
             log.set_metadata("episode_cost", {
@@ -431,16 +477,5 @@ class EpisodeRunner:
                 "total": episode_cost.total,
                 "call_count": episode_cost.call_count,
             })
-
-        # Score if requested
-        quality_score: float | None = None
-        if cfg.score_episode:
-            last_assistant = next(
-                (m.content for m in reversed(schema_messages) if m.role == "assistant"),
-                None,
-            )
-            if last_assistant is not None:
-                scorer = LexicalScorer() if cfg.use_lexical_scorer else TaskScorer(client=self._client)
-                quality_score = scorer.score(task, last_assistant).overall
 
         return log.finalize(quality_score)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,11 @@ class TestDefaults:
         from_constructor = HyperConfig()
         assert from_defaults.model_dump() == from_constructor.model_dump()
 
+    def test_measurement_model_defaults_to_none(self):
+        """Unset [measurement_model] means measurement roles use [model]."""
+        assert HyperConfig().measurement_model is None
+        assert HyperConfig.from_defaults().measurement_model is None
+
 
 class TestToml:
     """TOML loading and round-trip."""
@@ -124,6 +129,33 @@ class TestToml:
             learning_rat = 0.01
         """))
         with pytest.raises(ValidationError, match="learning_rat"):
+            HyperConfig.from_toml(toml_file)
+
+    def test_from_toml_measurement_model(self, tmp_path):
+        """[measurement_model] parses, fills the provider's default name."""
+        toml_file = tmp_path / "measurement.toml"
+        toml_file.write_text(textwrap.dedent("""\
+            [model]
+            provider = "ollama"
+
+            [measurement_model]
+            provider = "gemini"
+        """))
+        cfg = HyperConfig.from_toml(toml_file)
+        assert cfg.model.provider == "ollama"
+        assert cfg.measurement_model is not None
+        assert cfg.measurement_model.provider == "gemini"
+        assert cfg.measurement_model.name == "gemini-3.1-flash-lite-preview"
+
+    def test_from_toml_measurement_model_mismatch_raises(self, tmp_path):
+        """A cross-provider model tag is rejected at config time."""
+        toml_file = tmp_path / "mismatch.toml"
+        toml_file.write_text(textwrap.dedent("""\
+            [measurement_model]
+            provider = "ollama"
+            name = "gemini-3.1-flash-lite-preview"
+        """))
+        with pytest.raises(ValidationError):
             HyperConfig.from_toml(toml_file)
 
     def test_from_toml_with_tool_budgets(self, tmp_path):

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -20,7 +20,11 @@ from bicameral_agent.gemini import GeminiClient, GeminiResponse
 from bicameral_agent.heuristic_controller import Action, FullState, HeuristicController
 from bicameral_agent.schema import Episode, UserEventType
 from bicameral_agent.simulated_user import ActionType, Strictness, UserAction
-from bicameral_agent.cost_tracker import CostBudgetExceeded
+from bicameral_agent.cost_tracker import (
+    CostBudgetExceeded,
+    CostTrackedClient,
+    CostTracker,
+)
 from bicameral_agent.tool_primitive import BudgetExceededError
 
 
@@ -1130,6 +1134,101 @@ class TestIntegrationControllerSwap:
 # ---------------------------------------------------------------------------
 # TestCostBudgetHandling (issue #47)
 # ---------------------------------------------------------------------------
+
+
+class TestPerRoleClients:
+    """Issue #53: judge and sim-user clients are selectable per role."""
+
+    _PRICED_MODEL = "gemini-3.1-flash-lite-preview"
+
+    def _run_episode(self, runner: EpisodeRunner):
+        """Run a one-turn scored episode; return the SimulatedUser and
+        TaskScorer mock classes so tests can inspect construction kwargs."""
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+
+        with patch(
+            "bicameral_agent.episode_runner.SimulatedUser"
+        ) as MockSimUser, patch(
+            "bicameral_agent.episode_runner.TaskScorer"
+        ) as MockScorer:
+            mock_sim = MagicMock()
+            mock_sim.respond.return_value = UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+            MockSimUser.return_value = mock_sim
+            mock_scorer = MagicMock()
+            mock_scorer.score.return_value = MagicMock(overall=0.5)
+            MockScorer.return_value = mock_scorer
+
+            runner.run_episode(_make_task(), ctrl)
+
+        return MockSimUser, MockScorer
+
+    def test_roles_default_to_main_client(self):
+        """Back-compat: without per-role clients, everyone gets the main one."""
+        client = _make_mock_client()
+        runner = EpisodeRunner(
+            client, EpisodeConfig(max_turns=1, score_episode=True)
+        )
+        MockSimUser, MockScorer = self._run_episode(runner)
+        assert MockSimUser.call_args.kwargs["client"] is client
+        assert MockScorer.call_args.kwargs["client"] is client
+
+    def test_judge_and_sim_user_clients_override(self):
+        """Per-role clients reach the scorer and sim-user, not the answerer's."""
+        client = _make_mock_client()
+        judge = _make_mock_client()
+        sim = _make_mock_client()
+        runner = EpisodeRunner(
+            client,
+            EpisodeConfig(max_turns=1, score_episode=True),
+            judge_client=judge,
+            sim_user_client=sim,
+        )
+        MockSimUser, MockScorer = self._run_episode(runner)
+        assert MockSimUser.call_args.kwargs["client"] is sim
+        assert MockScorer.call_args.kwargs["client"] is judge
+
+    def test_measurement_clients_cost_tracked(self):
+        """With a cost tracker, judge and sim-user clients are wrapped too."""
+        client = _make_mock_client()
+        client.model = self._PRICED_MODEL
+        judge = _make_mock_client()
+        judge.model = self._PRICED_MODEL
+        sim = _make_mock_client()
+        sim.model = self._PRICED_MODEL
+        runner = EpisodeRunner(
+            client,
+            EpisodeConfig(max_turns=1, score_episode=True),
+            cost_tracker=CostTracker(),
+            judge_client=judge,
+            sim_user_client=sim,
+        )
+        MockSimUser, MockScorer = self._run_episode(runner)
+        judge_arg = MockScorer.call_args.kwargs["client"]
+        sim_arg = MockSimUser.call_args.kwargs["client"]
+        assert isinstance(judge_arg, CostTrackedClient)
+        assert isinstance(sim_arg, CostTrackedClient)
+        assert judge_arg._inner is judge
+        assert sim_arg._inner is sim
+
+    def test_default_judge_cost_tracked(self):
+        """Judge calls no longer bypass cost tracking (issue #53)."""
+        client = _make_mock_client()
+        client.model = self._PRICED_MODEL
+        runner = EpisodeRunner(
+            client,
+            EpisodeConfig(max_turns=1, score_episode=True),
+            cost_tracker=CostTracker(),
+        )
+        _, MockScorer = self._run_episode(runner)
+        judge_arg = MockScorer.call_args.kwargs["client"]
+        assert isinstance(judge_arg, CostTrackedClient)
+        assert judge_arg._inner is client
 
 
 class TestCostBudgetHandling:


### PR DESCRIPTION
## Summary
`--provider` was all-or-nothing: the same client drove the answerer, the tools, the simulated user, and the TaskScorer LLM judge, so cross-model conditions ("Gemini judged by Gemini" vs "Gemma judged by Gemma") were not comparable. This PR lets the measurement apparatus (judge + sim-user) be pinned independently of the system under test (answerer + tools), and fixes judge calls bypassing cost tracking.

## Work performed
- **EpisodeRunner** accepts optional `judge_client` / `sim_user_client`, both defaulting to the main client (back-compat). When a cost tracker is present, all three roles' clients are cost-tracked.
- **Tools follow the answerer** (documented in the class docstring): they are part of the system under test, so they deliberately stay on the main client.
- **Config**: one optional `[measurement_model]` section (provider/name) covering both measurement roles. Chosen over per-role `[judge_model]`/`[sim_user_model]`: the two roles form one measurement apparatus that #46 requires pinned as a unit, and a single section makes accidental divergence impossible; per-role flexibility remains available via the runner's constructor.
- **CLI**: `scripts/run_baseline_benchmark.py` gains `--judge-provider` / `--judge-model` (set both measurement roles), with the existing precedence — CLI wins over config — and a `gemini` default independent of `--provider`. Reuses the answerer client when provider+model match; `summary.json` now records `answerer` and `measurement` provider/model for provenance.
- **Cost tracking**: `TaskScorer` now receives the cost-tracked judge client (was the unwrapped client). The `episode_cost` metadata snapshot moves after scoring so judge cost is included, and a `CostBudgetExceeded` during scoring degrades to `quality_score=None` instead of crashing the run.
- Posted the #46 run-plan note: pin judge + sim-user to the same Gemini model/version across all conditions.

## Test plan
- New `TestPerRoleClients` in `tests/test_episode_runner.py`: back-compat default (all roles get the main client), per-role overrides reach `SimulatedUser`/`TaskScorer`, measurement clients are wrapped by `CostTrackedClient`, and the default judge no longer bypasses cost tracking.
- New config tests: `[measurement_model]` defaults to `None`, parses from TOML with provider-default name filling, and rejects cross-provider model tags.
- `uv run --extra dev --extra torch pytest -q`: 1182 passed, 34 skipped.
- `uv run --extra dev ruff check src/ tests/ scripts/`: clean. `--help` verified for the new flags.

Closes #53