### PR TITLE
Add TrainingDataStore for saving and loading training examples

### DIFF
--- a/src/bicameral_agent/training_data_store.py
+++ b/src/bicameral_agent/training_data_store.py
@@ -183,23 +183,24 @@ class TrainingDataStore:
             msg = "cannot save an empty list of examples"
             raise ValueError(msg)
 
-        states = np.stack([e.state for e in examples]).astype(np.float32, copy=False)
-        next_states = np.stack([e.next_state for e in examples]).astype(np.float32, copy=False)
+        raw: dict[str, Any] = {
+            "states": np.stack([e.state for e in examples]),
+            "actions": [e.action for e in examples],
+            "rewards": [e.reward for e in examples],
+            "next_states": np.stack([e.next_state for e in examples]),
+            "dones": [e.done for e in examples],
+            "returns": [e.discounted_return for e in examples],
+        }
+        columns: dict[str, np.ndarray] = {
+            name: np.asarray(raw[name], dtype=dtype) for name, dtype in _COLUMN_DTYPES.items()
+        }
+        states, next_states = columns["states"], columns["next_states"]
         if states.shape[1] != STATE_DIM or next_states.shape[1] != STATE_DIM:
             msg = (
                 f"state vectors must have {STATE_DIM} dims, got "
                 f"{states.shape[1]} / {next_states.shape[1]}"
             )
             raise ValueError(msg)
-
-        columns: dict[str, np.ndarray] = {
-            "states": states,
-            "actions": np.array([e.action for e in examples], dtype=np.int64),
-            "rewards": np.array([e.reward for e in examples], dtype=np.float64),
-            "next_states": next_states,
-            "dones": np.array([e.done for e in examples], dtype=np.bool_),
-            "returns": np.array([e.discounted_return for e in examples], dtype=np.float64),
-        }
 
         chunk_dir = self._root / f"{_CHUNK_PREFIX}{self._next_chunk_id():06d}"
         chunk_dir.mkdir()

--- a/src/bicameral_agent/training_data_store.py
+++ b/src/bicameral_agent/training_data_store.py
@@ -1,0 +1,326 @@
+"""Append-only storage and loading for training examples.
+
+Storage layout
+--------------
+
+Each :meth:`TrainingDataStore.save_examples` call writes one new
+immutable *chunk* directory under the store root::
+
+    root/
+        chunk-000000/
+            states.npy        (N, STATE_DIM) float32
+            actions.npy       (N,)  int64
+            rewards.npy       (N,)  float64
+            next_states.npy   (N, STATE_DIM) float32
+            dones.npy         (N,)  bool
+            returns.npy       (N,)  float64
+            meta.json         sidecar: iteration, count, per-example
+                              provenance (episode_id, decision_index),
+                              optional chunk-level metadata (controller
+                              type, episode quality, ...)
+        chunk-000001/
+            ...
+
+Existing chunks are never rewritten, so incremental addition of new
+iterations is cheap and append-only. Arrays are opened with
+``mmap_mode="r"`` so loading is fast and lazy even for large stores.
+``meta.json`` is written last: a chunk directory without it is treated
+as incomplete and ignored by loaders.
+
+Scalar float columns (rewards, returns) are stored as float64 to
+round-trip Python floats exactly; state vectors are float32, matching
+what :class:`~bicameral_agent.training_pipeline.TrainingDataPipeline`
+produces.
+
+Torch is an optional dependency: this module imports without torch.
+Only the ``Dataset``-returning methods (:meth:`load_all`,
+:meth:`load_iteration`, :meth:`load_filtered`, :meth:`split`) require
+it. Datasets yield ``(state, action, reward, next_state, done,
+discounted_return)`` tuples with the same ordering and dtypes as
+``TrainingDataPipeline.to_torch_dataset``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingExample
+
+if TYPE_CHECKING:  # pragma: no cover
+    from torch.utils.data import Dataset
+
+_META_FILENAME = "meta.json"
+_CHUNK_PREFIX = "chunk-"
+
+# Column name -> on-disk dtype.
+_COLUMN_DTYPES: dict[str, type] = {
+    "states": np.float32,
+    "actions": np.int64,
+    "rewards": np.float64,
+    "next_states": np.float32,
+    "dones": np.bool_,
+    "returns": np.float64,
+}
+
+
+class _Chunk:
+    """One immutable saved batch: memory-mapped columns plus sidecar metadata."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        with (path / _META_FILENAME).open(encoding="utf-8") as f:
+            self.meta: dict[str, Any] = json.load(f)
+        self.iteration: int = int(self.meta["iteration"])
+        self.count: int = int(self.meta["count"])
+        self.arrays: dict[str, np.ndarray] = {
+            name: np.load(path / f"{name}.npy", mmap_mode="r") for name in _COLUMN_DTYPES
+        }
+
+    def example_record(self, i: int) -> dict[str, Any]:
+        """Per-example metadata record used for filtering.
+
+        Chunk-level metadata (e.g. controller type, episode quality) is
+        merged with per-example provenance fields.
+        """
+        record: dict[str, Any] = dict(self.meta.get("metadata") or {})
+        record["iteration"] = self.iteration
+        record["episode_id"] = self.meta["episode_ids"][i]
+        record["decision_index"] = self.meta["decision_indices"][i]
+        record["done"] = bool(self.arrays["dones"][i])
+        return record
+
+
+# Lazily created torch Dataset subclass (keeps torch optional at import).
+_DATASET_CLS: type | None = None
+
+
+def _get_dataset_cls() -> type:
+    global _DATASET_CLS
+    if _DATASET_CLS is not None:
+        return _DATASET_CLS
+
+    import torch
+    from torch.utils.data import Dataset
+
+    class MemmapExampleDataset(Dataset):
+        """Dataset over memory-mapped chunks, optionally restricted to indices.
+
+        Items are ``(state, action, reward, next_state, done,
+        discounted_return)`` tensors, matching
+        ``TrainingDataPipeline.to_torch_dataset``.
+        """
+
+        def __init__(self, chunks: list[_Chunk], indices: np.ndarray | None = None) -> None:
+            self._chunks = chunks
+            self._offsets = np.cumsum([0] + [c.count for c in chunks])
+            total = int(self._offsets[-1])
+            if indices is None:
+                self._indices = np.arange(total, dtype=np.int64)
+            else:
+                self._indices = np.asarray(indices, dtype=np.int64)
+
+        def __len__(self) -> int:
+            return len(self._indices)
+
+        def __getitem__(self, idx: int):
+            g = int(self._indices[idx])
+            ci = int(np.searchsorted(self._offsets, g, side="right")) - 1
+            local = g - int(self._offsets[ci])
+            arrays = self._chunks[ci].arrays
+            return (
+                torch.from_numpy(np.array(arrays["states"][local])),
+                torch.tensor(int(arrays["actions"][local]), dtype=torch.long),
+                torch.tensor(float(arrays["rewards"][local]), dtype=torch.float32),
+                torch.from_numpy(np.array(arrays["next_states"][local])),
+                torch.tensor(bool(arrays["dones"][local]), dtype=torch.bool),
+                torch.tensor(float(arrays["returns"][local]), dtype=torch.float32),
+            )
+
+    _DATASET_CLS = MemmapExampleDataset
+    return _DATASET_CLS
+
+
+class TrainingDataStore:
+    """Append-only on-disk store for :class:`TrainingExample` records.
+
+    Parameters
+    ----------
+    root:
+        Directory holding the store. Created if it does not exist.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Saving
+    # ------------------------------------------------------------------
+
+    def save_examples(
+        self,
+        examples: list[TrainingExample],
+        iteration: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Append ``examples`` as a new immutable chunk tagged ``iteration``.
+
+        Existing chunks are never touched. ``metadata`` is an optional
+        chunk-level dict (e.g. ``{"controller": "heuristic",
+        "quality": 0.9}``) stored in the sidecar and made available to
+        :meth:`load_filtered` predicates.
+        """
+        if iteration < 0:
+            msg = f"iteration must be >= 0, got {iteration}"
+            raise ValueError(msg)
+        if not examples:
+            msg = "cannot save an empty list of examples"
+            raise ValueError(msg)
+
+        states = np.stack([e.state for e in examples]).astype(np.float32, copy=False)
+        next_states = np.stack([e.next_state for e in examples]).astype(np.float32, copy=False)
+        if states.shape[1] != STATE_DIM or next_states.shape[1] != STATE_DIM:
+            msg = (
+                f"state vectors must have {STATE_DIM} dims, got "
+                f"{states.shape[1]} / {next_states.shape[1]}"
+            )
+            raise ValueError(msg)
+
+        columns: dict[str, np.ndarray] = {
+            "states": states,
+            "actions": np.array([e.action for e in examples], dtype=np.int64),
+            "rewards": np.array([e.reward for e in examples], dtype=np.float64),
+            "next_states": next_states,
+            "dones": np.array([e.done for e in examples], dtype=np.bool_),
+            "returns": np.array([e.discounted_return for e in examples], dtype=np.float64),
+        }
+
+        chunk_dir = self._root / f"{_CHUNK_PREFIX}{self._next_chunk_id():06d}"
+        chunk_dir.mkdir()
+        for name, arr in columns.items():
+            np.save(chunk_dir / f"{name}.npy", arr)
+
+        meta = {
+            "iteration": iteration,
+            "count": len(examples),
+            "state_dim": STATE_DIM,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "metadata": dict(metadata or {}),
+            "episode_ids": [e.episode_id for e in examples],
+            "decision_indices": [e.decision_index for e in examples],
+        }
+        # Written last: a chunk without meta.json is ignored by loaders,
+        # so a crash mid-save cannot corrupt reads.
+        with (chunk_dir / _META_FILENAME).open("w", encoding="utf-8") as f:
+            json.dump(meta, f)
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def load_all(self) -> Dataset:
+        """Load all examples across all iterations as a PyTorch Dataset."""
+        return _get_dataset_cls()(self._chunks())
+
+    def load_iteration(self, n: int) -> Dataset:
+        """Load examples saved under iteration ``n`` as a PyTorch Dataset."""
+        return _get_dataset_cls()([c for c in self._chunks() if c.iteration == n])
+
+    def load_filtered(self, predicate: Callable[[dict[str, Any]], bool]) -> Dataset:
+        """Load examples whose metadata record satisfies ``predicate``.
+
+        The predicate receives one dict per example containing
+        ``iteration``, ``episode_id``, ``decision_index``, ``done`` and
+        any chunk-level metadata passed to :meth:`save_examples`.
+        """
+        chunks = self._chunks()
+        indices: list[int] = []
+        offset = 0
+        for chunk in chunks:
+            for i in range(chunk.count):
+                if predicate(chunk.example_record(i)):
+                    indices.append(offset + i)
+            offset += chunk.count
+        return _get_dataset_cls()(chunks, np.array(indices, dtype=np.int64))
+
+    def split(self, train_ratio: float = 0.8, seed: int = 0) -> tuple[Dataset, Dataset]:
+        """Deterministic (train, val) split over all stored examples.
+
+        The same store contents, ``train_ratio`` and ``seed`` always
+        produce the identical split.
+        """
+        if not 0.0 < train_ratio < 1.0:
+            msg = f"train_ratio must be in (0, 1), got {train_ratio}"
+            raise ValueError(msg)
+        chunks = self._chunks()
+        total = sum(c.count for c in chunks)
+        perm = np.random.default_rng(seed).permutation(total)
+        n_train = int(total * train_ratio)
+        cls = _get_dataset_cls()
+        return cls(chunks, perm[:n_train]), cls(chunks, perm[n_train:])
+
+    def load_examples(self, iteration: int | None = None) -> list[TrainingExample]:
+        """Materialize stored examples back into :class:`TrainingExample` objects.
+
+        Torch-free exact round-trip; optionally restricted to one iteration.
+        """
+        out: list[TrainingExample] = []
+        for chunk in self._chunks():
+            if iteration is not None and chunk.iteration != iteration:
+                continue
+            arrays = chunk.arrays
+            episode_ids = chunk.meta["episode_ids"]
+            decision_indices = chunk.meta["decision_indices"]
+            for i in range(chunk.count):
+                out.append(
+                    TrainingExample(
+                        state=np.array(arrays["states"][i]),
+                        action=int(arrays["actions"][i]),
+                        reward=float(arrays["rewards"][i]),
+                        next_state=np.array(arrays["next_states"][i]),
+                        done=bool(arrays["dones"][i]),
+                        discounted_return=float(arrays["returns"][i]),
+                        episode_id=episode_ids[i],
+                        decision_index=int(decision_indices[i]),
+                    )
+                )
+        return out
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return sum(c.count for c in self._chunks())
+
+    @property
+    def iterations(self) -> list[int]:
+        """Sorted list of distinct iteration numbers present in the store."""
+        return sorted({c.iteration for c in self._chunks()})
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _chunks(self) -> list[_Chunk]:
+        """All complete chunks, sorted by chunk id (== insertion order)."""
+        dirs = sorted(
+            p
+            for p in self._root.iterdir()
+            if p.is_dir() and p.name.startswith(_CHUNK_PREFIX) and (p / _META_FILENAME).exists()
+        )
+        return [_Chunk(p) for p in dirs]
+
+    def _next_chunk_id(self) -> int:
+        ids = [
+            int(p.name.removeprefix(_CHUNK_PREFIX))
+            for p in self._root.iterdir()
+            if p.is_dir() and p.name.startswith(_CHUNK_PREFIX)
+        ]
+        return max(ids) + 1 if ids else 0

--- a/tests/test_training_data_store.py
+++ b/tests/test_training_data_store.py
@@ -1,0 +1,324 @@
+"""Tests for TrainingDataStore (issue #38).
+
+Torch-dependent tests use ``pytest.importorskip("torch")`` (same
+pattern as test_training_pipeline.py) so collection works without the
+torch extra.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from bicameral_agent.training_data_store import TrainingDataStore
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingExample
+
+
+def make_examples(
+    n: int,
+    *,
+    seed: int = 0,
+    episode_prefix: str = "ep",
+) -> list[TrainingExample]:
+    """Synthetic examples with the real TrainingExample shape."""
+    rng = np.random.default_rng(seed)
+    examples: list[TrainingExample] = []
+    for i in range(n):
+        examples.append(
+            TrainingExample(
+                state=rng.random(STATE_DIM).astype(np.float32),
+                action=int(rng.integers(0, 4)),
+                reward=float(rng.normal()),
+                next_state=rng.random(STATE_DIM).astype(np.float32),
+                done=bool(i % 7 == 6),
+                discounted_return=float(rng.normal()),
+                episode_id=f"{episode_prefix}-{i // 10}",
+                decision_index=i % 10,
+            )
+        )
+    return examples
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> TrainingDataStore:
+    return TrainingDataStore(tmp_path / "store")
+
+
+# ---------------------------------------------------------------------------
+# AC1: 10,000 examples round-trip exactly
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_10k_exact(store: TrainingDataStore) -> None:
+    originals = make_examples(10_000, seed=1)
+    store.save_examples(originals, iteration=0)
+
+    loaded = store.load_examples()
+    assert len(loaded) == 10_000
+
+    np.testing.assert_array_equal(
+        np.stack([e.state for e in loaded]),
+        np.stack([e.state for e in originals]),
+    )
+    np.testing.assert_array_equal(
+        np.stack([e.next_state for e in loaded]),
+        np.stack([e.next_state for e in originals]),
+    )
+    assert [e.action for e in loaded] == [e.action for e in originals]
+    assert [e.reward for e in loaded] == [e.reward for e in originals]
+    assert [e.done for e in loaded] == [e.done for e in originals]
+    assert [e.discounted_return for e in loaded] == [
+        e.discounted_return for e in originals
+    ]
+    assert [e.episode_id for e in loaded] == [e.episode_id for e in originals]
+    assert [e.decision_index for e in loaded] == [e.decision_index for e in originals]
+
+
+# ---------------------------------------------------------------------------
+# AC2: load time for 10,000 examples < 1 second
+# ---------------------------------------------------------------------------
+
+
+def test_load_10k_under_one_second(store: TrainingDataStore) -> None:
+    store.save_examples(make_examples(10_000, seed=2), iteration=0)
+
+    t0 = time.perf_counter()
+    examples = store.load_examples()
+    elapsed = time.perf_counter() - t0
+    assert len(examples) == 10_000
+    assert elapsed < 1.0, f"load_examples took {elapsed:.2f}s; budget is 1s"
+
+
+def test_load_all_dataset_10k_under_one_second(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    store.save_examples(make_examples(10_000, seed=3), iteration=0)
+
+    t0 = time.perf_counter()
+    dataset = store.load_all()
+    n = len(dataset)
+    first = dataset[0]
+    last = dataset[n - 1]
+    elapsed = time.perf_counter() - t0
+    assert n == 10_000
+    assert first[0].shape == (STATE_DIM,)
+    assert last[0].shape == (STATE_DIM,)
+    assert elapsed < 1.0, f"load_all took {elapsed:.2f}s; budget is 1s"
+
+
+# ---------------------------------------------------------------------------
+# AC3: train/val split is deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_split_deterministic(store: TrainingDataStore, tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    store.save_examples(make_examples(1_000, seed=4), iteration=0)
+
+    train_a, val_a = store.split(train_ratio=0.8)
+    # A fresh store instance over the same directory must give the same split.
+    reopened = TrainingDataStore(tmp_path / "store")
+    train_b, val_b = reopened.split(train_ratio=0.8)
+
+    assert len(train_a) == len(train_b) == 800
+    assert len(val_a) == len(val_b) == 200
+    for i in range(len(train_a)):
+        assert torch.equal(train_a[i][0], train_b[i][0])
+    for i in range(len(val_a)):
+        assert torch.equal(val_a[i][0], val_b[i][0])
+
+
+def test_split_is_disjoint_and_covers_everything(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    originals = make_examples(100, seed=5)
+    store.save_examples(originals, iteration=0)
+
+    train, val = store.split(train_ratio=0.8)
+    # Use discounted_return as a per-example fingerprint (float64 draws
+    # are unique with probability 1).
+    split_values = sorted(
+        float(item[5]) for dataset in (train, val) for item in dataset
+    )
+    original_values = sorted(
+        np.float32(e.discounted_return) for e in originals
+    )
+    assert split_values == pytest.approx(original_values)
+
+
+def test_split_rejects_bad_ratio(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    store.save_examples(make_examples(10), iteration=0)
+    with pytest.raises(ValueError):
+        store.split(train_ratio=0.0)
+    with pytest.raises(ValueError):
+        store.split(train_ratio=1.0)
+
+
+# ---------------------------------------------------------------------------
+# AC4: incremental addition (5K + 5K -> 10K) without rewriting old chunks
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_addition(store: TrainingDataStore, tmp_path: Path) -> None:
+    store.save_examples(make_examples(5_000, seed=6, episode_prefix="a"), iteration=0)
+
+    root = tmp_path / "store"
+    first_chunk = sorted(p for p in root.iterdir() if p.is_dir())[0]
+    before = {p.name: p.read_bytes() for p in first_chunk.iterdir()}
+
+    store.save_examples(make_examples(5_000, seed=7, episode_prefix="b"), iteration=1)
+
+    assert len(store) == 10_000
+    loaded = store.load_examples()
+    assert len(loaded) == 10_000
+    assert sum(1 for e in loaded if e.episode_id.startswith("a-")) == 5_000
+    assert sum(1 for e in loaded if e.episode_id.startswith("b-")) == 5_000
+
+    # The first chunk's files were not rewritten.
+    after = {p.name: p.read_bytes() for p in first_chunk.iterdir()}
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# AC5: filtering by iteration
+# ---------------------------------------------------------------------------
+
+
+def test_load_iteration_filters_correctly(store: TrainingDataStore) -> None:
+    store.save_examples(make_examples(30, seed=8, episode_prefix="it1"), iteration=1)
+    store.save_examples(make_examples(20, seed=9, episode_prefix="it2"), iteration=2)
+    # A second chunk in iteration 1 accumulates.
+    store.save_examples(make_examples(10, seed=10, episode_prefix="it1b"), iteration=1)
+
+    assert store.iterations == [1, 2]
+    it1 = store.load_examples(iteration=1)
+    it2 = store.load_examples(iteration=2)
+    assert len(it1) == 40
+    assert len(it2) == 20
+    assert all(e.episode_id.startswith("it1") for e in it1)
+    assert all(e.episode_id.startswith("it2") for e in it2)
+    assert store.load_examples(iteration=3) == []
+
+
+def test_load_iteration_dataset(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    store.save_examples(make_examples(30, seed=8), iteration=1)
+    store.save_examples(make_examples(20, seed=9), iteration=2)
+    assert len(store.load_iteration(1)) == 30
+    assert len(store.load_iteration(2)) == 20
+    assert len(store.load_iteration(3)) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC6: PyTorch DataLoader batch iteration
+# ---------------------------------------------------------------------------
+
+
+def test_dataloader_iteration(store: TrainingDataStore) -> None:
+    torch = pytest.importorskip("torch")
+    from torch.utils.data import DataLoader
+
+    store.save_examples(make_examples(64, seed=11), iteration=0)
+    loader = DataLoader(store.load_all(), batch_size=16, shuffle=False)
+    batches = list(loader)
+    assert len(batches) == 4
+
+    states, actions, rewards, next_states, dones, returns = batches[0]
+    assert states.shape == (16, STATE_DIM)
+    assert next_states.shape == (16, STATE_DIM)
+    assert states.dtype == torch.float32
+    assert actions.dtype == torch.long
+    assert rewards.dtype == torch.float32
+    assert dones.dtype == torch.bool
+    assert returns.dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# Metadata filtering (episode quality, controller type, ...)
+# ---------------------------------------------------------------------------
+
+
+def test_load_filtered_by_chunk_metadata(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    store.save_examples(
+        make_examples(30, seed=12),
+        iteration=0,
+        metadata={"controller": "heuristic", "quality": 0.9},
+    )
+    store.save_examples(
+        make_examples(20, seed=13),
+        iteration=0,
+        metadata={"controller": "random", "quality": 0.2},
+    )
+
+    heuristic = store.load_filtered(lambda m: m["controller"] == "heuristic")
+    assert len(heuristic) == 30
+    good = store.load_filtered(lambda m: m["quality"] >= 0.5)
+    assert len(good) == 30
+    none = store.load_filtered(lambda m: m["quality"] > 1.0)
+    assert len(none) == 0
+
+
+def test_load_filtered_by_example_fields(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    store.save_examples(make_examples(50, seed=14, episode_prefix="x"), iteration=0)
+    first_episode = store.load_filtered(lambda m: m["episode_id"] == "x-0")
+    assert len(first_episode) == 10
+    terminal = store.load_filtered(lambda m: m["done"])
+    assert len(terminal) == 50 // 7
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_store(store: TrainingDataStore) -> None:
+    assert len(store) == 0
+    assert store.iterations == []
+    assert store.load_examples() == []
+
+
+def test_empty_store_dataset(store: TrainingDataStore) -> None:
+    pytest.importorskip("torch")
+    assert len(store.load_all()) == 0
+
+
+def test_save_empty_list_raises(store: TrainingDataStore) -> None:
+    with pytest.raises(ValueError):
+        store.save_examples([], iteration=0)
+
+
+def test_save_negative_iteration_raises(store: TrainingDataStore) -> None:
+    with pytest.raises(ValueError):
+        store.save_examples(make_examples(1), iteration=-1)
+
+
+def test_save_wrong_state_dim_raises(store: TrainingDataStore) -> None:
+    bad = TrainingExample(
+        state=np.zeros(STATE_DIM + 1, dtype=np.float32),
+        action=0,
+        reward=0.0,
+        next_state=np.zeros(STATE_DIM + 1, dtype=np.float32),
+        done=False,
+        discounted_return=0.0,
+        episode_id="bad",
+        decision_index=0,
+    )
+    with pytest.raises(ValueError):
+        store.save_examples([bad], iteration=0)
+
+
+def test_incomplete_chunk_is_ignored(store: TrainingDataStore, tmp_path: Path) -> None:
+    store.save_examples(make_examples(5, seed=15), iteration=0)
+    # Simulate a crash mid-save: chunk dir without meta.json.
+    partial = tmp_path / "store" / "chunk-000001"
+    partial.mkdir()
+    np.save(partial / "states.npy", np.zeros((3, STATE_DIM), dtype=np.float32))
+
+    assert len(store) == 5
+    # The next save must not collide with the partial directory.
+    store.save_examples(make_examples(5, seed=16), iteration=1)
+    assert len(store) == 10


### PR DESCRIPTION
## Summary
Implements `TrainingDataStore` (issue #38): append-only on-disk storage for `TrainingExample` records with memory-mapped numpy columns, a JSON metadata sidecar per chunk, and PyTorch `Dataset` loaders for training the MCTS policy.

## Work performed
- New module `src/bicameral_agent/training_data_store.py`:
  - `save_examples(examples, iteration, metadata=None)` — each call writes one immutable chunk directory (`chunk-NNNNNN/`) of `.npy` column arrays (`states`, `actions`, `rewards`, `next_states`, `dones`, `returns`) plus a `meta.json` sidecar with iteration, per-example provenance (`episode_id`, `decision_index`), and optional chunk-level metadata (controller type, episode quality, ...). Old chunks are never rewritten; `meta.json` is written last so a crash mid-save leaves an ignorable partial chunk.
  - `load_all()` / `load_iteration(n)` / `load_filtered(predicate)` — return a PyTorch `Dataset` over `mmap_mode="r"` arrays; items match `TrainingDataPipeline.to_torch_dataset`'s `(state, action, reward, next_state, done, discounted_return)` layout and dtypes.
  - `split(train_ratio=0.8, seed=0)` — deterministic (train, val) split via a seeded permutation.
  - `load_examples(iteration=None)` — torch-free exact reconstruction of `TrainingExample` objects; scalar float columns are stored as float64 so rewards/returns round-trip exactly.
  - Torch stays optional: the module imports without torch; the `Dataset` class is created lazily on first use.
- New tests `tests/test_training_data_store.py` (18 tests) using synthetic examples built from the real `STATE_DIM`/`TrainingExample` shape; torch-dependent tests use `pytest.importorskip("torch")` per repo convention so collection works without the extra.

## Test plan
- `uv run --extra dev --extra torch pytest -q` — 1192 passed, 34 skipped.
- `uv run --extra dev --extra torch ruff check src/ tests/` — clean.
- Acceptance criteria covered by tests:
  - 10,000 examples round-trip exactly (`test_round_trip_10k_exact`)
  - 10,000-example load < 1s (`test_load_10k_under_one_second`, `test_load_all_dataset_10k_under_one_second`)
  - Deterministic split, including across store re-open; disjoint and covering (`test_split_deterministic`, `test_split_is_disjoint_and_covers_everything`)
  - Incremental 5K + 5K -> 10K with first chunk byte-identical afterward (`test_incremental_addition`)
  - Iteration filtering incl. multi-chunk iterations (`test_load_iteration_*`)
  - DataLoader batch iteration with correct shapes/dtypes (`test_dataloader_iteration`)

Closes #38
