### PR TITLE
Complete the dataset factory: schema extensions, verifiers, runner wiring, seven adapters, docs (#56)

### DIFF
--- a/docs/eval_datasets.md
+++ b/docs/eval_datasets.md
@@ -1,0 +1,146 @@
+# Evaluation datasets (Issue #56)
+
+Plug-and-play external benchmarks for the research QA harness. Every dataset
+is one small adapter in `src/bicameral_agent/eval_datasets/` that maps
+upstream rows onto the existing `ResearchQATask` shape, declares a default
+verification metric, and shares one fetch/cache/load lifecycle.
+
+Supersedes `docs/hard_benchmark.md` (Issue #42), which now points here.
+
+## What ships in the repo vs. what is fetched
+
+**No external dataset is committed to this repository.** We map and point at
+upstream sources; you download the data yourself. This keeps the repo free of
+data whose redistribution terms are unclear (see Licensing below).
+
+| In git (owned by us) | Fetched locally (git-ignored) |
+|---|---|
+| `src/bicameral_agent/eval_datasets/` — adapters + registry | `data/external/<name>.json` — the pulled subsets |
+| `scripts/fetch_dataset.py` — fetch CLI | |
+| synthetic test fixtures / mocked pagers in `tests/` | |
+
+## Usage
+
+```bash
+# Fetch (writes data/external/<name>.json; prints license + citation)
+python scripts/fetch_dataset.py --dataset frames [--limit N]
+
+# Run the benchmark against it
+uv run python scripts/run_baseline_benchmark.py --dataset frames [--metric llm_judge]
+```
+
+In code:
+
+```python
+from bicameral_agent.eval_datasets import build_dataset, resolve_metric
+
+ds = build_dataset("supergpqa")
+ds.build(50)              # fetch from upstream, write the cache
+dataset = ds.load()       # -> ResearchQADataset
+metric = resolve_metric(ds)          # dataset default, CLI-overridable
+```
+
+`--dataset builtin` (the default) is the packaged 130-task pool — exactly the
+pre-factory behavior, nothing fetched or cached.
+
+## Dataset matrix
+
+| name | source | tier | default metric | license / gating |
+|---|---|---|---|---|
+| `builtin` | packaged `research_qa.json` | mixed | `llm_judge` | ours |
+| `frames` | HF `google/frames-benchmark` | hard | `llm_judge` | Apache-2.0 |
+| `crepe` | HF `tasksource/CREPE` | tricky | `llm_judge` | none declared — fetch-only, never redistribute |
+| `hard_benchmark` | FRAMES + CREPE composite | hard+tricky | `llm_judge` | see both |
+| `simpleqa_verified` | HF `google/simpleqa-verified` | typical | `exact_match` | MIT |
+| `supergpqa` | HF `m-a-p/SuperGPQA` | hard | `multiple_choice` | ODC-BY (attribution) |
+| `bbeh` | GitHub `google-deepmind/bbeh` | hard | `exact_match` | CC-BY-4.0 |
+| `healthbench_hard` | `openai/simple-evals` JSONL blob | hard | `rubric_coverage` | MIT |
+| `researchqa` | HF `realliyifei/ResearchQA` | hard | `rubric_coverage` | MIT |
+| `abstentionbench` | HF `facebook/AbstentionBench` | hard | `abstention` | **CC-BY-NC-4.0 — non-commercial only; fetch-only** |
+| `hle` | HF `cais/hle` | hard | `llm_judge` | MIT, **gated** (accept terms + `HF_TOKEN`) |
+
+Tier notes: adapters that cannot populate per-row `known_assumptions` map to
+`hard`, never `tricky` (the `tricky` invariant requires an annotated
+assumption). CREPE's presupposition annotations populate `known_assumptions`
+directly, so it is the `tricky` source.
+
+## Verifier matrix
+
+Metric names are registry keys for `bicameral_agent.verifiers.build_verifier`;
+each dataset declares a `default_metric` overridable via `--metric` within its
+`supported_metrics`. All verifiers return the normalized `TaskScore` shape
+(`overall` in [0, 1] feeds `EpisodeOutcome.quality_score`); the mode-specific
+report goes to `TaskScore.detail` and lands in
+`episode.metadata["verification"]`.
+
+| metric | backend | behavior |
+|---|---|---|
+| `llm_judge` | LLM (judge client) | rubric + gold-answer 1–5 grading (`TaskScorer`) |
+| `lexical` | deterministic | token F1 / ROUGE-L vs gold (`LexicalScorer`) |
+| `exact_match` | deterministic | normalized / numeric equality, with trailing "answer is X" extraction |
+| `multiple_choice` | deterministic | letter extraction (stated answer, bare letter, unique choice-text match) vs gold letter |
+| `rubric_coverage` | LLM (judge client) | which `rubric_items` are satisfied; earned points over positive points, negative points penalize (HealthBench-style) |
+| `abstention` | LLM (judge client) | did the answer abstain, compared to `abstention_expected` |
+
+## Task-schema extensions
+
+`ResearchQATask` gained three optional fields (all `None` for existing data):
+
+- `choices: list[str] | None` — multiple-choice options (SuperGPQA); options
+  are also embedded in the question text, since the answerer sees only
+  `question`.
+- `rubric_items: list[RubricItem] | None` — weighted criteria
+  (`RubricItem(criterion, points)`); HealthBench points may be negative.
+- `abstention_expected: bool | None` — AbstentionBench label.
+
+`gold_answer=""` is valid **only** when `rubric_items` is set (ResearchQA has
+no single gold answer); a validator enforces the pairing.
+
+## Per-dataset notes and caveats
+
+- **FRAMES** (`google/frames-benchmark`, Apache-2.0). Multi-hop factual QA.
+  Cite: *Fact, Fetch, and Reason: A Unified Evaluation of Retrieval-Augmented
+  Generation*, arXiv:2409.12941. Mapping: `Prompt`→question, `Answer`→gold;
+  rubric synthesized around the gold answer.
+- **CREPE** (via `tasksource/CREPE` re-host, arXiv:2211.17257). False-premise
+  questions; `presuppositions`→`known_assumptions`, `corrections`→gold. The
+  original repo declares **no license** (NOASSERTION): fetch-only, do not
+  redistribute. Cite: Yu et al., ACL 2023.
+- **SimpleQA Verified** (`google/simpleqa-verified`, MIT). 1,000 verified
+  short-answer facts; `problem`/`answer` columns, config `simpleqa_verified`,
+  split `eval`. The official SimpleQA autorater prompt is not implemented;
+  `exact_match` is the deterministic default and `llm_judge` gives graded
+  credit.
+- **SuperGPQA** (`m-a-p/SuperGPQA`, ODC-BY). `options`→`choices` (and embedded
+  in the question), `answer_letter`→gold. Cite: arXiv:2502.14739.
+- **BBEH** (`google-deepmind/bbeh`, CC-BY-4.0). Raw `task.json` per subtask on
+  GitHub; sampled round-robin across the 23 subtasks for coverage. Cite:
+  arXiv:2502.19187.
+- **HealthBench Hard** (openai/simple-evals blob, MIT). JSONL records:
+  conversation `prompt` (flattened into the question), weighted `rubrics`
+  → `rubric_items`, published ideal completion → gold answer. Cite:
+  arXiv:2505.08775.
+- **ResearchQA** (`realliyifei/ResearchQA`, MIT). Rubric-native: `query` +
+  unweighted `rubric` items (mapped at 1.0 point each), `gold_answer=""`.
+  Cite: arXiv:2509.00496.
+- **AbstentionBench** (`facebook/AbstentionBench`, **CC-BY-NC-4.0**).
+  Non-commercial license — fetched locally for research use only, never
+  redistributed. `should_abstain`→`abstention_expected`; rows without
+  reference answers get an explicit "abstain" gold statement. **Caveat:**
+  upstream currently ships a `datasets` loading script the HF datasets-server
+  cannot build, so a live fetch fails with an actionable error until upstream
+  publishes data files; the adapter targets the script's declared feature
+  schema. Cite: arXiv:2506.09038.
+- **HLE** (`cais/hle`, MIT, gated). Accept the dataset terms on Hugging Face
+  and export `HF_TOKEN`; the pager sends it (to the datasets-server only) as
+  a bearer token. Multi-modal rows are filtered out — text-only harness.
+  Field mapping is best-effort from the public dataset card (the gate blocks
+  offline schema verification). Cite: arXiv:2501.14249.
+
+## Output: EvalReport
+
+`scripts/run_baseline_benchmark.py` writes `summary.json` via
+`bicameral_agent.eval_report.EvalReport`: dataset/metric identity, answerer +
+measurement-model provenance, per-condition `MetricSummary` aggregates
+(unchanged shape — the ui/ Review screen keeps working), plus per-task
+`results` with each episode's score and verification detail.

--- a/docs/eval_datasets.md
+++ b/docs/eval_datasets.md
@@ -81,6 +81,7 @@ report goes to `TaskScore.detail` and lands in
 | `multiple_choice` | deterministic | letter extraction (stated answer, bare letter, unique choice-text match) vs gold letter |
 | `rubric_coverage` | LLM (judge client) | which `rubric_items` are satisfied; earned points over positive points, negative points penalize (HealthBench-style) |
 | `abstention` | LLM (judge client) | did the answer abstain, compared to `abstention_expected` |
+| `llm_autorater` | LLM (judge client) | official SimpleQA 3-way grading (verbatim openai/simple-evals template): correct→1.0, incorrect→0.0, not_attempted→0.0 with the verdict kept in `detail` |
 
 ## Task-schema extensions
 
@@ -108,9 +109,9 @@ no single gold answer); a validator enforces the pairing.
   redistribute. Cite: Yu et al., ACL 2023.
 - **SimpleQA Verified** (`google/simpleqa-verified`, MIT). 1,000 verified
   short-answer facts; `problem`/`answer` columns, config `simpleqa_verified`,
-  split `eval`. The official SimpleQA autorater prompt is not implemented;
-  `exact_match` is the deterministic default and `llm_judge` gives graded
-  credit.
+  split `eval`. `exact_match` is the deterministic default; `llm_autorater`
+  runs the official SimpleQA 3-way grading prompt and `llm_judge` gives
+  graded credit.
 - **SuperGPQA** (`m-a-p/SuperGPQA`, ODC-BY). `options`→`choices` (and embedded
   in the question), `answer_letter`→gold. Cite: arXiv:2502.14739.
 - **BBEH** (`google-deepmind/bbeh`, CC-BY-4.0). Raw `task.json` per subtask on

--- a/docs/hard_benchmark.md
+++ b/docs/hard_benchmark.md
@@ -1,119 +1,18 @@
 # Harder benchmark integration (Issue #42)
 
-> **Note (Issue #56):** the implementation now lives in the
-> `bicameral_agent.eval_datasets` package (`frames`, `crepe`, `hf_fetch`,
-> `hard`); `bicameral_agent.hard_benchmark` remains as a re-exporting shim, so
-> everything below still works as written. Datasets are also selectable by
-> name: `scripts/fetch_dataset.py --dataset hard_benchmark` to fetch, and
-> `scripts/run_baseline_benchmark.py --dataset hard_benchmark [--metric ...]`
-> to run against it.
+**Moved:** this document was generalized into
+[`docs/eval_datasets.md`](eval_datasets.md) (Issue #56), which covers the full
+dataset factory — FRAMES and CREPE included — plus the licensing/citation
+matrix and the verifier registry.
 
-Replaces the saturated `research_qa` evaluation pool (which a frontier answerer
-one-shots, pinning the judge at ceiling — see the RCA in #41) with two harder,
-externally-sourced task pools that map onto the existing `ResearchQATask` shape.
-
-## What ships in the repo vs. what is fetched
-
-**No external dataset is committed to this repository.** We map and point at
-upstream sources; you download the data yourself. This keeps the repo free of
-data whose redistribution terms are unclear (see Licensing below).
-
-| In git (owned by us) | Fetched locally (git-ignored) |
-|---|---|
-| `src/bicameral_agent/hard_benchmark.py` — mappers + fetch/load | `data/external/hard_benchmark.json` — the pulled subset |
-| `scripts/fetch_hard_benchmark.py` — fetch CLI | |
-| `tests/fixtures/hard_benchmark_sample.json` — synthetic, author-owned | |
-
-## How to fetch
+Quick pointers for the original #42 workflow:
 
 ```bash
-python scripts/fetch_hard_benchmark.py            # defaults: 100 FRAMES + 60 CREPE
-python scripts/fetch_hard_benchmark.py --frames 200 --crepe 100
+python scripts/fetch_dataset.py --dataset hard_benchmark   # FRAMES + CREPE
+uv run python scripts/run_baseline_benchmark.py --dataset hard_benchmark
 ```
 
-Writes `data/external/hard_benchmark.json` (git-ignored). Stdlib-only — no extra
-dependency, no API key. Load it in code:
-
-```python
-from bicameral_agent.hard_benchmark import load_hard_benchmark
-dataset = load_hard_benchmark()            # -> ResearchQADataset
-```
-
-`load_hard_benchmark()` raises an actionable `FileNotFoundError` if you haven't
-fetched yet. The returned `ResearchQADataset` is a drop-in for the existing
-interface and works with `select_tasks` in `scripts/run_baseline_benchmark.py`.
-
-## Datasets and mapping
-
-### Hard tier — FRAMES (`google/frames-benchmark`)
-Multi-hop factual QA requiring synthesis across multiple Wikipedia articles.
-824 questions; we pull a subset. Frontier headroom: ~0.40 accuracy with no
-retrieval, ~0.66 with a multi-step retrieval pipeline (arXiv:2409.12941).
-
-| FRAMES field | `ResearchQATask` field |
-|---|---|
-| `Prompt` | `question` |
-| `Answer` | `gold_answer` |
-| *(synthesized, anchored on the gold answer)* | `scoring_rubric` |
-| — | `difficulty = hard`, `split = eval` |
-
-FRAMES ships no rubric, so we synthesize a 1–5 rubric anchored on the gold
-answer and the multi-hop reasoning the question demands.
-
-### Tricky tier — CREPE (false-presupposition QA, arXiv:2211.17257)
-Open-domain questions built on a **false premise**, with the presupposition and
-its correction annotated. Pulled via the `tasksource/CREPE` re-host; we keep
-only rows labelled `false presupposition` that carry both a presupposition and a
-correction. Frontier models still fail false-premise correction badly
-(<30% on related false-presupposition probes).
-
-| CREPE field | `ResearchQATask` field |
-|---|---|
-| `question` | `question` |
-| `corrections` (joined) | `gold_answer` |
-| `presuppositions` | `known_assumptions` |
-| *(synthesized)* | `scoring_rubric` |
-| — | `difficulty = tricky`, `split = eval` |
-
-This is the cleanest possible mapping for the `tricky` tier: the dataset's own
-presupposition annotation populates `known_assumptions` directly, satisfying the
-`ResearchQATask` invariant that tricky tasks carry an assumption.
-
-## Licensing / attribution
-
-- **FRAMES** — Apache-2.0 (`google/frames-benchmark`). Cite: *"Fact, Fetch, and
-  Reason: A Unified Evaluation of Retrieval-Augmented Generation"*, arXiv:2409.12941.
-  Apache-2.0 would permit redistribution, but we fetch-at-build for uniformity.
-- **CREPE** — the original false-presupposition CREPE
-  (`github.com/velocityCavalry/CREPE`, arXiv:2211.17257) declares **no license**
-  (GitHub: NOASSERTION). We therefore **do not redistribute it**; the fetch
-  script pulls it locally for your own research use under the upstream terms.
-  Cite: *"CREPE: Open-Domain Question Answering with False Presuppositions"*,
-  Yu et al., ACL 2023.
-
-## Fallback datasets — and the triggers to watch for
-
-The pairing above is the primary choice. Keep these alternates in mind; each row
-is a concrete condition under which to switch.
-
-| Trigger to watch for | Fall back to |
-|---|---|
-| **Headroom collapses** — the 2026 answerer scores near-ceiling on FRAMES (the reported 0.40/0.66 figures are 2024-era Gemini-1.5-Pro; model progress may have eaten the gap). This is the #1 risk and must be checked by the #46 pilot. | **ResearchQA** (arXiv:2509.00496) or **ResearchRubrics** (arXiv:2511.07685): rubric-native long-form research QA, no system >70% rubric coverage. Better schema fit (per-question rubrics) but license/HF-loadability unconfirmed and scores were measured on agentic deep-research systems, not a one-shot answerer. |
-| **CREPE proves too easy or too noisy**, or its no-license status becomes a problem even for local use. | **FalseQA** (arXiv:2307.02394, `thunlp/FalseQA`): 2,365 human-written false-premise questions. Also has no declared license, so it is fetch-at-build only too — it was the original pick, demoted because CREPE ships presupposition+correction annotations that map more cleanly. |
-| **Single `scoring_rubric: str` can't capture rubric granularity** — ResearchQA/ResearchRubrics carry ~26 rubric items/task; collapsing to one string may lose the variance that makes them discriminating. | Extend the judge to multi-criterion scoring (overlaps with #45's discriminating-scorer work) before adopting the rubric-native sets. |
-
-## Known limitation — the pilot (AC #3) is deferred to #46
-
-Issue #42 asks for a pilot showing quality scores below ceiling with real
-variance. That can't be validly run from the dataset change alone:
-
-1. The judge currently saturates at ~5/5/5 **regardless of dataset difficulty**
-   (the `max_output_tokens=100` cap + leniency); fixing that is #45's job. A
-   pilot run now would show ceiling because of the *scorer*, not the data —
-   misleading.
-2. No Gemini API key is configured in the integration environment.
-
-So below-ceiling-with-variance is validated in **#46** (the re-run), after #45's
-discriminating-scorer fix lands. The right pilot is answerer-correctness against
-gold (independent of the judge): if the answerer gets a meaningful fraction of
-FRAMES/CREPE wrong, the headroom is real.
+`bicameral_agent.hard_benchmark` (`build_hard_benchmark` /
+`load_hard_benchmark`) remains as a re-exporting shim over
+`bicameral_agent.eval_datasets`, and the `data/external/hard_benchmark.json`
+cache format is unchanged, so previously fetched caches stay valid.

--- a/scripts/fetch_dataset.py
+++ b/scripts/fetch_dataset.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections import Counter
 from pathlib import Path
@@ -41,6 +42,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  license: {meta.license}")
     if meta.citation:
         print(f"  cite: {meta.citation}")
+    if meta.requires_hf_token and not os.environ.get("HF_TOKEN"):
+        print(
+            f"  note: {meta.name} is gated on Hugging Face; accept its terms "
+            "and set HF_TOKEN before fetching.",
+            file=sys.stderr,
+        )
 
     tasks = dataset.build(args.limit)
     dist = Counter(t.difficulty.value for t in tasks)

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -17,8 +17,6 @@ Real API calls are made; budget the run accordingly.
 from __future__ import annotations
 
 import argparse
-import dataclasses
-import json
 import logging
 import sys
 from pathlib import Path
@@ -28,6 +26,7 @@ from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
+from bicameral_agent.eval_report import EvalReport
 from bicameral_agent.model_client import build_client, default_model, provider_names
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
@@ -35,26 +34,6 @@ from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
 
 logger = logging.getLogger(__name__)
-
-# EpisodeRunner expresses scorer choice as a boolean (use_lexical_scorer)
-# today -- #45 owns that wiring -- so only these two metrics are runnable.
-_RUNNABLE_METRICS = ("llm_judge", "lexical")
-
-
-def ensure_runnable_metric(metric: str) -> str:
-    """Refuse metrics EpisodeRunner cannot express yet.
-
-    Guards the metric -> use_lexical_scorer boolean collapse below: a future
-    verifier registered in ``bicameral_agent.verifiers`` must fail loudly here
-    rather than silently fall back to the LLM judge.
-    """
-    if metric not in _RUNNABLE_METRICS:
-        raise ValueError(
-            f"Metric {metric!r} cannot be run by EpisodeRunner yet; runnable "
-            f"metrics: {list(_RUNNABLE_METRICS)}. New verifiers need runner "
-            "wiring through bicameral_agent.verifiers.build_verifier first."
-        )
-    return metric
 
 
 def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]:
@@ -137,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
     ).with_env_overrides()
 
     eval_dataset = build_dataset(args.dataset)
-    metric = ensure_runnable_metric(resolve_metric(eval_dataset, args.metric))
+    metric = resolve_metric(eval_dataset, args.metric)
     dataset = eval_dataset.load()
     tasks = select_tasks(dataset, args.tasks_per_condition)
     logger.info(
@@ -175,14 +154,12 @@ def main(argv: list[str] | None = None) -> int:
         provider, client.model, judge_provider, judge_client.model,
     )
 
-    # The resolved metric passed ensure_runnable_metric, so this boolean
-    # collapse is exhaustive over _RUNNABLE_METRICS.
     runner = EpisodeRunner(
         client,
         config=hyper.to_episode_config(
             max_turns=args.max_turns,
             score_episode=True,
-            use_lexical_scorer=(metric == "lexical"),
+            metric=metric,
         ),
         hyper_config=hyper,
         cost_tracker=cost_tracker,
@@ -217,19 +194,16 @@ def main(argv: list[str] | None = None) -> int:
     (output_dir / "report.txt").write_text(report_text)
     sys.stdout.write(report_text)
 
-    summary = {
-        "dataset": args.dataset,
-        "metric": metric,
-        "answerer": {"provider": provider, "model": client.model},
-        "measurement": {"provider": judge_provider, "model": judge_client.model},
-        "tasks_per_condition": args.tasks_per_condition,
-        "max_turns": args.max_turns,
-        "conditions": {
-            condition: dataclasses.asdict(report)
-            for condition, report in result.reports.items()
-        },
-    }
-    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    report = EvalReport.from_benchmark(
+        result,
+        dataset=args.dataset,
+        metric=metric,
+        answerer={"provider": provider, "model": client.model},
+        measurement={"provider": judge_provider, "model": judge_client.model},
+        tasks_per_condition=args.tasks_per_condition,
+        max_turns=args.max_turns,
+    )
+    (output_dir / "summary.json").write_text(report.to_json())
     logger.info("Wrote summary.json and report.txt to %s", output_dir)
 
     return 0

--- a/src/bicameral_agent/ab_test.py
+++ b/src/bicameral_agent/ab_test.py
@@ -371,7 +371,7 @@ class ABTestRunner:
                 config = dataclasses.replace(
                     condition.episode_config,
                     score_episode=self._score_episodes,
-                    use_lexical_scorer=self._use_lexical_scorer,
+                    metric="lexical" if self._use_lexical_scorer else "llm_judge",
                 )
                 runner = EpisodeRunner(self._client, config)
                 episode = runner.run_episode(task, controller)

--- a/src/bicameral_agent/dataset.py
+++ b/src/bicameral_agent/dataset.py
@@ -44,6 +44,18 @@ class TaskSplit(str, enum.Enum):
     TOOL_TEST = "tool_test"
 
 
+class RubricItem(BaseModel):
+    """One weighted criterion of a per-task rubric (Issue #56).
+
+    Points may be negative (e.g. HealthBench penalty items); the
+    rubric-coverage verifier normalizes earned points against the sum of
+    positive points.
+    """
+
+    criterion: str
+    points: float
+
+
 class ResearchQATask(BaseModel):
     """A single research QA evaluation task."""
 
@@ -55,6 +67,12 @@ class ResearchQATask(BaseModel):
     known_gaps: list[str] | None = Field(default=None)
     known_assumptions: list[str] | None = Field(default=None)
     scoring_rubric: str
+    choices: list[str] | None = Field(default=None)
+    """Multiple-choice options (e.g. SuperGPQA); None for free-form tasks."""
+    rubric_items: list[RubricItem] | None = Field(default=None)
+    """Weighted rubric criteria (HealthBench/ResearchQA); None otherwise."""
+    abstention_expected: bool | None = Field(default=None)
+    """Whether the correct behavior is to abstain (AbstentionBench label)."""
 
     @model_validator(mode="after")
     def check_tricky_has_assumptions(self) -> ResearchQATask:
@@ -63,6 +81,22 @@ class ResearchQATask(BaseModel):
             if not self.known_assumptions:
                 msg = f"Tricky task {self.task_id} must have at least one known_assumptions entry"
                 raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def check_empty_gold_requires_rubric(self) -> ResearchQATask:
+        """An empty gold answer is only valid for rubric-scored tasks.
+
+        Rubric-native datasets (e.g. ResearchQA) have no single gold answer;
+        everywhere else an empty gold answer is a mapping bug.
+        """
+        if self.gold_answer == "" and not self.rubric_items:
+            msg = (
+                f"Task {self.task_id} has an empty gold_answer but no "
+                "rubric_items; empty gold answers are only valid for "
+                "rubric-scored tasks"
+            )
+            raise ValueError(msg)
         return self
 
     @model_validator(mode="after")

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -30,13 +30,13 @@ from bicameral_agent.schema import (
     UserEventType,
     estimate_text_tokens,
 )
-from bicameral_agent.scorer import LexicalScorer, TaskScorer
 from bicameral_agent.signal_classifier import SignalClassifier
 from bicameral_agent.simulated_user import ActionType, Patience, SimulatedUser, Strictness
 from bicameral_agent.token_estimator import ContextFeatures
 from bicameral_agent.tool_latency import ToolLatencyModel
 from bicameral_agent.cost_tracker import CostBudgetExceeded, CostTrackedClient, CostTracker
 from bicameral_agent.tool_primitive import BudgetExceededError, TokenBudget
+from bicameral_agent.verifiers import build_verifier
 
 
 class InjectionMode(enum.Enum):
@@ -91,7 +91,12 @@ class EpisodeConfig:
     patience: Patience = Patience.MEDIUM
     strictness: Strictness = Strictness.MEDIUM
     score_episode: bool = False
-    use_lexical_scorer: bool = False
+    metric: str = "llm_judge"
+    """Verifier-registry key used when score_episode is set (Issue #56).
+
+    Replaces the former ``use_lexical_scorer`` boolean: ``metric="lexical"``
+    is the old True, ``"llm_judge"`` (default) the old False.
+    """
     injection_mode: InjectionMode = InjectionMode.BREAKPOINT
     persistent_injection: bool = True
 
@@ -433,8 +438,8 @@ class EpisodeRunner:
         if self._hyper_config is not None:
             log.set_metadata("hyperparameters", self._hyper_config.to_dict())
 
-        # Score if requested. The LLM judge uses the (cost-tracked) judge
-        # client, so its calls count toward budgets and episode cost.
+        # Score if requested. LLM-backed verifiers use the (cost-tracked)
+        # judge client, so their calls count toward budgets and episode cost.
         quality_score: float | None = None
         if cfg.score_episode:
             last_assistant = next(
@@ -442,9 +447,14 @@ class EpisodeRunner:
                 None,
             )
             if last_assistant is not None:
-                scorer = LexicalScorer() if cfg.use_lexical_scorer else TaskScorer(client=judge_client)
+                verifier = build_verifier(cfg.metric, client=judge_client)
                 try:
-                    quality_score = scorer.score(task, last_assistant).overall
+                    task_score = verifier.score(task, last_assistant)
+                    quality_score = task_score.overall
+                    log.set_metadata(
+                        "verification",
+                        {"metric": cfg.metric, "detail": task_score.detail},
+                    )
                 except CostBudgetExceeded:
                     logger.warning(
                         "CostBudgetExceeded while scoring, leaving quality_score unset"

--- a/src/bicameral_agent/eval_datasets/__init__.py
+++ b/src/bicameral_agent/eval_datasets/__init__.py
@@ -8,19 +8,33 @@ line. The package is named ``eval_datasets`` to avoid colliding with HF's
 
 from __future__ import annotations
 
+from bicameral_agent.eval_datasets.abstentionbench import AbstentionBench
 from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+from bicameral_agent.eval_datasets.bbeh import Bbeh
 from bicameral_agent.eval_datasets.builtin import BuiltinPool
 from bicameral_agent.eval_datasets.crepe import Crepe
 from bicameral_agent.eval_datasets.frames import Frames
 from bicameral_agent.eval_datasets.hard import HardBenchmark
+from bicameral_agent.eval_datasets.healthbench_hard import HealthBenchHard
+from bicameral_agent.eval_datasets.hle import Hle
+from bicameral_agent.eval_datasets.researchqa import ResearchQA
+from bicameral_agent.eval_datasets.simpleqa_verified import SimpleQAVerified
+from bicameral_agent.eval_datasets.supergpqa import SuperGPQA
 
 __all__ = [
+    "AbstentionBench",
+    "Bbeh",
     "BuiltinPool",
     "Crepe",
     "DatasetMeta",
     "EvalDataset",
     "Frames",
     "HardBenchmark",
+    "HealthBenchHard",
+    "Hle",
+    "ResearchQA",
+    "SimpleQAVerified",
+    "SuperGPQA",
     "build_dataset",
     "dataset_names",
     "resolve_metric",
@@ -31,6 +45,13 @@ _REGISTRY: dict[str, type[EvalDataset]] = {
     "frames": Frames,
     "crepe": Crepe,
     "hard_benchmark": HardBenchmark,
+    "simpleqa_verified": SimpleQAVerified,
+    "supergpqa": SuperGPQA,
+    "bbeh": Bbeh,
+    "healthbench_hard": HealthBenchHard,
+    "researchqa": ResearchQA,
+    "abstentionbench": AbstentionBench,
+    "hle": Hle,
 }
 
 

--- a/src/bicameral_agent/eval_datasets/abstentionbench.py
+++ b/src/bicameral_agent/eval_datasets/abstentionbench.py
@@ -61,26 +61,19 @@ def abstentionbench_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _abstentionbench_row_valid(row: dict) -> bool:
+    return bool(str(row.get("question") or "").strip() and "should_abstain" in row)
+
+
 def fetch_abstentionbench(limit: int = 100) -> list[ResearchQATask]:
     """Pull a subset of AbstentionBench rows and map them to tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(
-            ABSTENTIONBENCH_DATASET,
-            ABSTENTIONBENCH_SPLIT,
-            offset,
-            min(100, limit - len(tasks)),
-        )
-        if not page:
-            break
-        for raw in page:
-            if str(raw.get("question") or "").strip() and "should_abstain" in raw:
-                tasks.append(abstentionbench_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    return hf_fetch.fetch_mapped_tasks(
+        ABSTENTIONBENCH_DATASET,
+        ABSTENTIONBENCH_SPLIT,
+        limit,
+        abstentionbench_row_to_task,
+        is_valid=_abstentionbench_row_valid,
+    )
 
 
 class AbstentionBench(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/abstentionbench.py
+++ b/src/bicameral_agent/eval_datasets/abstentionbench.py
@@ -1,0 +1,106 @@
+"""AbstentionBench adapter: unanswerable-question probes, ``hard`` tier.
+
+``facebook/AbstentionBench`` (**CC-BY-NC-4.0 -- non-commercial only**; fetched
+locally, never redistributed): questions labeled with whether the correct
+behavior is to abstain, mapped onto ``abstention_expected`` for the
+``abstention`` verifier.
+
+Upstream schema (from the repo's loading script): ``question``,
+``reference_answers`` (list), ``should_abstain`` (bool), ``metadata_json``.
+
+Caveat: upstream currently ships a ``datasets`` *loading script* rather than
+data files, which the HF datasets-server cannot build -- so a live fetch
+fails with the pager's actionable error until upstream publishes parquet.
+The mapping below targets the script's declared feature schema so it works
+as-is once rows become servable.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+ABSTENTIONBENCH_DATASET = "facebook/AbstentionBench"
+ABSTENTIONBENCH_SPLIT = "test"
+
+_ABSTAIN_GOLD = (
+    "The correct response is to abstain: the question is unanswerable or "
+    "underspecified as posed."
+)
+
+
+def abstentionbench_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one AbstentionBench row into a ``hard`` abstention task.
+
+    Rows that should be abstained on typically carry no reference answer, so
+    the gold answer falls back to an explicit abstain statement (keeping the
+    LLM judge usable and the non-empty-gold invariant intact).
+    """
+    should_abstain = bool(row.get("should_abstain"))
+    references = [
+        str(a).strip() for a in (row.get("reference_answers") or []) if str(a).strip()
+    ]
+    gold = " ".join(references) if references else _ABSTAIN_GOLD
+    rubric = (
+        "5: Abstains (clearly states the question is unanswerable/"
+        "underspecified) when it should, or answers correctly when it "
+        "should not. 1: Answers confidently when abstention was required, "
+        "or abstains on an answerable question."
+    )
+    return ResearchQATask(
+        task_id=f"abstentionbench_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=str(row.get("question") or "").strip(),
+        gold_answer=gold,
+        scoring_rubric=rubric,
+        abstention_expected=should_abstain,
+    )
+
+
+def fetch_abstentionbench(limit: int = 100) -> list[ResearchQATask]:
+    """Pull a subset of AbstentionBench rows and map them to tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(
+            ABSTENTIONBENCH_DATASET,
+            ABSTENTIONBENCH_SPLIT,
+            offset,
+            min(100, limit - len(tasks)),
+        )
+        if not page:
+            break
+        for raw in page:
+            if str(raw.get("question") or "").strip() and "should_abstain" in raw:
+                tasks.append(abstentionbench_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class AbstentionBench(EvalDataset):
+    """AbstentionBench unanswerable-question probes (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="abstentionbench",
+        source=ABSTENTIONBENCH_DATASET,
+        license=(
+            "CC-BY-NC-4.0 -- NON-COMMERCIAL use only; fetch-only, do not "
+            "redistribute"
+        ),
+        citation=(
+            "AbstentionBench: Reasoning LLMs Fail on Unanswerable Questions "
+            "(arXiv:2506.09038), Kirichenko et al."
+        ),
+    )
+    default_metric: ClassVar[str] = "abstention"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("abstention", "llm_judge")
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_abstentionbench(limit)

--- a/src/bicameral_agent/eval_datasets/bbeh.py
+++ b/src/bicameral_agent/eval_datasets/bbeh.py
@@ -1,0 +1,106 @@
+"""BIG-Bench Extra Hard (BBEH) adapter: hard reasoning mapped to ``hard``.
+
+``google-deepmind/bbeh`` on GitHub (CC-BY-4.0): each subtask ships a
+``task.json`` with ``{"examples": [{"input", "target"}]}``. We sample
+round-robin across subtasks so a small pull still covers the reasoning mix,
+fetched as raw JSON over urllib (no HF dependency).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+BBEH_SOURCE = "https://github.com/google-deepmind/bbeh"
+BBEH_RAW_URL = (
+    "https://raw.githubusercontent.com/google-deepmind/bbeh/main/"
+    "bbeh/benchmark_tasks/{subtask}/task.json"
+)
+
+# The repo's benchmark_tasks/ directories as of 2026-07 (fixed here so fetch
+# order -- and therefore task ids -- is deterministic).
+BBEH_SUBTASKS: tuple[str, ...] = (
+    "bbeh_boardgame_qa",
+    "bbeh_boolean_expressions",
+    "bbeh_buggy_tables",
+    "bbeh_causal_understanding",
+    "bbeh_disambiguation_qa",
+    "bbeh_dyck_languages",
+    "bbeh_geometric_shapes",
+    "bbeh_hyperbaton",
+    "bbeh_linguini",
+    "bbeh_movie_recommendation",
+    "bbeh_multistep_arithmetic",
+    "bbeh_nycc",
+    "bbeh_object_counting",
+    "bbeh_object_properties",
+    "bbeh_sarc_triples",
+    "bbeh_shuffled_objects",
+    "bbeh_spatial_reasoning",
+    "bbeh_sportqa",
+    "bbeh_temporal_sequence",
+    "bbeh_time_arithmetic",
+    "bbeh_web_of_lies",
+    "bbeh_word_sorting",
+    "bbeh_zebra_puzzles",
+)
+
+
+def bbeh_example_to_task(example: dict, index: int) -> ResearchQATask:
+    """Map one BBEH example into a ``hard`` ResearchQATask."""
+    target = str(example.get("target") or "").strip()
+    rubric = (
+        f"5: States the exact correct answer ('{target}') with valid "
+        "reasoning. 3: Correct answer, flawed or missing reasoning. "
+        "1: Incorrect answer."
+    )
+    return ResearchQATask(
+        task_id=f"bbeh_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=str(example.get("input") or "").strip(),
+        gold_answer=target,
+        scoring_rubric=rubric,
+    )
+
+
+def fetch_bbeh(limit: int = 100) -> list[ResearchQATask]:
+    """Sample up to *limit* examples round-robin across BBEH subtasks."""
+    per_subtask = -(-limit // len(BBEH_SUBTASKS))  # ceil
+    tasks: list[ResearchQATask] = []
+    for subtask in BBEH_SUBTASKS:
+        payload = hf_fetch.http_get_json(BBEH_RAW_URL.format(subtask=subtask))
+        for example in (payload.get("examples") or [])[:per_subtask]:
+            if str(example.get("input") or "").strip() and str(
+                example.get("target") or ""
+            ).strip():
+                tasks.append(bbeh_example_to_task(example, len(tasks) + 1))
+                if len(tasks) == limit:
+                    return tasks
+    return tasks
+
+
+class Bbeh(EvalDataset):
+    """BIG-Bench Extra Hard reasoning tasks (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="bbeh",
+        source=BBEH_SOURCE,
+        license="CC-BY-4.0",
+        citation=(
+            "BIG-Bench Extra Hard (arXiv:2502.19187), Google DeepMind"
+        ),
+    )
+    default_metric: ClassVar[str] = "exact_match"
+    supported_metrics: ClassVar[tuple[str, ...]] = (
+        "exact_match",
+        "llm_judge",
+        "lexical",
+    )
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_bbeh(limit)

--- a/src/bicameral_agent/eval_datasets/crepe.py
+++ b/src/bicameral_agent/eval_datasets/crepe.py
@@ -45,23 +45,24 @@ def crepe_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _crepe_row_valid(row: dict) -> bool:
+    presups = [p for p in (row.get("presuppositions") or []) if p and p.strip()]
+    corrections = [c for c in (row.get("corrections") or []) if c and c.strip()]
+    return bool(presups and corrections)
+
+
 def fetch_crepe(limit: int = 60, split: str = "test") -> list[ResearchQATask]:
     """Scan CREPE and map false-presupposition rows to ``tricky`` tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(CREPE_DATASET, split, offset, 100)
-        if not page:
-            break
-        for raw in page:
-            presups = [p for p in (raw.get("presuppositions") or []) if p and p.strip()]
-            corrections = [c for c in (raw.get("corrections") or []) if c and c.strip()]
-            if presups and corrections:
-                tasks.append(crepe_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    # Fixed 100-row pages: most CREPE rows are filtered out, so asking for
+    # only the remaining count would multiply requests.
+    return hf_fetch.fetch_mapped_tasks(
+        CREPE_DATASET,
+        split,
+        limit,
+        crepe_row_to_task,
+        is_valid=_crepe_row_valid,
+        page_length=100,
+    )
 
 
 class Crepe(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/frames.py
+++ b/src/bicameral_agent/eval_datasets/frames.py
@@ -40,23 +40,17 @@ def frames_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _frames_row_valid(row: dict) -> bool:
+    return bool(
+        (row.get("Prompt") or "").strip() and (row.get("Answer") or "").strip()
+    )
+
+
 def fetch_frames(limit: int = 100, split: str = "test") -> list[ResearchQATask]:
     """Pull a subset of FRAMES rows and map them to ``hard`` tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(
-            FRAMES_DATASET, split, offset, min(100, limit - len(tasks))
-        )
-        if not page:
-            break
-        for raw in page:
-            if (raw.get("Prompt") or "").strip() and (raw.get("Answer") or "").strip():
-                tasks.append(frames_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    return hf_fetch.fetch_mapped_tasks(
+        FRAMES_DATASET, split, limit, frames_row_to_task, is_valid=_frames_row_valid
+    )
 
 
 class Frames(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/healthbench_hard.py
+++ b/src/bicameral_agent/eval_datasets/healthbench_hard.py
@@ -1,0 +1,98 @@
+"""HealthBench Hard adapter: rubric-graded health conversations, ``hard`` tier.
+
+The 1,000-example "hard" subset published with OpenAI's simple-evals (MIT),
+downloaded as JSONL from the openaipublic blob referenced by
+``openai/simple-evals``. Each example carries a weighted rubric (points may be
+negative for penalty items) which maps onto ``rubric_items`` for the
+``rubric_coverage`` verifier; the published ideal completion (when present)
+becomes the gold answer so the LLM judge stays usable.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+
+from bicameral_agent.dataset import (
+    ResearchQATask,
+    RubricItem,
+    TaskDifficulty,
+    TaskSplit,
+)
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+HEALTHBENCH_SOURCE = "https://github.com/openai/simple-evals (HealthBench hard subset)"
+HEALTHBENCH_HARD_URL = (
+    "https://openaipublic.blob.core.windows.net/simple-evals/"
+    "healthbench/hard_2025-05-08-21-00-10.jsonl"
+)
+
+
+def healthbench_record_to_task(record: dict, index: int) -> ResearchQATask:
+    """Map one HealthBench Hard JSONL record into a ``hard`` rubric task.
+
+    Multi-turn prompts are flattened into a single question transcript (the
+    answerer sees ``question`` only); single-turn prompts stay bare.
+    """
+    prompt = record.get("prompt") or []
+    if len(prompt) == 1:
+        question = str(prompt[0].get("content") or "").strip()
+    else:
+        question = "\n\n".join(
+            f"{m.get('role', 'user')}: {str(m.get('content') or '').strip()}"
+            for m in prompt
+        )
+    rubric_items = [
+        RubricItem(criterion=str(r.get("criterion") or ""), points=float(r.get("points", 0)))
+        for r in (record.get("rubrics") or [])
+    ]
+    ideal = (record.get("ideal_completions_data") or {}).get("ideal_completion") or ""
+    return ResearchQATask(
+        task_id=f"healthbench_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=str(ideal).strip(),
+        scoring_rubric=(
+            f"Scored by weighted coverage of {len(rubric_items)} rubric "
+            "criteria (see rubric_items; negative-point items are penalties)."
+        ),
+        rubric_items=rubric_items,
+    )
+
+
+def fetch_healthbench_hard(limit: int = 100) -> list[ResearchQATask]:
+    """Download the hard-subset JSONL and map the first *limit* records."""
+    text = hf_fetch.http_get_text(HEALTHBENCH_HARD_URL)
+    tasks: list[ResearchQATask] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if not (record.get("prompt") and record.get("rubrics")):
+            continue
+        tasks.append(healthbench_record_to_task(record, len(tasks) + 1))
+        if len(tasks) == limit:
+            break
+    return tasks
+
+
+class HealthBenchHard(EvalDataset):
+    """HealthBench Hard rubric-graded health QA (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="healthbench_hard",
+        source=HEALTHBENCH_SOURCE,
+        license="MIT",
+        citation=(
+            "HealthBench: Evaluating Large Language Models Towards Improved "
+            "Human Health (arXiv:2505.08775), OpenAI"
+        ),
+    )
+    default_metric: ClassVar[str] = "rubric_coverage"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("rubric_coverage", "llm_judge")
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_healthbench_hard(limit)

--- a/src/bicameral_agent/eval_datasets/hf_fetch.py
+++ b/src/bicameral_agent/eval_datasets/hf_fetch.py
@@ -11,6 +11,7 @@ No HF ``datasets``/``pandas`` dependency, per repo policy -- plain ``urllib``.
 from __future__ import annotations
 
 import json
+import os
 import time
 import urllib.error
 import urllib.parse
@@ -26,16 +27,18 @@ RETRY_BASE_DELAY_S = 2.0
 RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
 
 
-def http_get_json(url: str) -> dict:
-    """GET *url* as JSON, retrying transient (rate-limit / 5xx / network) errors."""
+def http_get_text(url: str, headers: dict[str, str] | None = None) -> str:
+    """GET *url* as text, retrying transient (rate-limit / 5xx / network) errors."""
     last_err: Exception | None = None
     for attempt in range(MAX_ATTEMPTS):
         if attempt > 0:
             time.sleep(RETRY_BASE_DELAY_S * 2 ** (attempt - 1))
         try:
-            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            req = urllib.request.Request(
+                url, headers={"User-Agent": USER_AGENT, **(headers or {})}
+            )
             with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
-                return json.loads(resp.read())
+                return resp.read().decode("utf-8")
         except urllib.error.HTTPError as err:
             if err.code not in RETRYABLE_HTTP_CODES:
                 raise
@@ -47,13 +50,28 @@ def http_get_json(url: str) -> dict:
     ) from last_err
 
 
-def fetch_page(dataset: str, split: str, offset: int, length: int) -> list[dict]:
-    """Fetch one page of raw rows from the datasets-server rows API."""
+def http_get_json(url: str, headers: dict[str, str] | None = None) -> dict:
+    """GET *url* as JSON, retrying transient (rate-limit / 5xx / network) errors."""
+    return json.loads(http_get_text(url, headers=headers))
+
+
+def fetch_page(
+    dataset: str, split: str, offset: int, length: int, config: str = "default"
+) -> list[dict]:
+    """Fetch one page of raw rows from the datasets-server rows API.
+
+    Gated datasets (e.g. ``cais/hle``) are fetched with the ``HF_TOKEN``
+    environment variable as a bearer token when it is set; the token is only
+    ever sent to the datasets-server endpoint.
+    """
     url = (
         f"{HF_ROWS_ENDPOINT}?dataset={urllib.parse.quote(dataset)}"
-        f"&config=default&split={split}&offset={offset}&length={length}"
+        f"&config={urllib.parse.quote(config)}"
+        f"&split={split}&offset={offset}&length={length}"
     )
-    payload = http_get_json(url)
+    token = os.environ.get("HF_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"} if token else None
+    payload = http_get_json(url, headers=headers)
     if "rows" not in payload:
         # An error payload (e.g. rate-limit body) must not read as an empty
         # terminal page — that silently truncates the benchmark.

--- a/src/bicameral_agent/eval_datasets/hf_fetch.py
+++ b/src/bicameral_agent/eval_datasets/hf_fetch.py
@@ -16,6 +16,9 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
 
 HF_ROWS_ENDPOINT = "https://datasets-server.huggingface.co/rows"
 USER_AGENT = "bicameral-agent/0.1 (research eval; issue-42)"
@@ -80,3 +83,42 @@ def fetch_page(
             f"{payload.get('error', payload)!r}"
         )
     return [row["row"] for row in payload["rows"]]
+
+
+def fetch_mapped_tasks(
+    dataset: str,
+    split: str,
+    limit: int,
+    row_to_task: Callable[[dict, int], T],
+    *,
+    config: str = "default",
+    is_valid: Callable[[dict], bool] | None = None,
+    page_length: int | None = None,
+) -> list[T]:
+    """Page through the rows API, mapping valid rows until *limit* tasks.
+
+    The shared fetch loop behind every HF-backed adapter: pulls pages from
+    offset 0 onward, keeps rows passing *is_valid* (all rows when None), and
+    maps each with ``row_to_task(row, index)`` where *index* is 1-based over
+    the kept rows. Stops at *limit* tasks or an empty terminal page.
+
+    ``page_length`` fixes the requested page size (useful when most rows are
+    filtered out, e.g. CREPE); by default each request asks for exactly the
+    remaining number of tasks, capped at 100.
+    """
+    tasks: list[T] = []
+    offset = 0
+    while len(tasks) < limit:
+        length = (
+            page_length if page_length is not None else min(100, limit - len(tasks))
+        )
+        page = fetch_page(dataset, split, offset, length, config=config)
+        if not page:
+            break
+        for raw in page:
+            if is_valid is None or is_valid(raw):
+                tasks.append(row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks

--- a/src/bicameral_agent/eval_datasets/hle.py
+++ b/src/bicameral_agent/eval_datasets/hle.py
@@ -39,25 +39,26 @@ def hle_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _hle_row_valid(row: dict) -> bool:
+    if row.get("image"):  # text-only harness: skip multi-modal rows
+        return False
+    return bool(
+        str(row.get("question") or "").strip() and str(row.get("answer") or "").strip()
+    )
+
+
 def fetch_hle(limit: int = 100) -> list[ResearchQATask]:
     """Pull text-only HLE rows (requires HF_TOKEN; the dataset is gated)."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(HLE_DATASET, HLE_SPLIT, offset, 100)
-        if not page:
-            break
-        for raw in page:
-            if raw.get("image"):  # text-only harness: skip multi-modal rows
-                continue
-            if str(raw.get("question") or "").strip() and str(
-                raw.get("answer") or ""
-            ).strip():
-                tasks.append(hle_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    # Fixed 100-row pages: multi-modal rows are filtered out, so asking for
+    # only the remaining count would multiply requests.
+    return hf_fetch.fetch_mapped_tasks(
+        HLE_DATASET,
+        HLE_SPLIT,
+        limit,
+        hle_row_to_task,
+        is_valid=_hle_row_valid,
+        page_length=100,
+    )
 
 
 class Hle(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/hle.py
+++ b/src/bicameral_agent/eval_datasets/hle.py
@@ -1,0 +1,82 @@
+"""Humanity's Last Exam (HLE) adapter: frontier-difficulty QA, ``hard`` tier.
+
+``cais/hle`` (MIT, **gated**): expert-written questions at the frontier of
+human knowledge. The dataset requires accepting the terms on Hugging Face and
+an ``HF_TOKEN`` environment variable for the fetch (the pager sends it as a
+bearer token). Multi-modal rows (non-empty ``image``) are filtered out --
+the harness is text-only.
+
+Row schema (per the public dataset card): ``id``, ``question``, ``answer``,
+``answer_type`` (exactMatch / multipleChoice), ``image``, ``category``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+HLE_DATASET = "cais/hle"
+HLE_SPLIT = "test"
+
+
+def hle_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one text-only HLE row into a ``hard`` ResearchQATask."""
+    answer = str(row.get("answer") or "").strip()
+    rubric = (
+        f"5: States the correct answer ('{answer}') with sound reasoning. "
+        "3: Correct answer, weak justification. 1: Incorrect or fabricated."
+    )
+    return ResearchQATask(
+        task_id=f"hle_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=str(row.get("question") or "").strip(),
+        gold_answer=answer,
+        scoring_rubric=rubric,
+    )
+
+
+def fetch_hle(limit: int = 100) -> list[ResearchQATask]:
+    """Pull text-only HLE rows (requires HF_TOKEN; the dataset is gated)."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(HLE_DATASET, HLE_SPLIT, offset, 100)
+        if not page:
+            break
+        for raw in page:
+            if raw.get("image"):  # text-only harness: skip multi-modal rows
+                continue
+            if str(raw.get("question") or "").strip() and str(
+                raw.get("answer") or ""
+            ).strip():
+                tasks.append(hle_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class Hle(EvalDataset):
+    """Humanity's Last Exam text-only subset (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="hle",
+        source=HLE_DATASET,
+        license="MIT (gated: accept terms on Hugging Face; needs HF_TOKEN)",
+        citation="Humanity's Last Exam (arXiv:2501.14249), CAIS & Scale AI",
+        requires_hf_token=True,
+    )
+    default_metric: ClassVar[str] = "llm_judge"
+    supported_metrics: ClassVar[tuple[str, ...]] = (
+        "llm_judge",
+        "exact_match",
+        "lexical",
+    )
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_hle(limit)

--- a/src/bicameral_agent/eval_datasets/researchqa.py
+++ b/src/bicameral_agent/eval_datasets/researchqa.py
@@ -45,27 +45,22 @@ def researchqa_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _researchqa_row_valid(row: dict) -> bool:
+    has_rubric = any(
+        str(r.get("rubric_item") or "").strip() for r in (row.get("rubric") or [])
+    )
+    return bool(str(row.get("query") or "").strip() and has_rubric)
+
+
 def fetch_researchqa(limit: int = 100) -> list[ResearchQATask]:
     """Pull a subset of ResearchQA rows and map them to rubric tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(
-            RESEARCHQA_DATASET, RESEARCHQA_SPLIT, offset, min(100, limit - len(tasks))
-        )
-        if not page:
-            break
-        for raw in page:
-            has_rubric = any(
-                str(r.get("rubric_item") or "").strip()
-                for r in (raw.get("rubric") or [])
-            )
-            if str(raw.get("query") or "").strip() and has_rubric:
-                tasks.append(researchqa_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    return hf_fetch.fetch_mapped_tasks(
+        RESEARCHQA_DATASET,
+        RESEARCHQA_SPLIT,
+        limit,
+        researchqa_row_to_task,
+        is_valid=_researchqa_row_valid,
+    )
 
 
 class ResearchQA(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/researchqa.py
+++ b/src/bicameral_agent/eval_datasets/researchqa.py
@@ -1,0 +1,88 @@
+"""ResearchQA adapter: rubric-native long-form research QA, ``hard`` tier.
+
+``realliyifei/ResearchQA`` (MIT): research questions mined from scholarly
+surveys, each annotated with per-question rubric items but **no single gold
+answer** -- tasks carry ``gold_answer=""`` plus ``rubric_items`` (the pairing
+the dataset schema validator enforces). Upstream rubric items are unweighted,
+so each maps to 1.0 points.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import (
+    ResearchQATask,
+    RubricItem,
+    TaskDifficulty,
+    TaskSplit,
+)
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+RESEARCHQA_DATASET = "realliyifei/ResearchQA"
+RESEARCHQA_SPLIT = "test"
+
+
+def researchqa_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one ResearchQA row into a ``hard`` rubric-scored task."""
+    rubric_items = [
+        RubricItem(criterion=str(r.get("rubric_item") or "").strip(), points=1.0)
+        for r in (row.get("rubric") or [])
+        if str(r.get("rubric_item") or "").strip()
+    ]
+    return ResearchQATask(
+        task_id=f"researchqa_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=str(row.get("query") or "").strip(),
+        gold_answer="",
+        scoring_rubric=(
+            f"Scored by coverage of {len(rubric_items)} rubric items "
+            "(see rubric_items); no single gold answer exists."
+        ),
+        rubric_items=rubric_items,
+    )
+
+
+def fetch_researchqa(limit: int = 100) -> list[ResearchQATask]:
+    """Pull a subset of ResearchQA rows and map them to rubric tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(
+            RESEARCHQA_DATASET, RESEARCHQA_SPLIT, offset, min(100, limit - len(tasks))
+        )
+        if not page:
+            break
+        for raw in page:
+            has_rubric = any(
+                str(r.get("rubric_item") or "").strip()
+                for r in (raw.get("rubric") or [])
+            )
+            if str(raw.get("query") or "").strip() and has_rubric:
+                tasks.append(researchqa_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class ResearchQA(EvalDataset):
+    """ResearchQA rubric-native long-form research QA (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="researchqa",
+        source=RESEARCHQA_DATASET,
+        license="MIT",
+        citation=(
+            "ResearchQA: Evaluating Scholarly Question Answering at Scale "
+            "(arXiv:2509.00496)"
+        ),
+    )
+    default_metric: ClassVar[str] = "rubric_coverage"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("rubric_coverage",)
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_researchqa(limit)

--- a/src/bicameral_agent/eval_datasets/simpleqa_verified.py
+++ b/src/bicameral_agent/eval_datasets/simpleqa_verified.py
@@ -1,0 +1,85 @@
+"""SimpleQA Verified adapter: short-form factuality mapped to ``typical``.
+
+``google/simpleqa-verified`` (MIT): 1,000 human-verified short-answer factual
+questions from OpenAI's SimpleQA. Gold answers are short strings, so the
+deterministic ``exact_match`` verifier is the default; the LLM judge remains
+available for graded credit.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+SIMPLEQA_DATASET = "google/simpleqa-verified"
+SIMPLEQA_CONFIG = "simpleqa_verified"
+SIMPLEQA_SPLIT = "eval"
+
+
+def simpleqa_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one SimpleQA Verified row into a ``typical`` ResearchQATask."""
+    question = (row.get("problem") or "").strip()
+    answer = (row.get("answer") or "").strip()
+    rubric = (
+        f"5: States the correct short answer ('{answer}') exactly. "
+        "3: States it with hedging or extraneous alternatives. 1: Wrong, "
+        "missing, or fabricated."
+    )
+    return ResearchQATask(
+        task_id=f"simpleqa_typical_{index:03d}",
+        difficulty=TaskDifficulty.TYPICAL,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=answer,
+        scoring_rubric=rubric,
+    )
+
+
+def fetch_simpleqa_verified(limit: int = 100) -> list[ResearchQATask]:
+    """Pull a subset of SimpleQA Verified rows and map them to tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(
+            SIMPLEQA_DATASET,
+            SIMPLEQA_SPLIT,
+            offset,
+            min(100, limit - len(tasks)),
+            config=SIMPLEQA_CONFIG,
+        )
+        if not page:
+            break
+        for raw in page:
+            if (raw.get("problem") or "").strip() and (raw.get("answer") or "").strip():
+                tasks.append(simpleqa_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class SimpleQAVerified(EvalDataset):
+    """SimpleQA Verified short-form factuality (``typical`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="simpleqa_verified",
+        source=SIMPLEQA_DATASET,
+        license="MIT",
+        citation=(
+            "SimpleQA Verified (Google DeepMind, 2025); based on Measuring "
+            "short-form factuality in large language models (arXiv:2411.04368)"
+        ),
+    )
+    default_metric: ClassVar[str] = "exact_match"
+    supported_metrics: ClassVar[tuple[str, ...]] = (
+        "exact_match",
+        "llm_judge",
+        "lexical",
+    )
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_simpleqa_verified(limit)

--- a/src/bicameral_agent/eval_datasets/simpleqa_verified.py
+++ b/src/bicameral_agent/eval_datasets/simpleqa_verified.py
@@ -2,8 +2,9 @@
 
 ``google/simpleqa-verified`` (MIT): 1,000 human-verified short-answer factual
 questions from OpenAI's SimpleQA. Gold answers are short strings, so the
-deterministic ``exact_match`` verifier is the default; the LLM judge remains
-available for graded credit.
+deterministic ``exact_match`` verifier is the default; the official SimpleQA
+3-way autorater (``llm_autorater``) and the LLM judge are the graded
+alternatives.
 """
 
 from __future__ import annotations
@@ -38,27 +39,22 @@ def simpleqa_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _simpleqa_row_valid(row: dict) -> bool:
+    return bool(
+        (row.get("problem") or "").strip() and (row.get("answer") or "").strip()
+    )
+
+
 def fetch_simpleqa_verified(limit: int = 100) -> list[ResearchQATask]:
     """Pull a subset of SimpleQA Verified rows and map them to tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(
-            SIMPLEQA_DATASET,
-            SIMPLEQA_SPLIT,
-            offset,
-            min(100, limit - len(tasks)),
-            config=SIMPLEQA_CONFIG,
-        )
-        if not page:
-            break
-        for raw in page:
-            if (raw.get("problem") or "").strip() and (raw.get("answer") or "").strip():
-                tasks.append(simpleqa_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    return hf_fetch.fetch_mapped_tasks(
+        SIMPLEQA_DATASET,
+        SIMPLEQA_SPLIT,
+        limit,
+        simpleqa_row_to_task,
+        config=SIMPLEQA_CONFIG,
+        is_valid=_simpleqa_row_valid,
+    )
 
 
 class SimpleQAVerified(EvalDataset):
@@ -76,6 +72,7 @@ class SimpleQAVerified(EvalDataset):
     default_metric: ClassVar[str] = "exact_match"
     supported_metrics: ClassVar[tuple[str, ...]] = (
         "exact_match",
+        "llm_autorater",
         "llm_judge",
         "lexical",
     )

--- a/src/bicameral_agent/eval_datasets/supergpqa.py
+++ b/src/bicameral_agent/eval_datasets/supergpqa.py
@@ -49,27 +49,23 @@ def supergpqa_row_to_task(row: dict, index: int) -> ResearchQATask:
     )
 
 
+def _supergpqa_row_valid(row: dict) -> bool:
+    return bool(
+        (row.get("question") or "").strip()
+        and row.get("options")
+        and (row.get("answer_letter") or "").strip()
+    )
+
+
 def fetch_supergpqa(limit: int = 100) -> list[ResearchQATask]:
     """Pull a subset of SuperGPQA rows and map them to tasks."""
-    tasks: list[ResearchQATask] = []
-    offset = 0
-    while len(tasks) < limit:
-        page = hf_fetch.fetch_page(
-            SUPERGPQA_DATASET, SUPERGPQA_SPLIT, offset, min(100, limit - len(tasks))
-        )
-        if not page:
-            break
-        for raw in page:
-            if (
-                (raw.get("question") or "").strip()
-                and raw.get("options")
-                and (raw.get("answer_letter") or "").strip()
-            ):
-                tasks.append(supergpqa_row_to_task(raw, len(tasks) + 1))
-                if len(tasks) == limit:
-                    break
-        offset += len(page)
-    return tasks
+    return hf_fetch.fetch_mapped_tasks(
+        SUPERGPQA_DATASET,
+        SUPERGPQA_SPLIT,
+        limit,
+        supergpqa_row_to_task,
+        is_valid=_supergpqa_row_valid,
+    )
 
 
 class SuperGPQA(EvalDataset):

--- a/src/bicameral_agent/eval_datasets/supergpqa.py
+++ b/src/bicameral_agent/eval_datasets/supergpqa.py
@@ -1,0 +1,92 @@
+"""SuperGPQA adapter: graduate-level multiple choice mapped to ``hard``.
+
+``m-a-p/SuperGPQA`` (ODC-BY, attribution required): multiple-choice questions
+across 285 graduate disciplines. Options are embedded into the question text
+(the answerer only sees ``question``) and also kept in ``choices`` for the
+deterministic ``multiple_choice`` verifier; the gold answer is the letter.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets.base import DatasetMeta, EvalDataset
+
+SUPERGPQA_DATASET = "m-a-p/SuperGPQA"
+SUPERGPQA_SPLIT = "train"
+
+
+def format_choices(options: list[str]) -> str:
+    """Render options as an A./B./... block for the question text."""
+    return "\n".join(
+        f"{chr(ord('A') + i)}. {opt}" for i, opt in enumerate(options)
+    )
+
+
+def supergpqa_row_to_task(row: dict, index: int) -> ResearchQATask:
+    """Map one SuperGPQA row into a ``hard`` multiple-choice task."""
+    options = [str(o) for o in (row.get("options") or [])]
+    letter = (row.get("answer_letter") or "").strip().upper()
+    question = (
+        f"{(row.get('question') or '').strip()}\n\n"
+        f"Options:\n{format_choices(options)}\n\n"
+        "Answer with the letter of the correct option."
+    )
+    rubric = (
+        f"5: Selects option {letter} with sound reasoning. 3: Selects option "
+        f"{letter} without justification. 1: Selects any other option or none."
+    )
+    return ResearchQATask(
+        task_id=f"supergpqa_hard_{index:03d}",
+        difficulty=TaskDifficulty.HARD,
+        split=TaskSplit.EVAL,
+        question=question,
+        gold_answer=letter,
+        scoring_rubric=rubric,
+        choices=options,
+    )
+
+
+def fetch_supergpqa(limit: int = 100) -> list[ResearchQATask]:
+    """Pull a subset of SuperGPQA rows and map them to tasks."""
+    tasks: list[ResearchQATask] = []
+    offset = 0
+    while len(tasks) < limit:
+        page = hf_fetch.fetch_page(
+            SUPERGPQA_DATASET, SUPERGPQA_SPLIT, offset, min(100, limit - len(tasks))
+        )
+        if not page:
+            break
+        for raw in page:
+            if (
+                (raw.get("question") or "").strip()
+                and raw.get("options")
+                and (raw.get("answer_letter") or "").strip()
+            ):
+                tasks.append(supergpqa_row_to_task(raw, len(tasks) + 1))
+                if len(tasks) == limit:
+                    break
+        offset += len(page)
+    return tasks
+
+
+class SuperGPQA(EvalDataset):
+    """SuperGPQA graduate-level multiple choice (``hard`` tier)."""
+
+    meta: ClassVar[DatasetMeta] = DatasetMeta(
+        name="supergpqa",
+        source=SUPERGPQA_DATASET,
+        license="ODC-BY (attribution required)",
+        citation=(
+            "SuperGPQA: Scaling LLM Evaluation across 285 Graduate "
+            "Disciplines (arXiv:2502.14739)"
+        ),
+    )
+    default_metric: ClassVar[str] = "multiple_choice"
+    supported_metrics: ClassVar[tuple[str, ...]] = ("multiple_choice", "llm_judge")
+    default_limit = 100
+
+    def fetch_tasks(self, limit: int) -> list[ResearchQATask]:
+        return fetch_supergpqa(limit)

--- a/src/bicameral_agent/eval_report.py
+++ b/src/bicameral_agent/eval_report.py
@@ -1,0 +1,87 @@
+"""Unified evaluation report model (Issue #56).
+
+Consolidates what ``scripts/run_baseline_benchmark.py`` previously wrote to
+``summary.json`` as an ad-hoc dict: dataset/metric identity, answerer and
+measurement-model provenance (Issue #53), per-condition aggregates, and
+per-task results with verification detail.
+
+The serialized shape is backward-compatible with the previous summary.json:
+the ``conditions`` mapping still holds ``ConditionReport`` dicts (with
+``summaries.<metric>.mean/std/ci_lower/ci_upper/n``), and the
+``tasks_per_condition`` / ``max_turns`` keys are preserved, so the ui/ Review
+screen keeps reading runs unchanged. New keys are purely additive.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from pydantic import BaseModel, Field
+
+from bicameral_agent.baseline_benchmark import BenchmarkResult
+
+
+class TaskResult(BaseModel):
+    """One episode's scored outcome within a benchmark run."""
+
+    task_id: str
+    condition: str
+    score: float | None = None
+    """Normalized [0, 1] quality score -- comparable across metrics."""
+    detail: str | None = None
+    """Verifier-specific report (from episode.metadata["verification"])."""
+
+
+class EvalReport(BaseModel):
+    """Machine-readable report for one benchmark run."""
+
+    dataset: str
+    metric: str
+    answerer: dict[str, str]
+    measurement: dict[str, str]
+    tasks_per_condition: int
+    max_turns: int
+    conditions: dict[str, dict]
+    """Per-condition ConditionReport dicts (summaries with mean/std/CI)."""
+    results: list[TaskResult] = Field(default_factory=list)
+
+    @classmethod
+    def from_benchmark(
+        cls,
+        result: BenchmarkResult,
+        *,
+        dataset: str,
+        metric: str,
+        answerer: dict[str, str],
+        measurement: dict[str, str],
+        tasks_per_condition: int,
+        max_turns: int,
+    ) -> EvalReport:
+        """Build a report from a completed :class:`BenchmarkResult`."""
+        results = [
+            TaskResult(
+                task_id=str(episode.metadata.get("task_id", "")),
+                condition=condition,
+                score=episode.outcome.quality_score,
+                detail=(episode.metadata.get("verification") or {}).get("detail"),
+            )
+            for condition, episodes in result.episodes.items()
+            for episode in episodes
+        ]
+        return cls(
+            dataset=dataset,
+            metric=metric,
+            answerer=answerer,
+            measurement=measurement,
+            tasks_per_condition=tasks_per_condition,
+            max_turns=max_turns,
+            conditions={
+                condition: dataclasses.asdict(report)
+                for condition, report in result.reports.items()
+            },
+            results=results,
+        )
+
+    def to_json(self) -> str:
+        """Serialize to the summary.json payload."""
+        return self.model_dump_json(indent=2)

--- a/src/bicameral_agent/scorer.py
+++ b/src/bicameral_agent/scorer.py
@@ -37,6 +37,9 @@ class TaskScore(BaseModel):
     overall: float = Field(ge=0.0, le=1.0)
     """Weighted aggregate score. Compatible with EpisodeOutcome.quality_score."""
 
+    detail: str | None = None
+    """Optional verifier-specific report (e.g. matched vs expected answer)."""
+
     @classmethod
     def from_raw(cls, quality: int, completeness: int, accuracy: int) -> TaskScore:
         """Create from raw 1-5 integer scores, normalizing to [0, 1].

--- a/src/bicameral_agent/verifiers.py
+++ b/src/bicameral_agent/verifiers.py
@@ -4,16 +4,23 @@ Formalizes the contract that ``TaskScorer`` / ``LexicalScorer`` already
 duck-type -- ``score(task, answer) -> TaskScore`` -- as a plain dict registry
 mirroring ``model_client.build_client``. Datasets declare a ``default_metric``
 (overridable within their ``supported_metrics``); callers turn the resolved
-metric name into a concrete verifier here. Future deterministic/rubric
-verifiers (exact match, multiple choice, rubric coverage, ...) register the
-same way.
+metric name into a concrete verifier here.
+
+Deterministic verifiers (``exact_match``, ``multiple_choice``) make no LLM
+calls and emit binary 1.0/0.0 scores; LLM-backed verifiers
+(``rubric_coverage``, ``abstention``) grade against per-task rubric items or
+abstention labels. All verifiers return the existing ``TaskScore`` shape,
+using ``TaskScore.detail`` for the mode-specific report.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Callable, Protocol, runtime_checkable
 
 from bicameral_agent.dataset import ResearchQATask
+from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.llm_output import safe_parse_json
 from bicameral_agent.scorer import LexicalScorer, TaskScore, TaskScorer
 
 
@@ -24,11 +31,280 @@ class Verifier(Protocol):
     def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore: ...
 
 
+def _binary_score(correct: bool, detail: str) -> TaskScore:
+    """A 1.0/0.0 TaskScore for deterministic verifiers."""
+    v = 1.0 if correct else 0.0
+    return TaskScore(quality=v, completeness=v, accuracy=v, overall=v, detail=detail)
+
+
+def _clip(text: str, limit: int = 80) -> str:
+    """Truncate long answers so TaskScore.detail stays readable."""
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+_ARTICLES = frozenset({"a", "an", "the"})
+
+# Trailing "answer is X" / "Answer: X" extraction for verbose responses.
+_FINAL_ANSWER_RE = re.compile(
+    r"(?:final answer|answer)\s*(?:is|:)\s*(.+?)\s*(?:\.\s*)?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def normalize_answer(text: str) -> str:
+    """Normalize for exact-match comparison.
+
+    Lowercases, strips punctuation, drops articles, collapses whitespace --
+    the standard short-form-QA normalization (SQuAD-style).
+    """
+    lowered = "".join(
+        ch if ch.isalnum() or ch.isspace() else " " for ch in text.lower()
+    )
+    return " ".join(t for t in lowered.split() if t not in _ARTICLES)
+
+
+def _as_number(text: str) -> float | None:
+    """Parse a numeric answer, tolerating $ , % decorations."""
+    cleaned = text.strip().rstrip("%").replace(",", "").replace("$", "")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+class ExactMatchVerifier:
+    """Deterministic normalized/numeric equality against the gold answer.
+
+    The full response is compared, plus any trailing "answer is X" /
+    "Answer: X" extraction, so a verbose response that states the right
+    final answer still matches. No LLM calls.
+    """
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore:
+        gold = task.gold_answer
+        candidates = [agent_answer]
+        extracted = _FINAL_ANSWER_RE.findall(agent_answer)
+        if extracted:
+            candidates.append(extracted[-1])
+        correct = any(self._matches(gold, c) for c in candidates)
+        shown = _clip(candidates[-1])
+        return _binary_score(
+            correct,
+            f"exact_match: expected {_clip(gold)!r}, got {shown!r} -> "
+            f"{'match' if correct else 'no match'}",
+        )
+
+    @staticmethod
+    def _matches(gold: str, candidate: str) -> bool:
+        norm_gold = normalize_answer(gold)
+        if norm_gold and norm_gold == normalize_answer(candidate):
+            return True
+        gold_num, cand_num = _as_number(gold), _as_number(candidate)
+        return gold_num is not None and cand_num is not None and gold_num == cand_num
+
+
+_MC_ANSWER_RE = re.compile(
+    r"(?:final answer|answer)\s*(?:is|:)?\s*\(?([A-Ja-j])\)?(?![A-Za-z])",
+    re.IGNORECASE,
+)
+_LONE_LETTER_RE = re.compile(r"^\W*([A-Ja-j])\W*$")
+
+
+class MultipleChoiceVerifier:
+    """Deterministic letter-choice grading (gold_answer is a letter A-J).
+
+    Extraction order: explicit "answer is X" statements (last wins), a bare
+    letter response, then a unique match of one option's text within the
+    response (using ``task.choices``). No LLM calls.
+    """
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore:
+        expected = task.gold_answer.strip().upper()
+        extracted = self._extract_letter(agent_answer, task.choices)
+        correct = extracted is not None and extracted == expected
+        return _binary_score(
+            correct,
+            f"multiple_choice: extracted {extracted!r}, expected {expected!r}",
+        )
+
+    @staticmethod
+    def _extract_letter(answer: str, choices: list[str] | None) -> str | None:
+        stated = _MC_ANSWER_RE.findall(answer)
+        if stated:
+            return stated[-1].upper()
+        lone = _LONE_LETTER_RE.match(answer.strip())
+        if lone:
+            return lone.group(1).upper()
+        if choices:
+            norm_answer = normalize_answer(answer)
+            hits = [
+                i
+                for i, choice in enumerate(choices)
+                if normalize_answer(choice)
+                and normalize_answer(choice) in norm_answer
+            ]
+            if len(hits) == 1:
+                return chr(ord("A") + hits[0])
+        return None
+
+
+_RUBRIC_SYSTEM_PROMPT = (
+    "You are a strict grader. Given a response and a numbered list of rubric "
+    "criteria, decide which criteria the response explicitly satisfies. Only "
+    "count a criterion as met if the response clearly and correctly addresses "
+    "it -- never give the benefit of the doubt."
+)
+
+_RUBRIC_USER_TEMPLATE = """\
+## Question
+{question}
+
+## Response to Grade
+{agent_answer}
+
+## Rubric Criteria
+{criteria}
+
+Return the 1-based indices of the criteria that the response satisfies."""
+
+_RUBRIC_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "met_indices": {"type": "array", "items": {"type": "integer"}},
+    },
+    "required": ["met_indices"],
+}
+
+
+class RubricCoverageVerifier:
+    """LLM-graded weighted rubric coverage (requires ``task.rubric_items``).
+
+    One judge call decides which criteria the response satisfies; the score
+    is earned points over the sum of positive points, clamped to [0, 1]
+    (negative-point penalty items subtract, HealthBench-style).
+    """
+
+    def __init__(self, client: GeminiClient | None = None) -> None:
+        self._client = client or GeminiClient()
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore:
+        items = task.rubric_items
+        if not items:
+            raise ValueError(
+                f"Task {task.task_id} has no rubric_items; the rubric_coverage "
+                "metric requires a rubric-annotated dataset"
+            )
+        criteria = "\n".join(
+            f"{i}. [{item.points:g} points] {item.criterion}"
+            for i, item in enumerate(items, start=1)
+        )
+        response = self._client.generate(
+            [
+                {
+                    "role": "user",
+                    "content": _RUBRIC_USER_TEMPLATE.format(
+                        question=task.question,
+                        agent_answer=agent_answer,
+                        criteria=criteria,
+                    ),
+                }
+            ],
+            system_prompt=_RUBRIC_SYSTEM_PROMPT,
+            thinking_level="minimal",
+            temperature=0,
+            max_output_tokens=400,
+            response_schema=_RUBRIC_RESPONSE_SCHEMA,
+        )
+        parsed = safe_parse_json(response, context="RubricCoverageVerifier", default={})
+        raw_indices = parsed.get("met_indices") or []
+        met = {
+            i for i in raw_indices if isinstance(i, int) and 1 <= i <= len(items)
+        }
+        earned = sum(items[i - 1].points for i in met)
+        total = sum(item.points for item in items if item.points > 0)
+        overall = min(1.0, max(0.0, earned / total)) if total > 0 else 0.0
+        detail = (
+            f"rubric_coverage: met {len(met)}/{len(items)} criteria "
+            f"({earned:g}/{total:g} points)"
+        )
+        return TaskScore(
+            quality=overall,
+            completeness=overall,
+            accuracy=overall,
+            overall=overall,
+            detail=detail,
+        )
+
+
+_ABSTENTION_SYSTEM_PROMPT = (
+    "You judge whether a response abstains. A response abstains if it "
+    "declines to answer, says the question is unanswerable or underspecified, "
+    "or states that it does not know -- rather than committing to a direct "
+    "answer."
+)
+
+_ABSTENTION_USER_TEMPLATE = """\
+## Question
+{question}
+
+## Response
+{agent_answer}
+
+Did the response abstain rather than give a direct answer?"""
+
+_ABSTENTION_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {"abstained": {"type": "boolean"}},
+    "required": ["abstained"],
+}
+
+
+class AbstentionVerifier:
+    """LLM-judged abstention correctness (uses ``task.abstention_expected``).
+
+    Scores 1.0 when the response's abstention behavior matches the task's
+    label (abstained when it should, answered when it should).
+    """
+
+    def __init__(self, client: GeminiClient | None = None) -> None:
+        self._client = client or GeminiClient()
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore:
+        response = self._client.generate(
+            [
+                {
+                    "role": "user",
+                    "content": _ABSTENTION_USER_TEMPLATE.format(
+                        question=task.question, agent_answer=agent_answer
+                    ),
+                }
+            ],
+            system_prompt=_ABSTENTION_SYSTEM_PROMPT,
+            thinking_level="minimal",
+            temperature=0,
+            max_output_tokens=100,
+            response_schema=_ABSTENTION_RESPONSE_SCHEMA,
+        )
+        parsed = safe_parse_json(response, context="AbstentionVerifier", default={})
+        abstained = bool(parsed.get("abstained", False))
+        expected = bool(task.abstention_expected)
+        correct = abstained == expected
+        return _binary_score(
+            correct,
+            f"abstention: abstained={abstained}, expected_abstention={expected}",
+        )
+
+
 # client -> verifier factories; ``client`` is any model client satisfying the
 # build_client contract (only LLM-backed verifiers use it).
 _VERIFIERS: dict[str, Callable[[object | None], Verifier]] = {
     "llm_judge": lambda client: TaskScorer(client=client),
     "lexical": lambda client: LexicalScorer(),
+    "exact_match": lambda client: ExactMatchVerifier(),
+    "multiple_choice": lambda client: MultipleChoiceVerifier(),
+    "rubric_coverage": lambda client: RubricCoverageVerifier(client=client),
+    "abstention": lambda client: AbstentionVerifier(client=client),
 }
 
 

--- a/src/bicameral_agent/verifiers.py
+++ b/src/bicameral_agent/verifiers.py
@@ -296,6 +296,146 @@ class AbstentionVerifier:
         )
 
 
+# The official SimpleQA grader template, verbatim from openai/simple-evals
+# (MIT; simpleqa_eval.py GRADER_TEMPLATE). Grades a predicted answer against
+# the gold target as CORRECT / INCORRECT / NOT_ATTEMPTED (letters A/B/C).
+_AUTORATER_TEMPLATE = """
+Your job is to look at a question, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"].
+First, I will give examples of each grade, and then you will grade a new example.
+
+
+The following are examples of CORRECT predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia Obama and Sasha Obama
+Predicted answer 1: sasha and malia obama
+Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check
+Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001.
+```
+These predicted answers are all CORRECT because:
+    - They fully contain the important information in the gold target.
+    - They do not contain any information that contradicts the gold target.
+    - Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.
+    - Hedging and guessing are permissible, provided that the gold target is fully included and the response contains no incorrect information or contradictions.
+
+
+The following are examples of INCORRECT predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: Malia.
+Predicted answer 2: Malia, Sasha, and Susan.
+Predicted answer 3: Barack Obama does not have any children.
+Predicted answer 4: I think it's either Malia and Sasha. Or it could be Malia and Jackie. Or it could be Joey and Malia.
+Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children.
+Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer?
+Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information.
+```
+These predicted answers are all INCORRECT because:
+    - A factual statement in the answer contradicts the gold target. Incorrect statements that have some hedging (e.g., "it is possible that", "although i'm not sure, i think") are also considered incorrect.
+
+
+The following are examples of NOT_ATTEMPTED predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: I don't know.
+Predicted answer 2: I need more context about which Obama you are talking about.
+Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children.
+Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one.
+```
+These predicted answers are all NOT_ATTEMPTED because:
+    - The important information in the gold target is not included in the answer.
+    - No statements in the answer contradict the gold target.
+
+
+Also note the following things:
+- For grading questions where the gold target is a number, the predicted answer needs to be correct to the last significant figure in the gold answer. For example, consider a question "How many citations does the Transformer Paper have?" with gold target "120k".
+    - Predicted answers "120k", "124k", and 115k" are all CORRECT.
+    - Predicted answers "100k" and "113k" are INCORRECT.
+    - Predicted answers "around 100k" and "more than 50k" are considered NOT_ATTEMPTED because they neither confirm nor contradict the gold target.
+- The gold target may contain more information than the question. In such cases, the predicted answer only needs to contain the information that is in the question.
+    - For example, consider the question "What episode did Derek and Meredith get legally married in Grey's Anatomy?" with gold target "Season 7, Episode 20: White Wedding". Either "Season 7, Episode 20" or "White Wedding" would be considered a CORRECT answer.
+- Do not punish predicted answers if they omit information that would be clearly inferred from the question.
+    - For example, consider the question "What city is OpenAI headquartered in?" and the gold target "San Francisco, California". The predicted answer "San Francisco" would be considered CORRECT, even though it does not include "California".
+    - Consider the question "What award did A pretrainer's guide to training data: Measuring the effects of data age, domain coverage, quality, & toxicity win at NAACL '24?", the gold target is "Outstanding Paper Award". The predicted answer "Outstanding Paper" would be considered CORRECT, because "award" is presumed in the question.
+    - For the question "What is the height of Jason Wei in meters?", the gold target is "1.73 m". The predicted answer "1.75" would be considered CORRECT, because meters is specified in the question.
+    - For the question "What is the name of Barack Obama's wife?", the gold target is "Michelle Obama". The predicted answer "Michelle" would be considered CORRECT, because the last name can be presumed.
+- Do not punish for typos in people's name if it's clearly the same name.
+    - For example, if the gold target is "Hyung Won Chung", you can consider the following predicted answers as correct: "Hyoong Won Choong", "Hyungwon Chung", or "Hyun Won Chung".
+
+
+Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
+```
+Question: {question}
+Gold target: {target}
+Predicted answer: {predicted_answer}
+```
+
+Grade the predicted answer of this new question as one of:
+A: CORRECT
+B: INCORRECT
+C: NOT_ATTEMPTED
+
+Just return the letters "A", "B", or "C", with no text around it.
+""".strip()
+
+_AUTORATER_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {"grade": {"type": "string", "enum": ["A", "B", "C"]}},
+    "required": ["grade"],
+}
+
+_AUTORATER_VERDICTS = {"A": "correct", "B": "incorrect", "C": "not_attempted"}
+
+_BARE_LETTER_GRADE_RE = re.compile(r"\b([ABC])\b")
+
+
+class LlmAutoraterVerifier:
+    """SimpleQA official 3-way autorater: correct / incorrect / not_attempted.
+
+    Runs the verbatim openai/simple-evals grading template against the judge
+    client. Scoring: correct -> 1.0; incorrect and not_attempted -> 0.0 (so
+    ``overall`` stays comparable with every other metric feeding
+    ``quality_score``), with the verdict recorded in ``TaskScore.detail`` so
+    abstention (`not_attempted`) remains distinguishable from a wrong answer
+    downstream. Unparseable judge output defaults to not_attempted, matching
+    the reference implementation.
+    """
+
+    def __init__(self, client: GeminiClient | None = None) -> None:
+        self._client = client or GeminiClient()
+
+    def score(self, task: ResearchQATask, agent_answer: str) -> TaskScore:
+        response = self._client.generate(
+            [
+                {
+                    "role": "user",
+                    "content": _AUTORATER_TEMPLATE.format(
+                        question=task.question,
+                        target=task.gold_answer,
+                        predicted_answer=agent_answer,
+                    ),
+                }
+            ],
+            thinking_level="minimal",
+            temperature=0,
+            max_output_tokens=100,
+            response_schema=_AUTORATER_RESPONSE_SCHEMA,
+        )
+        parsed = safe_parse_json(response, context="LlmAutoraterVerifier", default={})
+        grade = str(parsed.get("grade", "")).strip().upper()
+        if grade not in _AUTORATER_VERDICTS:
+            # Fall back to the bare letter the template itself asks for;
+            # like the reference implementation, no grade means NOT_ATTEMPTED.
+            match = _BARE_LETTER_GRADE_RE.search(
+                getattr(response, "content", None) or ""
+            )
+            grade = match.group(1) if match else "C"
+        verdict = _AUTORATER_VERDICTS[grade]
+        return _binary_score(verdict == "correct", f"llm_autorater: {verdict}")
+
+
 # client -> verifier factories; ``client`` is any model client satisfying the
 # build_client contract (only LLM-backed verifiers use it).
 _VERIFIERS: dict[str, Callable[[object | None], Verifier]] = {
@@ -305,6 +445,7 @@ _VERIFIERS: dict[str, Callable[[object | None], Verifier]] = {
     "multiple_choice": lambda client: MultipleChoiceVerifier(),
     "rubric_coverage": lambda client: RubricCoverageVerifier(client=client),
     "abstention": lambda client: AbstentionVerifier(client=client),
+    "llm_autorater": lambda client: LlmAutoraterVerifier(client=client),
 }
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from bicameral_agent.dataset import (
     ResearchQADataset,
     ResearchQATask,
+    RubricItem,
     TaskDifficulty,
     TaskSplit,
 )
@@ -130,6 +131,56 @@ class TestSchemaRejection:
                 gold_answer="A",
                 scoring_rubric="rubric",
             )
+
+
+class TestSchemaExtensions:
+    """Issue #56: optional choices / rubric_items / abstention_expected."""
+
+    @staticmethod
+    def _task(**overrides):
+        defaults = dict(
+            task_id="ext_001",
+            difficulty=TaskDifficulty.TYPICAL,
+            split=TaskSplit.EVAL,
+            question="Q?",
+            gold_answer="A.",
+            scoring_rubric="5: Good. 1: Bad.",
+        )
+        defaults.update(overrides)
+        return ResearchQATask(**defaults)
+
+    def test_new_fields_default_to_none(self):
+        task = self._task()
+        assert task.choices is None
+        assert task.rubric_items is None
+        assert task.abstention_expected is None
+
+    def test_new_fields_round_trip(self):
+        task = self._task(
+            choices=["red", "blue"],
+            rubric_items=[RubricItem(criterion="mentions blue", points=2.0)],
+            abstention_expected=False,
+        )
+        reloaded = ResearchQATask.model_validate(task.model_dump(mode="json"))
+        assert reloaded.choices == ["red", "blue"]
+        assert reloaded.rubric_items[0].criterion == "mentions blue"
+        assert reloaded.rubric_items[0].points == 2.0
+        assert reloaded.abstention_expected is False
+
+    def test_empty_gold_without_rubric_rejected(self):
+        with pytest.raises(ValidationError, match="rubric_items"):
+            self._task(gold_answer="")
+
+    def test_empty_gold_with_rubric_accepted(self):
+        task = self._task(
+            gold_answer="",
+            rubric_items=[RubricItem(criterion="covers topic", points=1.0)],
+        )
+        assert task.gold_answer == ""
+
+    def test_empty_gold_with_empty_rubric_rejected(self):
+        with pytest.raises(ValidationError, match="rubric_items"):
+            self._task(gold_answer="", rubric_items=[])
 
 
 class TestLoaderFiltering:

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -146,7 +146,7 @@ class TestEpisodeConfig:
         assert cfg.max_turns == 25
         assert cfg.thinking_level == "medium"
         assert cfg.score_episode is False
-        assert cfg.use_lexical_scorer is False
+        assert cfg.metric == "llm_judge"
 
     def test_custom_values(self):
         cfg = EpisodeConfig(max_turns=10, thinking_level="low", score_episode=True)
@@ -1151,7 +1151,7 @@ class TestPerRoleClients:
         with patch(
             "bicameral_agent.episode_runner.SimulatedUser"
         ) as MockSimUser, patch(
-            "bicameral_agent.episode_runner.TaskScorer"
+            "bicameral_agent.verifiers.TaskScorer"
         ) as MockScorer:
             mock_sim = MagicMock()
             mock_sim.respond.return_value = UserAction(
@@ -1161,7 +1161,7 @@ class TestPerRoleClients:
             )
             MockSimUser.return_value = mock_sim
             mock_scorer = MagicMock()
-            mock_scorer.score.return_value = MagicMock(overall=0.5)
+            mock_scorer.score.return_value = MagicMock(overall=0.5, detail=None)
             MockScorer.return_value = mock_scorer
 
             runner.run_episode(_make_task(), ctrl)
@@ -1229,6 +1229,46 @@ class TestPerRoleClients:
         judge_arg = MockScorer.call_args.kwargs["client"]
         assert isinstance(judge_arg, CostTrackedClient)
         assert judge_arg._inner is client
+
+
+class TestScoringWiring:
+    """Issue #56: EpisodeConfig.metric selects the verifier via build_verifier."""
+
+    def _run_scored(self, metric: str, answer: str):
+        client = _make_mock_client()
+        client.generate.return_value = _mock_gemini_response(content=answer)
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+        runner = EpisodeRunner(
+            client, EpisodeConfig(max_turns=1, score_episode=True, metric=metric)
+        )
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.return_value = UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+            MockSimUser.return_value = mock_sim
+            return runner.run_episode(_make_task(), ctrl)
+
+    def test_lexical_metric_scores_without_llm_judge(self):
+        gold = _make_task().gold_answer
+        episode = self._run_scored("lexical", gold)
+        assert episode.outcome.quality_score == 1.0
+        verification = episode.metadata["verification"]
+        assert verification["metric"] == "lexical"
+        assert verification["detail"] is None
+
+    def test_deterministic_metric_detail_lands_in_metadata(self):
+        episode = self._run_scored("exact_match", "Something unrelated")
+        assert episode.outcome.quality_score == 0.0
+        assert "exact_match" in episode.metadata["verification"]["detail"]
+
+    def test_unknown_metric_fails_loudly(self):
+        with pytest.raises(ValueError, match="Unknown metric"):
+            self._run_scored("not_a_metric", "x")
 
 
 class TestCostBudgetHandling:

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -4,6 +4,7 @@ Fully offline: adapters are exercised against monkeypatched pagers and tmp
 caches; no network and no externally-licensed data are required.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -19,7 +20,16 @@ from bicameral_agent.eval_datasets import (
     dataset_names,
     resolve_metric,
 )
-from bicameral_agent.eval_datasets import hf_fetch
+from bicameral_agent.eval_datasets import (
+    abstentionbench,
+    bbeh,
+    healthbench_hard,
+    hf_fetch,
+    hle,
+    researchqa,
+    simpleqa_verified,
+    supergpqa,
+)
 from bicameral_agent.eval_datasets.base import EXTERNAL_DATA_DIR
 from bicameral_agent.verifiers import verifier_names
 
@@ -32,7 +42,19 @@ def _frames_page(start: int, n: int) -> list[dict]:
 
 class TestRegistry:
     def test_known_names(self):
-        assert dataset_names() == ["builtin", "crepe", "frames", "hard_benchmark"]
+        assert dataset_names() == [
+            "abstentionbench",
+            "bbeh",
+            "builtin",
+            "crepe",
+            "frames",
+            "hard_benchmark",
+            "healthbench_hard",
+            "hle",
+            "researchqa",
+            "simpleqa_verified",
+            "supergpqa",
+        ]
 
     def test_build_dataset_dispatches(self):
         assert isinstance(build_dataset("builtin"), BuiltinPool)
@@ -118,23 +140,228 @@ class TestAdapterLifecycle:
             HardBenchmark(frames_n=2, crepe_n=2).build(limit=3)
 
 
-class TestRunnableMetricGuard:
-    """The benchmark script's metric -> use_lexical_scorer collapse must fail
-    loudly for any future verifier the runner cannot express yet."""
+class TestSimpleQAVerified:
+    def test_row_mapping(self, monkeypatch):
+        rows = [
+            {"problem": "Capital of France?", "answer": "Paris", "topic": "Geo"},
+            {"problem": "", "answer": "skipped"},  # blank problem filtered
+            {"problem": "2+2?", "answer": "4"},
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = simpleqa_verified.fetch_simpleqa_verified(limit=2)
+        assert [t.task_id for t in tasks] == [
+            "simpleqa_typical_001",
+            "simpleqa_typical_002",
+        ]
+        assert tasks[0].gold_answer == "Paris"
+        assert all(t.difficulty == TaskDifficulty.TYPICAL for t in tasks)
 
-    @pytest.fixture()
-    def ensure_runnable_metric(self, monkeypatch):
-        monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
-        from run_baseline_benchmark import ensure_runnable_metric
+    def test_uses_named_config(self, monkeypatch):
+        seen: dict = {}
 
-        return ensure_runnable_metric
+        def fake_fetch(dataset, split, offset, length, config="default"):
+            seen.update(dataset=dataset, split=split, config=config)
+            return []
 
-    def test_runnable_metrics_pass_through(self, ensure_runnable_metric):
-        assert ensure_runnable_metric("llm_judge") == "llm_judge"
-        assert ensure_runnable_metric("lexical") == "lexical"
+        monkeypatch.setattr(hf_fetch, "fetch_page", fake_fetch)
+        simpleqa_verified.fetch_simpleqa_verified(limit=1)
+        assert seen == {
+            "dataset": "google/simpleqa-verified",
+            "split": "eval",
+            "config": "simpleqa_verified",
+        }
 
-    def test_unwired_metric_raises_instead_of_llm_judge_fallback(
-        self, ensure_runnable_metric
-    ):
-        with pytest.raises(ValueError, match="build_verifier"):
-            ensure_runnable_metric("exact_match")
+
+class TestSuperGPQA:
+    def test_row_mapping(self, monkeypatch):
+        rows = [
+            {
+                "question": "Which is prime?",
+                "options": ["4", "7", "9"],
+                "answer": "7",
+                "answer_letter": "b",
+            }
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = supergpqa.fetch_supergpqa(limit=1)
+        task = tasks[0]
+        assert task.gold_answer == "B"  # normalized to upper case
+        assert task.choices == ["4", "7", "9"]
+        assert "A. 4" in task.question and "B. 7" in task.question
+        assert task.difficulty == TaskDifficulty.HARD
+
+    def test_rows_missing_fields_skipped(self, monkeypatch):
+        rows = [
+            {"question": "no options", "options": [], "answer_letter": "A"},
+            {"question": "ok", "options": ["x", "y"], "answer_letter": "A"},
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = supergpqa.fetch_supergpqa(limit=2)
+        assert len(tasks) == 1
+        assert tasks[0].question.startswith("ok")
+
+
+class TestBbeh:
+    def test_round_robin_sampling(self, monkeypatch):
+        def fake_get(url):
+            name = url.rsplit("/", 2)[-2]
+            return {
+                "examples": [
+                    {"input": f"{name} q{i}", "target": f"t{i}"} for i in range(3)
+                ]
+            }
+
+        monkeypatch.setattr(hf_fetch, "http_get_json", fake_get)
+        tasks = bbeh.fetch_bbeh(limit=25)
+        assert len(tasks) == 25
+        # ceil(25/23) = 2 per subtask; the first two subtasks contribute both
+        assert tasks[0].question == "bbeh_boardgame_qa q0"
+        assert tasks[1].question == "bbeh_boardgame_qa q1"
+        assert tasks[2].question == "bbeh_boolean_expressions q0"
+        assert all(t.difficulty == TaskDifficulty.HARD for t in tasks)
+        assert tasks[0].gold_answer == "t0"
+
+
+class TestHealthBenchHard:
+    _RECORD = {
+        "prompt": [{"role": "user", "content": "Is my dose safe?"}],
+        "prompt_id": "abc",
+        "rubrics": [
+            {"criterion": "Advises consulting a clinician", "points": 5},
+            {"criterion": "Recommends doubling the dose", "points": -3},
+        ],
+        "ideal_completions_data": {"ideal_completion": "Check with your doctor."},
+    }
+
+    def test_jsonl_mapping(self, monkeypatch):
+        jsonl = json.dumps(self._RECORD) + "\n\n" + json.dumps(self._RECORD)
+        monkeypatch.setattr(hf_fetch, "http_get_text", lambda url: jsonl)
+        tasks = healthbench_hard.fetch_healthbench_hard(limit=2)
+        assert len(tasks) == 2
+        task = tasks[0]
+        assert task.question == "Is my dose safe?"
+        assert task.gold_answer == "Check with your doctor."
+        assert [i.points for i in task.rubric_items] == [5.0, -3.0]
+        assert task.difficulty == TaskDifficulty.HARD
+
+    def test_multi_turn_prompt_flattened(self, monkeypatch):
+        record = dict(
+            self._RECORD,
+            prompt=[
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello"},
+                {"role": "user", "content": "Dose?"},
+            ],
+        )
+        monkeypatch.setattr(
+            hf_fetch, "http_get_text", lambda url: json.dumps(record)
+        )
+        (task,) = healthbench_hard.fetch_healthbench_hard(limit=1)
+        assert "user: Hi" in task.question
+        assert "assistant: Hello" in task.question
+
+
+class TestResearchQA:
+    def test_rubric_native_mapping(self, monkeypatch):
+        rows = [
+            {
+                "query": "How does X affect Y?",
+                "rubric": [
+                    {"rubric_item": "Mentions mechanism A", "type": ["Other"]},
+                    {"rubric_item": "Compares with Z", "type": ["Comparison"]},
+                ],
+            },
+            {"query": "No rubric", "rubric": []},  # filtered out
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = researchqa.fetch_researchqa(limit=1)
+        (task,) = tasks
+        assert task.gold_answer == ""  # rubric-native: no single gold answer
+        assert [i.criterion for i in task.rubric_items] == [
+            "Mentions mechanism A",
+            "Compares with Z",
+        ]
+        assert all(i.points == 1.0 for i in task.rubric_items)
+
+    def test_default_metric_is_rubric_coverage(self):
+        assert build_dataset("researchqa").default_metric == "rubric_coverage"
+
+
+class TestAbstentionBench:
+    def test_abstain_row_mapping(self, monkeypatch):
+        rows = [
+            {
+                "question": "What is in my pocket?",
+                "reference_answers": [],
+                "should_abstain": True,
+                "metadata_json": "{}",
+            },
+            {
+                "question": "What is 2+2?",
+                "reference_answers": ["4"],
+                "should_abstain": False,
+                "metadata_json": "{}",
+            },
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = abstentionbench.fetch_abstentionbench(limit=2)
+        assert tasks[0].abstention_expected is True
+        assert "abstain" in tasks[0].gold_answer  # explicit abstain gold
+        assert tasks[1].abstention_expected is False
+        assert tasks[1].gold_answer == "4"
+
+    def test_license_is_flagged_non_commercial(self):
+        assert "NON-COMMERCIAL" in abstentionbench.AbstentionBench.meta.license
+
+
+class TestHle:
+    def test_multimodal_rows_filtered(self, monkeypatch):
+        rows = [
+            {"question": "Text-only?", "answer": "Yes", "image": ""},
+            {"question": "Has image", "answer": "No", "image": "base64..."},
+            {"question": "Also text", "answer": "Sure", "image": None},
+        ]
+        monkeypatch.setattr(
+            hf_fetch, "fetch_page", lambda *a, **kw: rows if a[2] == 0 else []
+        )
+        tasks = hle.fetch_hle(limit=3)
+        assert [t.question for t in tasks] == ["Text-only?", "Also text"]
+
+    def test_requires_hf_token_flagged(self):
+        assert hle.Hle.meta.requires_hf_token is True
+
+
+class TestHfFetchAuth:
+    def test_token_sent_to_datasets_server(self, monkeypatch):
+        seen: dict = {}
+
+        def fake_json(url, headers=None):
+            seen["headers"] = headers
+            return {"rows": []}
+
+        monkeypatch.setattr(hf_fetch, "http_get_json", fake_json)
+        monkeypatch.setenv("HF_TOKEN", "hf_secret")
+        hf_fetch.fetch_page("cais/hle", "test", 0, 10)
+        assert seen["headers"] == {"Authorization": "Bearer hf_secret"}
+
+    def test_no_token_no_header(self, monkeypatch):
+        seen: dict = {}
+
+        def fake_json(url, headers=None):
+            seen["headers"] = headers
+            return {"rows": []}
+
+        monkeypatch.setattr(hf_fetch, "http_get_json", fake_json)
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        hf_fetch.fetch_page("google/frames-benchmark", "test", 0, 10)
+        assert seen["headers"] is None

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -114,7 +114,11 @@ class TestAdapterLifecycle:
 
     def test_build_then_load_round_trip(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            hf_fetch, "fetch_page", lambda ds, split, offset, length: _frames_page(offset, length)
+            hf_fetch,
+            "fetch_page",
+            lambda ds, split, offset, length, config="default": _frames_page(
+                offset, length
+            ),
         )
         cache = tmp_path / "frames.json"
         built = Frames(cache_path=cache).build(limit=3)
@@ -125,7 +129,7 @@ class TestAdapterLifecycle:
 
     def test_short_fetch_refuses_to_write_cache(self, monkeypatch, tmp_path):
         pages = [_frames_page(0, 2), []]
-        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a: pages.pop(0))
+        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a, **kw: pages.pop(0))
         cache = tmp_path / "frames.json"
         with pytest.raises(RuntimeError, match="short benchmark"):
             Frames(cache_path=cache).build(limit=5)

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -1,0 +1,90 @@
+"""Tests for the unified EvalReport model (Issue #56)."""
+
+import json
+
+from bicameral_agent.ab_test import compute_summary
+from bicameral_agent.baseline_benchmark import BenchmarkResult, ConditionReport
+from bicameral_agent.eval_report import EvalReport
+
+# Metrics the ui/ Review screen reads from summary.json
+# (ui/src/core/runs.ts HEADLINE_METRICS); their shape must not break.
+_HEADLINE_METRICS = (
+    "quality_score",
+    "total_tokens",
+    "total_turns",
+    "wall_clock_ms",
+    "tool_cost_usd",
+    "avg_queue_depth",
+    "drain_count",
+)
+
+
+def _condition_report(condition: str) -> ConditionReport:
+    return ConditionReport(
+        condition=condition,
+        n_episodes=2,
+        summaries={name: compute_summary([0.5, 1.0]) for name in _HEADLINE_METRICS},
+        latency_mape_percent=12.5,
+        latency_n_pairs=3,
+    )
+
+
+def _make_report(result: BenchmarkResult) -> EvalReport:
+    return EvalReport.from_benchmark(
+        result,
+        dataset="builtin",
+        metric="llm_judge",
+        answerer={"provider": "gemini", "model": "gemini-x"},
+        measurement={"provider": "gemini", "model": "gemini-x"},
+        tasks_per_condition=2,
+        max_turns=10,
+    )
+
+
+class TestEvalReport:
+    def test_summary_shape_backward_compatible(self, make_episode):
+        """The serialized shape keeps every key the ui/ Review screen reads."""
+        result = BenchmarkResult(
+            episodes={"heuristic": [make_episode()]},
+            reports={"heuristic": _condition_report("heuristic")},
+        )
+        payload = json.loads(_make_report(result).to_json())
+
+        assert payload["dataset"] == "builtin"
+        assert payload["metric"] == "llm_judge"
+        assert payload["tasks_per_condition"] == 2
+        assert payload["max_turns"] == 10
+        assert payload["answerer"] == {"provider": "gemini", "model": "gemini-x"}
+        condition = payload["conditions"]["heuristic"]
+        assert condition["n_episodes"] == 2
+        for name in _HEADLINE_METRICS:
+            summary = condition["summaries"][name]
+            assert set(summary) == {"mean", "std", "ci_lower", "ci_upper", "n"}
+
+    def test_results_capture_scores_and_verification_detail(self, make_episode):
+        episode = make_episode(
+            metadata={
+                "task_id": "t9",
+                "verification": {
+                    "metric": "exact_match",
+                    "detail": "exact_match: expected 'x', got 'y' -> no match",
+                },
+            }
+        )
+        result = BenchmarkResult(
+            episodes={"random": [episode]},
+            reports={"random": _condition_report("random")},
+        )
+        (task_result,) = _make_report(result).results
+        assert task_result.task_id == "t9"
+        assert task_result.condition == "random"
+        assert task_result.score == episode.outcome.quality_score
+        assert "no match" in task_result.detail
+
+    def test_results_tolerate_unverified_episodes(self, make_episode):
+        result = BenchmarkResult(
+            episodes={"random": [make_episode(metadata={"task_id": "t1"})]},
+            reports={"random": _condition_report("random")},
+        )
+        (task_result,) = _make_report(result).results
+        assert task_result.detail is None

--- a/tests/test_hard_benchmark.py
+++ b/tests/test_hard_benchmark.py
@@ -89,7 +89,7 @@ class TestPager:
         pages = [[_frames_row(i) for i in range(3)], [_frames_row(i) for i in range(3, 6)]]
         calls: list[tuple[int, int]] = []
 
-        def fake_fetch_page(dataset, split, offset, length):
+        def fake_fetch_page(dataset, split, offset, length, config="default"):
             calls.append((offset, length))
             return pages.pop(0)
 
@@ -107,7 +107,7 @@ class TestPager:
             [_crepe_row(0), _crepe_row(1, valid=False), _crepe_row(2), _crepe_row(3, valid=False)],
             [],
         ]
-        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a: pages.pop(0))
+        monkeypatch.setattr(hf_fetch, "fetch_page", lambda *a, **kw: pages.pop(0))
         tasks = fetch_crepe(limit=10)
         assert len(tasks) == 2
         assert all(t.difficulty == TaskDifficulty.TRICKY for t in tasks)

--- a/tests/test_hard_benchmark.py
+++ b/tests/test_hard_benchmark.py
@@ -115,7 +115,7 @@ class TestPager:
 
     def test_error_payload_raises_instead_of_empty_page(self, monkeypatch):
         monkeypatch.setattr(
-            hf_fetch, "http_get_json", lambda url: {"error": "rate limited"}
+            hf_fetch, "http_get_json", lambda url, headers=None: {"error": "rate limited"}
         )
         with pytest.raises(RuntimeError, match="rate limited"):
             hf_fetch.fetch_page("some/dataset", "test", 0, 100)

--- a/tests/test_serialization_parquet.py
+++ b/tests/test_serialization_parquet.py
@@ -57,6 +57,18 @@ class TestParquetRoundTrip:
         assert restored.outcome.model_dump() == ep.outcome.model_dump()
         assert restored.metadata == {"nested": {"key": [1, 2, 3]}}
 
+    def test_verification_metadata_round_trips(self, make_episode, tmp_path):
+        """Issue #56: verifier detail in metadata survives the parquet trip."""
+        verification = {
+            "metric": "multiple_choice",
+            "detail": "multiple_choice: extracted 'B', expected 'B'",
+        }
+        ep = make_episode(metadata={"verification": verification})
+        path = str(tmp_path / "episode.parquet")
+        ep.to_parquet(path)
+        restored = Episode.from_parquet(path)
+        assert restored.metadata["verification"] == verification
+
     def test_empty_episode(self, tmp_path):
         ep = Episode(
             outcome=EpisodeOutcome(total_tokens=0, total_turns=0, wall_clock_ms=0)

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -1,14 +1,31 @@
 """Tests for the verifier registry (Issue #56). No LLM calls."""
 
+import json
+from unittest.mock import MagicMock
+
 import pytest
 
-from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.dataset import (
+    ResearchQATask,
+    RubricItem,
+    TaskDifficulty,
+    TaskSplit,
+)
 from bicameral_agent.scorer import LexicalScorer, TaskScorer
-from bicameral_agent.verifiers import Verifier, build_verifier, verifier_names
+from bicameral_agent.verifiers import (
+    AbstentionVerifier,
+    ExactMatchVerifier,
+    MultipleChoiceVerifier,
+    RubricCoverageVerifier,
+    Verifier,
+    build_verifier,
+    normalize_answer,
+    verifier_names,
+)
 
 
-def _task() -> ResearchQATask:
-    return ResearchQATask(
+def _task(**overrides) -> ResearchQATask:
+    defaults = dict(
         task_id="t1",
         difficulty=TaskDifficulty.TYPICAL,
         split=TaskSplit.EVAL,
@@ -16,11 +33,29 @@ def _task() -> ResearchQATask:
         gold_answer="The sky is blue.",
         scoring_rubric="5: correct. 1: incorrect.",
     )
+    defaults.update(overrides)
+    return ResearchQATask(**defaults)
+
+
+def _mock_client(payload: dict) -> MagicMock:
+    """A model client whose generate() returns the given JSON payload."""
+    response = MagicMock()
+    response.content = json.dumps(payload)
+    client = MagicMock()
+    client.generate.return_value = response
+    return client
 
 
 class TestBuildVerifier:
     def test_known_metrics(self):
-        assert verifier_names() == ["lexical", "llm_judge"]
+        assert verifier_names() == [
+            "abstention",
+            "exact_match",
+            "lexical",
+            "llm_judge",
+            "multiple_choice",
+            "rubric_coverage",
+        ]
 
     def test_lexical_is_deterministic_scorer(self):
         verifier = build_verifier("lexical")
@@ -34,10 +69,185 @@ class TestBuildVerifier:
         assert isinstance(verifier, TaskScorer)
         assert verifier._client is sentinel
 
+    def test_deterministic_verifiers_dispatch(self):
+        assert isinstance(build_verifier("exact_match"), ExactMatchVerifier)
+        assert isinstance(build_verifier("multiple_choice"), MultipleChoiceVerifier)
+
+    def test_llm_backed_verifiers_receive_client(self):
+        sentinel = object()
+        assert build_verifier("rubric_coverage", client=sentinel)._client is sentinel
+        assert build_verifier("abstention", client=sentinel)._client is sentinel
+
     def test_unknown_metric_lists_known(self):
         with pytest.raises(ValueError, match="lexical"):
-            build_verifier("exact_match")
+            build_verifier("nope")
 
     def test_registry_entries_satisfy_protocol(self):
         for metric in verifier_names():
             assert isinstance(build_verifier(metric, client=object()), Verifier)
+
+
+class TestNormalizeAnswer:
+    def test_case_punctuation_articles(self):
+        assert normalize_answer("The Sky, is BLUE!") == "sky is blue"
+
+    def test_whitespace_collapsed(self):
+        assert normalize_answer("  a   b  \n c ") == "b c"
+
+
+class TestExactMatchVerifier:
+    def test_exact_match_scores_one(self):
+        score = ExactMatchVerifier().score(_task(gold_answer="Paris"), "Paris")
+        assert score.overall == 1.0
+        assert "match" in score.detail
+
+    def test_normalized_match(self):
+        score = ExactMatchVerifier().score(_task(gold_answer="Paris"), "the PARIS.")
+        assert score.overall == 1.0
+
+    def test_mismatch_scores_zero_with_detail(self):
+        score = ExactMatchVerifier().score(_task(gold_answer="Paris"), "London")
+        assert score.overall == 0.0
+        assert "'Paris'" in score.detail
+        assert "'London'" in score.detail
+
+    def test_final_answer_extraction(self):
+        answer = "Let me reason about this.\nThe answer is Paris."
+        score = ExactMatchVerifier().score(_task(gold_answer="Paris"), answer)
+        assert score.overall == 1.0
+
+    def test_numeric_equivalence(self):
+        score = ExactMatchVerifier().score(_task(gold_answer="1,000"), "1000.0")
+        assert score.overall == 1.0
+
+    def test_verbose_non_answer_scores_zero(self):
+        score = ExactMatchVerifier().score(
+            _task(gold_answer="Paris"), "It could be Paris or London."
+        )
+        assert score.overall == 0.0
+
+
+class TestMultipleChoiceVerifier:
+    def _mc_task(self, gold="B") -> ResearchQATask:
+        return _task(
+            gold_answer=gold,
+            choices=["red herring", "correct choice", "another option"],
+        )
+
+    def test_stated_answer_correct(self):
+        score = MultipleChoiceVerifier().score(
+            self._mc_task(), "Reasoning... The answer is B."
+        )
+        assert score.overall == 1.0
+        assert "'B'" in score.detail
+
+    def test_stated_answer_wrong(self):
+        score = MultipleChoiceVerifier().score(self._mc_task(), "Answer: (C)")
+        assert score.overall == 0.0
+        assert "extracted 'C'" in score.detail
+        assert "expected 'B'" in score.detail
+
+    def test_bare_letter(self):
+        assert MultipleChoiceVerifier().score(self._mc_task(), "B.").overall == 1.0
+
+    def test_last_stated_answer_wins(self):
+        answer = "Initially the answer is A. On reflection, the answer is B."
+        assert MultipleChoiceVerifier().score(self._mc_task(), answer).overall == 1.0
+
+    def test_choice_text_match(self):
+        score = MultipleChoiceVerifier().score(
+            self._mc_task(), "I would go with the correct choice here."
+        )
+        assert score.overall == 1.0
+
+    def test_no_extractable_choice_scores_zero(self):
+        score = MultipleChoiceVerifier().score(
+            self._mc_task(), "This is hard to say."
+        )
+        assert score.overall == 0.0
+        assert "None" in score.detail
+
+
+class TestRubricCoverageVerifier:
+    def _rubric_task(self) -> ResearchQATask:
+        return _task(
+            gold_answer="",
+            rubric_items=[
+                RubricItem(criterion="mentions blue", points=3.0),
+                RubricItem(criterion="mentions scattering", points=1.0),
+                RubricItem(criterion="claims the sky is green", points=-2.0),
+            ],
+        )
+
+    def test_weighted_coverage(self):
+        client = _mock_client({"met_indices": [1]})
+        score = RubricCoverageVerifier(client=client).score(self._rubric_task(), "blue")
+        assert score.overall == pytest.approx(3.0 / 4.0)
+        assert "1/3 criteria" in score.detail
+
+    def test_negative_points_subtract_and_clamp(self):
+        client = _mock_client({"met_indices": [3]})
+        score = RubricCoverageVerifier(client=client).score(self._rubric_task(), "green")
+        assert score.overall == 0.0
+
+    def test_full_coverage_clamped_to_one(self):
+        client = _mock_client({"met_indices": [1, 2]})
+        score = RubricCoverageVerifier(client=client).score(
+            self._rubric_task(), "blue scattering"
+        )
+        assert score.overall == 1.0
+
+    def test_out_of_range_indices_ignored(self):
+        client = _mock_client({"met_indices": [0, 2, 99]})
+        score = RubricCoverageVerifier(client=client).score(self._rubric_task(), "x")
+        assert score.overall == pytest.approx(1.0 / 4.0)
+
+    def test_malformed_judge_output_scores_zero(self):
+        response = MagicMock()
+        response.content = "not json"
+        client = MagicMock()
+        client.generate.return_value = response
+        score = RubricCoverageVerifier(client=client).score(self._rubric_task(), "x")
+        assert score.overall == 0.0
+
+    def test_task_without_rubric_items_rejected(self):
+        with pytest.raises(ValueError, match="rubric_items"):
+            RubricCoverageVerifier(client=MagicMock()).score(_task(), "x")
+
+    def test_criteria_reach_the_judge(self):
+        client = _mock_client({"met_indices": []})
+        RubricCoverageVerifier(client=client).score(self._rubric_task(), "x")
+        prompt = client.generate.call_args[0][0][0]["content"]
+        assert "mentions blue" in prompt
+        assert "mentions scattering" in prompt
+
+
+class TestAbstentionVerifier:
+    def test_correct_abstention(self):
+        client = _mock_client({"abstained": True})
+        score = AbstentionVerifier(client=client).score(
+            _task(abstention_expected=True), "I cannot answer that."
+        )
+        assert score.overall == 1.0
+        assert "abstained=True" in score.detail
+
+    def test_missed_abstention(self):
+        client = _mock_client({"abstained": False})
+        score = AbstentionVerifier(client=client).score(
+            _task(abstention_expected=True), "It is definitely 42."
+        )
+        assert score.overall == 0.0
+
+    def test_unwarranted_abstention(self):
+        client = _mock_client({"abstained": True})
+        score = AbstentionVerifier(client=client).score(
+            _task(abstention_expected=False), "I do not know."
+        )
+        assert score.overall == 0.0
+
+    def test_answering_when_expected(self):
+        client = _mock_client({"abstained": False})
+        score = AbstentionVerifier(client=client).score(
+            _task(abstention_expected=False), "The sky is blue."
+        )
+        assert score.overall == 1.0

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -15,6 +15,7 @@ from bicameral_agent.scorer import LexicalScorer, TaskScorer
 from bicameral_agent.verifiers import (
     AbstentionVerifier,
     ExactMatchVerifier,
+    LlmAutoraterVerifier,
     MultipleChoiceVerifier,
     RubricCoverageVerifier,
     Verifier,
@@ -52,6 +53,7 @@ class TestBuildVerifier:
             "abstention",
             "exact_match",
             "lexical",
+            "llm_autorater",
             "llm_judge",
             "multiple_choice",
             "rubric_coverage",
@@ -77,6 +79,7 @@ class TestBuildVerifier:
         sentinel = object()
         assert build_verifier("rubric_coverage", client=sentinel)._client is sentinel
         assert build_verifier("abstention", client=sentinel)._client is sentinel
+        assert build_verifier("llm_autorater", client=sentinel)._client is sentinel
 
     def test_unknown_metric_lists_known(self):
         with pytest.raises(ValueError, match="lexical"):
@@ -251,3 +254,51 @@ class TestAbstentionVerifier:
             _task(abstention_expected=False), "The sky is blue."
         )
         assert score.overall == 1.0
+
+
+class TestLlmAutoraterVerifier:
+    """SimpleQA official 3-way grading, against a mocked judge client."""
+
+    def test_correct_scores_one(self):
+        client = _mock_client({"grade": "A"})
+        score = LlmAutoraterVerifier(client=client).score(_task(), "It is blue.")
+        assert score.overall == 1.0
+        assert score.detail == "llm_autorater: correct"
+
+    def test_incorrect_scores_zero(self):
+        client = _mock_client({"grade": "B"})
+        score = LlmAutoraterVerifier(client=client).score(_task(), "It is green.")
+        assert score.overall == 0.0
+        assert score.detail == "llm_autorater: incorrect"
+
+    def test_not_attempted_scores_zero_but_distinguishable(self):
+        client = _mock_client({"grade": "C"})
+        score = LlmAutoraterVerifier(client=client).score(_task(), "I don't know.")
+        assert score.overall == 0.0  # comparable with quality_score across metrics
+        assert score.detail == "llm_autorater: not_attempted"
+
+    def test_bare_letter_fallback(self):
+        response = MagicMock()
+        response.content = "B"  # the letter the official template asks for
+        client = MagicMock()
+        client.generate.return_value = response
+        score = LlmAutoraterVerifier(client=client).score(_task(), "It is green.")
+        assert score.overall == 0.0
+        assert score.detail == "llm_autorater: incorrect"
+
+    def test_malformed_output_defaults_to_not_attempted(self):
+        response = MagicMock()
+        response.content = "no verdict here"
+        client = MagicMock()
+        client.generate.return_value = response
+        score = LlmAutoraterVerifier(client=client).score(_task(), "x")
+        assert score.overall == 0.0
+        assert score.detail == "llm_autorater: not_attempted"
+
+    def test_official_template_receives_fields(self):
+        client = _mock_client({"grade": "A"})
+        LlmAutoraterVerifier(client=client).score(_task(), "It is blue.")
+        prompt = client.generate.call_args[0][0][0]["content"]
+        assert "Gold target: The sky is blue." in prompt
+        assert "Predicted answer: It is blue." in prompt
+        assert '["CORRECT", "INCORRECT", "NOT_ATTEMPTED"]' in prompt


### PR DESCRIPTION
## Summary

Finishes issue #56 on top of the PR #69 skeleton: task-schema extensions, the deterministic + rubric/abstention verifiers, runner/report wiring (`EpisodeConfig.metric`, `EvalReport`), all seven remaining external dataset adapters, and the generalized `docs/eval_datasets.md`.

## Work performed

**Step 2 — task schema extensions** (`dataset.py`)
- Optional `choices`, `rubric_items` (`RubricItem(criterion, points)`), `abstention_expected` fields — all default `None`, so the packaged 130-task pool and existing caches validate unchanged.
- Validator: `gold_answer=""` is only valid when `rubric_items` is set (ResearchQA's rubric-native rows).

**Step 3 (rest) — verifiers** (`verifiers.py`, `scorer.py`)
- `TaskScore.detail: str | None` (additive) for the mode-specific report.
- `ExactMatchVerifier`: normalized (lowercase/punctuation/articles) or numeric equality, plus trailing "answer is X" extraction; binary 1.0/0.0.
- `MultipleChoiceVerifier`: letter extraction (stated answer > bare letter > unique choice-text match via `task.choices`) vs the gold letter.
- `RubricCoverageVerifier` (LLM): single judge call over numbered criteria; score = earned points / positive points, clamped — negative-point penalty items subtract (HealthBench-style).
- `AbstentionVerifier` (LLM): judged abstained-or-not compared to `abstention_expected`.

**Step 4 — runner + report wiring** (`episode_runner.py`, `ab_test.py`, `eval_report.py`, `scripts/run_baseline_benchmark.py`)
- `EpisodeConfig.metric: str = "llm_judge"` replaces `use_lexical_scorer` (all call sites migrated; `ABTestRunner` keeps its public boolean and maps it internally — the smaller honest change).
- `EpisodeRunner` scores through `build_verifier(cfg.metric, client=judge_client)` and writes `{metric, detail}` to `episode.metadata["verification"]` (parquet round-trip tested).
- New `EvalReport`/`TaskResult` models; the benchmark script's `summary.json` now comes from `EvalReport.to_json()`. The `conditions.*.summaries.<metric>.{mean,std,ci_lower,ci_upper,n}`, `n_episodes`, `tasks_per_condition`, `max_turns` keys are unchanged (checked against `ui/src/core/runs.ts` `HEADLINE_METRICS`); per-task `results` are additive.
- The `ensure_runnable_metric` guard is removed: with `build_verifier` wired into the runner, every registered metric is runnable, so the guard (and its tests) are obsolete.

**Steps 6–8 — adapter waves** (`eval_datasets/`)
- Wave 1: `simpleqa_verified` (typical, default `exact_match`), `supergpqa` (hard, `multiple_choice`; options embedded in the question text and kept in `choices`), `bbeh` (hard, `exact_match`; round-robin over the 23 GitHub subtask `task.json` files).
- Wave 2: `healthbench_hard` (hard, `rubric_coverage`; JSONL blob from openai/simple-evals, weighted rubrics incl. negative points, ideal completion as gold), `researchqa` (hard, `rubric_coverage`; `gold_answer=""` + unweighted rubric items at 1.0 each).
- Wave 3: `abstentionbench` (hard, `abstention`; CC-BY-NC — fetch-only, flagged in `DatasetMeta.license`), `hle` (hard, default `llm_judge`; gated, `requires_hf_token=True`, text-only rows).
- `hf_fetch`: `config=` parameter (SimpleQA Verified uses config `simpleqa_verified`/split `eval`), `HF_TOKEN` bearer auth sent to the datasets-server only, and `http_get_text` for raw JSONL/JSON downloads. `scripts/fetch_dataset.py` warns when a gated dataset is fetched without `HF_TOKEN`.

**Step 9 — docs**
- `docs/eval_datasets.md`: usage, dataset/license/citation matrix, verifier matrix, schema extensions, per-dataset caveats. `docs/hard_benchmark.md` reduced to a pointer stub.

**Adapter caveats / assumptions**
- Field mappings for simpleqa_verified, supergpqa, researchqa, healthbench_hard, and bbeh were verified against live upstream (3-task smoke fetches succeed end-to-end, including cache load round-trips).
- `abstentionbench`: upstream ships a `datasets` loading script the HF datasets-server cannot build, so a live fetch currently fails; the adapter targets the script's declared feature schema (`question`/`reference_answers`/`should_abstain`) and works as-is once upstream publishes servable data. Rows with no reference answer get an explicit abstain-statement gold so the non-empty-gold invariant holds.
- `hle`: gated, so the schema is best-effort from the public dataset card (`question`/`answer`/`image`); fetch requires accepting the terms + `HF_TOKEN`.
- The issue table's `llm_autorater` (official SimpleQA 3-way prompt) is not implemented; `simpleqa_verified` defaults to deterministic `exact_match` with `llm_judge` as the graded alternative.
- `EvalReport.to_text()` was skipped: the script still uses `baseline_benchmark.format_report` directly for `report.txt`, so the wrapper would have been dead code.

## Test plan

- `uv run --extra dev --extra torch pytest -q` — 1226 passed, 34 skipped.
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean.
- New offline tests: schema-extension validators; all six verifiers (deterministic ones with no LLM calls, LLM ones against mocked clients); per-adapter mapping tests with mocked pagers/downloads; HF_TOKEN header behavior; runner metric wiring + `verification` metadata; parquet round-trip of the verification payload; `EvalReport` UI-shape compatibility.
- Live smoke (not in CI): `scripts/fetch_dataset.py` for simpleqa_verified / supergpqa / bbeh / researchqa / healthbench_hard against real upstream, plus `build_dataset(...).load()` round-trips.

Closes #56