### PR TITLE
Partial: Transition model for MCTS environment simulation

### DIFF
--- a/scripts/train_transition_model.py
+++ b/scripts/train_transition_model.py
@@ -1,0 +1,163 @@
+"""Fit the MCTS transition model (issue #27) from parquet episode files.
+
+Loads episodes, converts them to (state, action, next_state, reward)
+tuples with :class:`~bicameral_agent.training_pipeline.TrainingDataPipeline`,
+trains :class:`~bicameral_agent.transition_model.TransitionModel` with a
+deterministic episode-level held-out split, and writes:
+
+- ``<out-dir>/transition_model.pt``  — model checkpoint
+- ``<out-dir>/metrics.json``         — config, data stats, loss curve,
+  held-out evaluation and per-AC pass/fail flags
+
+Usage (on the completed #46 baseline re-run)::
+
+    uv run --extra torch python scripts/train_transition_model.py \\
+        data/baseline_rerun/*.parquet --out-dir data/transition_model
+
+Exit code is 0 whenever the fit itself succeeds; acceptance-criteria
+outcomes are data-dependent and reported in ``metrics.json`` /  stdout
+rather than via the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+from bicameral_agent.serialization import episodes_from_parquet
+from bicameral_agent.training_pipeline import DEFAULT_MAX_TURNS, TrainingDataPipeline
+from bicameral_agent.transition_model import (
+    TransitionTrainingConfig,
+    fit_transition_model,
+)
+
+# Issue #27 acceptance-criteria thresholds.
+AC_STATE_MSE_MAX = 0.1
+AC_REWARD_CORR_MIN = 0.4
+AC_LATENCY_MS_MAX = 2.0
+AC_TRAIN_SECONDS_MAX = 30 * 60
+
+
+def acceptance_criteria(metrics: dict, train_seconds: float) -> dict[str, bool | None]:
+    """Per-AC pass/fail flags (*None* = not evaluable on this data)."""
+    rollout = metrics.get("rollout") or {}
+    corr = metrics.get("reward_correlation")
+    mse = metrics.get("state_mse_per_dim_mean")
+    return {
+        "state_mse_per_dim_mean_lt_0.1": None if mse is None else mse < AC_STATE_MSE_MAX,
+        "reward_correlation_gt_0.4": None if corr is None else corr > AC_REWARD_CORR_MIN,
+        "rollout_5_step_bounded": rollout.get("bounded"),
+        "forward_latency_lt_2ms": metrics["latency_ms_median"] < AC_LATENCY_MS_MAX,
+        "training_lt_30min_cpu": train_seconds < AC_TRAIN_SECONDS_MAX,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "episodes", nargs="+",
+        help="Parquet episode files (multi-episode format, e.g. data/baseline_rerun/*.parquet).",
+    )
+    parser.add_argument(
+        "--out-dir", default="data/transition_model",
+        help="Directory for transition_model.pt and metrics.json (default: %(default)s).",
+    )
+    parser.add_argument("--epochs", type=int, default=300)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--hidden-dim", type=int, default=128)
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--max-turns", type=int, default=DEFAULT_MAX_TURNS,
+        help="EpisodeConfig.max_turns used when the episodes were generated "
+        "(default: %(default)s).",
+    )
+    args = parser.parse_args(argv)
+
+    episodes = []
+    for path in args.episodes:
+        loaded = episodes_from_parquet(path)
+        print(f"loaded {len(loaded):3d} episodes from {path}")
+        episodes.extend(loaded)
+    if not episodes:
+        print("error: no episodes found in the given files", file=sys.stderr)
+        return 1
+
+    pipeline = TrainingDataPipeline(max_turns=args.max_turns)
+    examples = pipeline.process_episodes(episodes)
+    if not examples:
+        print("error: episodes produced no training examples", file=sys.stderr)
+        return 1
+    print(f"{len(episodes)} episodes -> {len(examples)} (state, action, next_state, reward) tuples")
+
+    config = TransitionTrainingConfig(
+        hidden_dim=args.hidden_dim,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.lr,
+        train_ratio=args.train_ratio,
+        seed=args.seed,
+    )
+    result = fit_transition_model(examples, config)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model_path = out_dir / "transition_model.pt"
+    result.model.save(model_path)
+
+    acs = acceptance_criteria(result.metrics, result.train_seconds)
+    payload = {
+        "config": dataclasses.asdict(config),
+        "data": {
+            "episode_files": list(args.episodes),
+            "n_episodes": len(episodes),
+            "n_examples": len(examples),
+            "n_train": result.n_train,
+            "n_val": result.n_val,
+        },
+        "train": {
+            "train_seconds": result.train_seconds,
+            "first_epoch_loss": result.epoch_losses[0],
+            "final_epoch_loss": result.epoch_losses[-1],
+            "loss_curve_total": [e["total"] for e in result.epoch_losses],
+        },
+        "eval": result.metrics,
+        "acceptance_criteria": acs,
+        "model_path": str(model_path),
+        "param_count": result.model.param_count,
+    }
+    metrics_path = out_dir / "metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    m = result.metrics
+    print(f"\nsaved {model_path} ({result.model.param_count} params) and {metrics_path}")
+    print(f"train: {result.n_train} examples, val: {result.n_val}, "
+          f"{config.epochs} epochs in {result.train_seconds:.1f}s")
+    print(f"train loss: {result.epoch_losses[0]['total']:.4f} -> "
+          f"{result.epoch_losses[-1]['total']:.4f}")
+    print(f"held-out state MSE (per-dim mean): {fmt(m['state_mse_per_dim_mean'])}  "
+          f"(max dim: {fmt(m['state_mse_per_dim_max'])})")
+    print(f"held-out reward MSE: {fmt(m['reward_mse'])}, "
+          f"correlation r: {fmt(m['reward_correlation'])}")
+    rollout = m.get("rollout") or {}
+    print(f"rollout ({rollout.get('steps')}-step) max state norm: "
+          f"{fmt(rollout.get('max_state_norm'))} (bound {fmt(rollout.get('norm_bound'))})")
+    print(f"forward latency (median): {m['latency_ms_median']:.3f} ms")
+    print("\nacceptance criteria:")
+    for name, ok in acs.items():
+        status = "PASS" if ok else ("FAIL" if ok is not None else "N/A ")
+        print(f"  [{status}] {name}")
+    return 0
+
+
+def fmt(v: float | None) -> str:
+    return "n/a" if v is None else f"{v:.4f}"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bicameral_agent/policy_value_net.py
+++ b/src/bicameral_agent/policy_value_net.py
@@ -13,13 +13,13 @@ Architecture
 
 from __future__ import annotations
 
-from pathlib import Path
 import numpy as np
 import torch
 import torch.nn as nn
 
 from bicameral_agent.encoder import FEATURE_DIM
 from bicameral_agent.heuristic_controller import Action
+from bicameral_agent.torch_checkpoint import TorchCheckpointMixin
 
 NUM_ACTIONS: int = 4
 """Number of discrete actions the policy head selects from."""
@@ -33,7 +33,7 @@ ACTION_ORDER: tuple[Action, ...] = (
 """Maps policy output index → Action enum value."""
 
 
-class PolicyValueNetwork(nn.Module):
+class PolicyValueNetwork(TorchCheckpointMixin, nn.Module):
     """Neural network that produces action probabilities and a value estimate.
 
     Parameters
@@ -163,25 +163,3 @@ class PolicyValueNetwork(nn.Module):
     def param_count(self) -> int:
         """Total number of trainable parameters."""
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
-
-    def save(self, path: str | Path) -> None:
-        """Save model checkpoint to *path*."""
-        torch.save(self.state_dict(), path)
-
-    @classmethod
-    def load(cls, path: str | Path, **kwargs: int) -> PolicyValueNetwork:
-        """Load a model checkpoint from *path*.
-
-        Parameters
-        ----------
-        path:
-            File path to a saved state dict.
-        **kwargs:
-            Constructor keyword arguments (``input_dim``, ``hidden_dim``,
-            ``num_actions``) to recreate the architecture before loading
-            weights.
-        """
-        model = cls(**kwargs)
-        model.load_state_dict(torch.load(path, weights_only=True))
-        model.eval()
-        return model

--- a/src/bicameral_agent/torch_checkpoint.py
+++ b/src/bicameral_agent/torch_checkpoint.py
@@ -1,0 +1,43 @@
+"""Shared state-dict checkpoint save/load for torch models.
+
+Extracted from the identical save/load pairs on
+:class:`~bicameral_agent.policy_value_net.PolicyValueNetwork` and
+:class:`~bicameral_agent.transition_model.TransitionModel`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Self
+
+import torch
+
+
+class TorchCheckpointMixin:
+    """State-dict ``save``/``load`` for ``nn.Module`` subclasses.
+
+    Mix in ahead of ``nn.Module``. ``load`` is a classmethod, so ``cls``
+    stays bound to the concrete subclass it is called on and returns an
+    instance of that subclass.
+    """
+
+    def save(self, path: str | Path) -> None:
+        """Save model checkpoint (state dict) to *path*."""
+        torch.save(self.state_dict(), path)
+
+    @classmethod
+    def load(cls, path: str | Path, **kwargs: int) -> Self:
+        """Load a model checkpoint from *path*.
+
+        Parameters
+        ----------
+        path:
+            File path to a saved state dict.
+        **kwargs:
+            Constructor keyword arguments to recreate the architecture
+            before loading weights (e.g. ``input_dim`` / ``hidden_dim``).
+        """
+        model = cls(**kwargs)
+        model.load_state_dict(torch.load(path, weights_only=True))
+        model.eval()
+        return model

--- a/src/bicameral_agent/transition_model.py
+++ b/src/bicameral_agent/transition_model.py
@@ -38,13 +38,13 @@ from __future__ import annotations
 
 import dataclasses
 import time
-from pathlib import Path
 
 import numpy as np
 import torch
 import torch.nn as nn
 
 from bicameral_agent.policy_value_net import NUM_ACTIONS
+from bicameral_agent.torch_checkpoint import TorchCheckpointMixin
 from bicameral_agent.training_pipeline import STATE_DIM, TrainingExample
 
 DEFAULT_HIDDEN_DIM: int = 128
@@ -57,7 +57,7 @@ components in ~[0, 1], hence norm <= sqrt(state_dim); the factor leaves
 generous headroom while still catching exponential divergence."""
 
 
-class TransitionModel(nn.Module):
+class TransitionModel(TorchCheckpointMixin, nn.Module):
     """MLP predicting ``(next_state, reward)`` from ``(state, action one-hot)``.
 
     Parameters
@@ -178,28 +178,6 @@ class TransitionModel(nn.Module):
     def param_count(self) -> int:
         """Total number of trainable parameters."""
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
-
-    def save(self, path: str | Path) -> None:
-        """Save model checkpoint to *path*."""
-        torch.save(self.state_dict(), path)
-
-    @classmethod
-    def load(cls, path: str | Path, **kwargs: int) -> TransitionModel:
-        """Load a model checkpoint from *path*.
-
-        Parameters
-        ----------
-        path:
-            File path to a saved state dict.
-        **kwargs:
-            Constructor keyword arguments (``state_dim``, ``num_actions``,
-            ``hidden_dim``) to recreate the architecture before loading
-            weights.
-        """
-        model = cls(**kwargs)
-        model.load_state_dict(torch.load(path, weights_only=True))
-        model.eval()
-        return model
 
 
 # ---------------------------------------------------------------------------

--- a/src/bicameral_agent/transition_model.py
+++ b/src/bicameral_agent/transition_model.py
@@ -1,0 +1,490 @@
+"""Learned transition model for MCTS environment simulation.
+
+Predicts ``(next_state, reward)`` from ``(state, action)`` so MCTS can
+simulate rollouts without running the real system (the MuZero-style
+environment model, issue #27).
+
+Architecture
+------------
+- Input: 108-dim state vector (:data:`~bicameral_agent.training_pipeline.STATE_DIM`)
+  concatenated with a 4-dim action one-hot (:data:`~bicameral_agent.policy_value_net.ACTION_ORDER`)
+- Trunk: 3 hidden layers x 128 units, ReLU activations
+- State head: Linear -> 108-dim predicted next state
+- Reward head: Linear -> scalar predicted reward
+
+Training data
+-------------
+The fit/eval helpers consume ``list[TrainingExample]`` — produced either
+by :class:`~bicameral_agent.training_pipeline.TrainingDataPipeline`
+(directly from parquet episode files) or by
+:meth:`~bicameral_agent.training_data_store.TrainingDataStore.load_examples`.
+The store's torch ``Dataset`` loaders are not used here: transition-model
+fits are small, one-shot reads (hundreds of examples), so materializing
+the examples is simpler than memory-mapped streaming and keeps a single
+code path for both data sources.
+
+Terminal decision points (``done=True``) carry a zero *placeholder*
+``next_state``, so the state head is trained and evaluated only on
+non-terminal transitions (masked loss). The reward head trains on all
+transitions, including terminal ones — terminal rewards carry the episode
+quality score, the main signal MCTS needs.
+
+States are already normalized to roughly [0, 1] per dimension by the
+pipeline's cap-based normalization, so "per-dimension normalized MSE" is
+computed directly on the raw vectors.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from bicameral_agent.policy_value_net import NUM_ACTIONS
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingExample
+
+DEFAULT_HIDDEN_DIM: int = 128
+"""Hidden-layer width per the issue #27 spec."""
+
+ROLLOUT_NORM_BOUND_FACTOR: float = 10.0
+"""Rollout states are "bounded" if their L2 norm stays below
+``ROLLOUT_NORM_BOUND_FACTOR * sqrt(state_dim)``. A well-formed state has
+components in ~[0, 1], hence norm <= sqrt(state_dim); the factor leaves
+generous headroom while still catching exponential divergence."""
+
+
+class TransitionModel(nn.Module):
+    """MLP predicting ``(next_state, reward)`` from ``(state, action one-hot)``.
+
+    Parameters
+    ----------
+    state_dim:
+        Dimensionality of the state vector (default: ``STATE_DIM``).
+    num_actions:
+        Number of discrete actions (default: ``NUM_ACTIONS``); the action
+        input is a one-hot of this width, indexed by
+        ``policy_value_net.ACTION_ORDER``.
+    hidden_dim:
+        Width of each of the 3 hidden layers (default: 128).
+    """
+
+    def __init__(
+        self,
+        state_dim: int = STATE_DIM,
+        num_actions: int = NUM_ACTIONS,
+        hidden_dim: int = DEFAULT_HIDDEN_DIM,
+    ) -> None:
+        super().__init__()
+        self.state_dim = state_dim
+        self.num_actions = num_actions
+        self.hidden_dim = hidden_dim
+
+        self.trunk = nn.Sequential(
+            nn.Linear(state_dim + num_actions, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+        )
+        self.state_head = nn.Linear(hidden_dim, state_dim)
+        self.reward_head = nn.Linear(hidden_dim, 1)
+
+    def forward(
+        self, states: torch.Tensor, action_onehots: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Predict next states and rewards for a batch.
+
+        Parameters
+        ----------
+        states:
+            Tensor of shape ``(batch, state_dim)``.
+        action_onehots:
+            Tensor of shape ``(batch, num_actions)``.
+
+        Returns
+        -------
+        tuple[Tensor, Tensor]
+            ``(next_states, rewards)`` with shapes ``(batch, state_dim)``
+            and ``(batch,)``.
+        """
+        features = self.trunk(torch.cat([states, action_onehots], dim=-1))
+        next_states = self.state_head(features)
+        rewards = self.reward_head(features).squeeze(-1)
+        return next_states, rewards
+
+    @torch.no_grad()
+    def predict(self, state: np.ndarray, action: int) -> tuple[np.ndarray, float]:
+        """Numpy-in, numpy-out inference for a single ``(state, action)``.
+
+        Parameters
+        ----------
+        state:
+            1-D array of shape ``(state_dim,)``. Any float dtype is
+            accepted; the input is cast to float32.
+        action:
+            Categorical action index in ``[0, num_actions)`` matching
+            ``policy_value_net.ACTION_ORDER``.
+
+        Returns
+        -------
+        tuple[ndarray, float]
+            ``(next_state, reward)`` where ``next_state`` is a float32
+            array of shape ``(state_dim,)`` and ``reward`` a Python float.
+        """
+        if not 0 <= action < self.num_actions:
+            msg = f"action must be in [0, {self.num_actions}), got {action}"
+            raise ValueError(msg)
+        x = torch.as_tensor(state, dtype=torch.float32).unsqueeze(0)
+        onehot = torch.zeros((1, self.num_actions), dtype=torch.float32)
+        onehot[0, action] = 1.0
+        next_state, reward = self.forward(x, onehot)
+        return next_state.squeeze(0).numpy(), reward.item()
+
+    @torch.no_grad()
+    def rollout(
+        self, state: np.ndarray, actions: list[int]
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Simulate a multi-step rollout by feeding predictions back in.
+
+        Parameters
+        ----------
+        state:
+            Initial state, shape ``(state_dim,)``.
+        actions:
+            Action index per step; the rollout length is ``len(actions)``.
+
+        Returns
+        -------
+        tuple[ndarray, ndarray]
+            ``(states, rewards)``: predicted states of shape
+            ``(len(actions), state_dim)`` (float32) and rewards of shape
+            ``(len(actions),)`` (float32).
+        """
+        states = np.zeros((len(actions), self.state_dim), dtype=np.float32)
+        rewards = np.zeros(len(actions), dtype=np.float32)
+        current = np.asarray(state, dtype=np.float32)
+        for i, action in enumerate(actions):
+            current, reward = self.predict(current, action)
+            states[i] = current
+            rewards[i] = reward
+        return states, rewards
+
+    @property
+    def param_count(self) -> int:
+        """Total number of trainable parameters."""
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+    def save(self, path: str | Path) -> None:
+        """Save model checkpoint to *path*."""
+        torch.save(self.state_dict(), path)
+
+    @classmethod
+    def load(cls, path: str | Path, **kwargs: int) -> TransitionModel:
+        """Load a model checkpoint from *path*.
+
+        Parameters
+        ----------
+        path:
+            File path to a saved state dict.
+        **kwargs:
+            Constructor keyword arguments (``state_dim``, ``num_actions``,
+            ``hidden_dim``) to recreate the architecture before loading
+            weights.
+        """
+        model = cls(**kwargs)
+        model.load_state_dict(torch.load(path, weights_only=True))
+        model.eval()
+        return model
+
+
+# ---------------------------------------------------------------------------
+# Training harness
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TransitionTrainingConfig:
+    """Hyperparameters for :func:`fit_transition_model`."""
+
+    hidden_dim: int = DEFAULT_HIDDEN_DIM
+    epochs: int = 300
+    batch_size: int = 64
+    learning_rate: float = 1e-3
+    reward_loss_weight: float = 1.0
+    train_ratio: float = 0.8
+    seed: int = 0
+    rollout_steps: int = 5
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TransitionFitResult:
+    """Output of :func:`fit_transition_model`.
+
+    ``epoch_losses`` holds one dict per epoch with keys ``total``,
+    ``state`` and ``reward`` (mean training loss over the epoch's
+    batches). ``metrics`` is the held-out evaluation from
+    :func:`evaluate_transition_model`.
+    """
+
+    model: TransitionModel
+    epoch_losses: list[dict[str, float]]
+    metrics: dict
+    n_train: int
+    n_val: int
+    train_seconds: float
+
+
+def split_examples(
+    examples: list[TrainingExample],
+    train_ratio: float = 0.8,
+    seed: int = 0,
+) -> tuple[list[TrainingExample], list[TrainingExample]]:
+    """Deterministic (train, val) split, grouped by episode.
+
+    Whole episodes go to one side or the other so temporally correlated
+    decision points from the same episode never straddle the split.
+    Episodes are assigned to train (in a seed-permuted order over sorted
+    episode ids) until at least ``train_ratio`` of the examples are
+    covered. With >= 2 episodes both sides are guaranteed non-empty.
+    """
+    if not 0.0 < train_ratio < 1.0:
+        msg = f"train_ratio must be in (0, 1), got {train_ratio}"
+        raise ValueError(msg)
+    episode_ids = sorted({e.episode_id for e in examples})
+    perm = np.random.default_rng(seed).permutation(len(episode_ids))
+    ordered = [episode_ids[i] for i in perm]
+
+    counts = {eid: 0 for eid in episode_ids}
+    for e in examples:
+        counts[e.episode_id] += 1
+    total = len(examples)
+
+    train_ids: set[str] = set()
+    covered = 0
+    for eid in ordered:
+        if covered >= train_ratio * total and len(train_ids) < len(episode_ids):
+            break
+        # Never put every episode in train when a val side is possible.
+        if len(train_ids) == len(episode_ids) - 1:
+            break
+        train_ids.add(eid)
+        covered += counts[eid]
+
+    train = [e for e in examples if e.episode_id in train_ids]
+    val = [e for e in examples if e.episode_id not in train_ids]
+    return train, val
+
+
+def _to_tensors(
+    examples: list[TrainingExample], num_actions: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Stack examples into ``(states, action_onehots, next_states, rewards, dones)``."""
+    states = torch.from_numpy(np.stack([e.state for e in examples])).float()
+    next_states = torch.from_numpy(np.stack([e.next_state for e in examples])).float()
+    actions = torch.tensor([e.action for e in examples], dtype=torch.long)
+    onehots = torch.nn.functional.one_hot(actions, num_classes=num_actions).float()
+    rewards = torch.tensor([e.reward for e in examples], dtype=torch.float32)
+    dones = torch.tensor([e.done for e in examples], dtype=torch.bool)
+    return states, onehots, next_states, rewards, dones
+
+
+def _masked_losses(
+    model: TransitionModel,
+    states: torch.Tensor,
+    onehots: torch.Tensor,
+    next_states: torch.Tensor,
+    rewards: torch.Tensor,
+    dones: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """(state_loss, reward_loss) with terminal rows excluded from state loss."""
+    pred_next, pred_reward = model(states, onehots)
+    non_terminal = ~dones
+    if bool(non_terminal.any()):
+        state_loss = torch.mean((pred_next[non_terminal] - next_states[non_terminal]) ** 2)
+    else:
+        state_loss = torch.zeros((), dtype=torch.float32)
+    reward_loss = torch.mean((pred_reward - rewards) ** 2)
+    return state_loss, reward_loss
+
+
+def fit_transition_model(
+    examples: list[TrainingExample],
+    config: TransitionTrainingConfig | None = None,
+) -> TransitionFitResult:
+    """Train a :class:`TransitionModel` on training examples.
+
+    Deterministic for a fixed ``config.seed`` and example list: weight
+    initialization, the episode-level split and batch shuffling are all
+    seeded. MSE losses for both heads (state loss masked on terminal
+    rows, see module docstring).
+
+    Raises
+    ------
+    ValueError
+        If ``examples`` is empty.
+    """
+    config = config or TransitionTrainingConfig()
+    if not examples:
+        msg = "cannot fit a transition model on an empty example list"
+        raise ValueError(msg)
+
+    torch.manual_seed(config.seed)
+    model = TransitionModel(hidden_dim=config.hidden_dim)
+
+    train, val = split_examples(examples, config.train_ratio, config.seed)
+    tensors = _to_tensors(train, model.num_actions)
+    states, onehots, next_states, rewards, dones = tensors
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    rng = np.random.default_rng(config.seed)
+    n = len(train)
+
+    start = time.perf_counter()
+    epoch_losses: list[dict[str, float]] = []
+    for _ in range(config.epochs):
+        perm = rng.permutation(n)
+        sums = {"total": 0.0, "state": 0.0, "reward": 0.0}
+        n_batches = 0
+        for lo in range(0, n, config.batch_size):
+            idx = torch.from_numpy(perm[lo : lo + config.batch_size])
+            state_loss, reward_loss = _masked_losses(
+                model,
+                states[idx],
+                onehots[idx],
+                next_states[idx],
+                rewards[idx],
+                dones[idx],
+            )
+            loss = state_loss + config.reward_loss_weight * reward_loss
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            sums["total"] += loss.item()
+            sums["state"] += state_loss.item()
+            sums["reward"] += reward_loss.item()
+            n_batches += 1
+        epoch_losses.append({k: v / n_batches for k, v in sums.items()})
+    train_seconds = time.perf_counter() - start
+
+    model.eval()
+    metrics = evaluate_transition_model(model, val, rollout_steps=config.rollout_steps)
+    return TransitionFitResult(
+        model=model,
+        epoch_losses=epoch_losses,
+        metrics=metrics,
+        n_train=len(train),
+        n_val=len(val),
+        train_seconds=train_seconds,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def measure_forward_latency(
+    model: TransitionModel,
+    n_warmup: int = 10,
+    n_iters: int = 100,
+    seed: int = 0,
+) -> float:
+    """Median single-state ``predict`` latency in milliseconds."""
+    rng = np.random.default_rng(seed)
+    state = rng.random(model.state_dim).astype(np.float32)
+    for _ in range(n_warmup):
+        model.predict(state, 0)
+    times = []
+    for i in range(n_iters):
+        start = time.perf_counter()
+        model.predict(state, i % model.num_actions)
+        times.append(time.perf_counter() - start)
+    return float(sorted(times)[len(times) // 2] * 1000)
+
+
+@torch.no_grad()
+def evaluate_transition_model(
+    model: TransitionModel,
+    examples: list[TrainingExample],
+    rollout_steps: int = 5,
+    max_rollout_starts: int = 32,
+) -> dict:
+    """Evaluate a transition model on held-out examples.
+
+    Returns a JSON-serializable dict with:
+
+    - ``state_mse_per_dim``: per-dimension MSE over non-terminal
+      transitions (states are pipeline-normalized, so these are the
+      "normalized" MSEs from the issue AC), plus ``state_mse_per_dim_mean``
+      and ``state_mse_per_dim_max``.
+    - ``reward_mse`` and ``reward_correlation`` (Pearson r over all
+      transitions; *None* when undefined, e.g. constant rewards or a
+      single example).
+    - ``rollout``: ``rollout_steps``-step feedback rollouts from held-out
+      states — ``max_state_norm``, the boundedness threshold and a
+      ``bounded`` flag.
+    - ``latency_ms_median``: single-state forward latency.
+    """
+    was_training = model.training
+    model.eval()
+
+    out: dict = {
+        "n_examples": len(examples),
+        "n_state_examples": 0,
+        "state_mse_per_dim": None,
+        "state_mse_per_dim_mean": None,
+        "state_mse_per_dim_max": None,
+        "reward_mse": None,
+        "reward_correlation": None,
+        "rollout": None,
+        "latency_ms_median": measure_forward_latency(model),
+    }
+
+    if examples:
+        states, onehots, next_states, rewards, dones = _to_tensors(
+            examples, model.num_actions
+        )
+        pred_next, pred_reward = model(states, onehots)
+
+        non_terminal = ~dones
+        out["n_state_examples"] = int(non_terminal.sum())
+        if out["n_state_examples"] > 0:
+            sq_err = (pred_next[non_terminal] - next_states[non_terminal]) ** 2
+            per_dim = sq_err.mean(dim=0).numpy()
+            out["state_mse_per_dim"] = [float(v) for v in per_dim]
+            out["state_mse_per_dim_mean"] = float(per_dim.mean())
+            out["state_mse_per_dim_max"] = float(per_dim.max())
+
+        out["reward_mse"] = float(torch.mean((pred_reward - rewards) ** 2))
+        actual = rewards.numpy()
+        predicted = pred_reward.numpy()
+        if len(actual) >= 2 and actual.std() > 0 and predicted.std() > 0:
+            out["reward_correlation"] = float(np.corrcoef(actual, predicted)[0, 1])
+
+        # Multi-step rollout divergence: feed predictions back in for
+        # rollout_steps, cycling through the action space, from a sample
+        # of held-out states.
+        bound = ROLLOUT_NORM_BOUND_FACTOR * float(np.sqrt(model.state_dim))
+        start_states = states[non_terminal] if out["n_state_examples"] else states
+        n_starts = min(max_rollout_starts, len(start_states))
+        max_norm = 0.0
+        for i in range(n_starts):
+            actions = [(i + step) % model.num_actions for step in range(rollout_steps)]
+            rollout_states, _ = model.rollout(start_states[i].numpy(), actions)
+            max_norm = max(max_norm, float(np.linalg.norm(rollout_states, axis=1).max()))
+        out["rollout"] = {
+            "steps": rollout_steps,
+            "n_starts": n_starts,
+            "max_state_norm": max_norm,
+            "norm_bound": bound,
+            "bounded": bool(n_starts > 0 and max_norm <= bound),
+        }
+
+    if was_training:
+        model.train()
+    return out

--- a/tests/test_transition_model.py
+++ b/tests/test_transition_model.py
@@ -1,0 +1,387 @@
+"""Tests for the MCTS transition model (issue #27).
+
+The whole module requires torch (``bicameral_agent.transition_model``
+imports it at module level, matching policy_value_net), so it is skipped
+wholesale when torch is unavailable — the module-level equivalent of
+test_training_pipeline.py's per-test ``pytest.importorskip`` pattern.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.heuristic_controller import TOOL_IDS
+from bicameral_agent.policy_value_net import NUM_ACTIONS
+from bicameral_agent.schema import Episode, EpisodeOutcome, Message, ToolInvocation
+from bicameral_agent.serialization import episodes_to_parquet
+from bicameral_agent.training_pipeline import (
+    STATE_DIM,
+    TrainingDataPipeline,
+    TrainingExample,
+)
+from bicameral_agent.transition_model import (
+    TransitionModel,
+    TransitionTrainingConfig,
+    evaluate_transition_model,
+    fit_transition_model,
+    measure_forward_latency,
+    split_examples,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PARTIAL_DATA_DIR = Path(
+    "/Users/eli/Documents/Code/bicameral-agent/data/baseline_rerun_partial1"
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data builders
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_examples(
+    n: int = 200,
+    n_episodes: int = 10,
+    seed: int = 0,
+) -> list[TrainingExample]:
+    """Learnable synthetic transitions with contractive linear dynamics.
+
+    ``next_state = 0.5 * state + action-dependent offset`` (clipped to
+    [0, 1]) and ``reward = mean(state) - 0.1 * action`` — deterministic
+    functions a small MLP can fit, so training loss must decrease and
+    rollouts of the fitted model stay bounded.
+    """
+    rng = np.random.default_rng(seed)
+    offsets = rng.random((NUM_ACTIONS, STATE_DIM)).astype(np.float32) * 0.3
+    examples: list[TrainingExample] = []
+    per_ep = n // n_episodes
+    for i in range(n):
+        state = rng.random(STATE_DIM).astype(np.float32)
+        action = int(rng.integers(NUM_ACTIONS))
+        next_state = np.clip(0.5 * state + offsets[action], 0.0, 1.0).astype(np.float32)
+        reward = float(state.mean() - 0.1 * action)
+        done = (i % per_ep) == per_ep - 1
+        examples.append(
+            TrainingExample(
+                state=state,
+                action=action,
+                reward=reward,
+                next_state=next_state if not done else np.zeros(STATE_DIM, dtype=np.float32),
+                done=done,
+                discounted_return=reward,
+                episode_id=f"ep-{i // per_ep}",
+                decision_index=i % per_ep,
+            )
+        )
+    return examples
+
+
+def _synthetic_episode(num_turns: int, quality: float, base_ts: int) -> Episode:
+    """Minimal valid Episode with ``num_turns`` user/assistant pairs."""
+    messages: list[Message] = []
+    tools: list[ToolInvocation] = []
+    tool_ids = list(TOOL_IDS.values())
+    for turn in range(1, num_turns + 1):
+        user_ts = base_ts + (turn - 1) * 1000
+        messages.append(
+            Message(role="user", content=f"user {turn}", timestamp_ms=user_ts, token_count=10)
+        )
+        if turn % 2 == 0:  # alternate tool use so actions vary
+            tools.append(
+                ToolInvocation(
+                    tool_id=tool_ids[turn % len(tool_ids)],
+                    invoked_at_ms=user_ts + 100,
+                    completed_at_ms=user_ts + 300,
+                    input_tokens=20,
+                    output_tokens=30,
+                    result_deposited=False,
+                )
+            )
+        messages.append(
+            Message(
+                role="assistant",
+                content=f"assistant {turn}",
+                timestamp_ms=user_ts + 500,
+                token_count=20,
+            )
+        )
+    return Episode(
+        messages=messages,
+        tool_invocations=tools,
+        outcome=EpisodeOutcome(
+            quality_score=quality,
+            total_tokens=sum(m.token_count for m in messages),
+            total_turns=num_turns,
+            wall_clock_ms=num_turns * 1000,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape / dtype contracts
+# ---------------------------------------------------------------------------
+
+
+class TestShapes:
+    def test_forward_batch_shapes_and_dtypes(self) -> None:
+        model = TransitionModel()
+        states = torch.rand(7, STATE_DIM)
+        onehots = torch.nn.functional.one_hot(
+            torch.arange(7) % NUM_ACTIONS, NUM_ACTIONS
+        ).float()
+        next_states, rewards = model(states, onehots)
+        assert next_states.shape == (7, STATE_DIM)
+        assert rewards.shape == (7,)
+        assert next_states.dtype == torch.float32
+        assert rewards.dtype == torch.float32
+
+    def test_predict_numpy_contract(self) -> None:
+        model = TransitionModel()
+        # float64 input must be accepted and cast
+        state = np.random.default_rng(0).random(STATE_DIM)
+        next_state, reward = model.predict(state, 2)
+        assert isinstance(next_state, np.ndarray)
+        assert next_state.shape == (STATE_DIM,)
+        assert next_state.dtype == np.float32
+        assert isinstance(reward, float)
+
+    def test_predict_rejects_bad_action(self) -> None:
+        model = TransitionModel()
+        state = np.zeros(STATE_DIM, dtype=np.float32)
+        with pytest.raises(ValueError, match="action"):
+            model.predict(state, NUM_ACTIONS)
+        with pytest.raises(ValueError, match="action"):
+            model.predict(state, -1)
+
+    def test_rollout_shapes(self) -> None:
+        model = TransitionModel()
+        state = np.random.default_rng(1).random(STATE_DIM).astype(np.float32)
+        states, rewards = model.rollout(state, [0, 1, 2, 3, 0])
+        assert states.shape == (5, STATE_DIM)
+        assert rewards.shape == (5,)
+        assert states.dtype == np.float32
+
+    def test_architecture_spec(self) -> None:
+        """3 hidden layers x 128 units, ReLU (issue #27)."""
+        model = TransitionModel()
+        linears = [m for m in model.trunk if isinstance(m, torch.nn.Linear)]
+        relus = [m for m in model.trunk if isinstance(m, torch.nn.ReLU)]
+        assert len(linears) == 3
+        assert len(relus) == 3
+        assert all(m.out_features == 128 for m in linears)
+        assert linears[0].in_features == STATE_DIM + NUM_ACTIONS
+        assert model.state_head.out_features == STATE_DIM
+        assert model.reward_head.out_features == 1
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_seeded_init_is_deterministic(self) -> None:
+        torch.manual_seed(123)
+        m1 = TransitionModel()
+        torch.manual_seed(123)
+        m2 = TransitionModel()
+        for p1, p2 in zip(m1.parameters(), m2.parameters(), strict=True):
+            assert torch.equal(p1, p2)
+
+    def test_fit_is_deterministic_for_fixed_seed(self) -> None:
+        examples = _synthetic_examples(n=80)
+        config = TransitionTrainingConfig(epochs=5, seed=42)
+        r1 = fit_transition_model(examples, config)
+        r2 = fit_transition_model(examples, config)
+        assert r1.epoch_losses == r2.epoch_losses
+        for p1, p2 in zip(r1.model.parameters(), r2.model.parameters(), strict=True):
+            assert torch.equal(p1, p2)
+
+    def test_split_is_deterministic_and_episode_grouped(self) -> None:
+        examples = _synthetic_examples(n=100, n_episodes=10)
+        t1, v1 = split_examples(examples, train_ratio=0.8, seed=7)
+        t2, v2 = split_examples(examples, train_ratio=0.8, seed=7)
+        assert [e.episode_id for e in t1] == [e.episode_id for e in t2]
+        assert len(t1) + len(v1) == len(examples)
+        assert len(t1) > 0 and len(v1) > 0
+        assert {e.episode_id for e in t1}.isdisjoint({e.episode_id for e in v1})
+
+
+# ---------------------------------------------------------------------------
+# Training behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTraining:
+    def test_loss_decreases_on_synthetic_data(self) -> None:
+        examples = _synthetic_examples(n=200)
+        config = TransitionTrainingConfig(epochs=50, seed=0)
+        result = fit_transition_model(examples, config)
+        first = result.epoch_losses[0]["total"]
+        last = result.epoch_losses[-1]["total"]
+        assert last < first * 0.5, f"loss did not decrease: {first:.4f} -> {last:.4f}"
+
+    def test_fit_rejects_empty_examples(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            fit_transition_model([])
+
+    def test_rollout_stays_bounded_after_fitting(self) -> None:
+        examples = _synthetic_examples(n=200)
+        result = fit_transition_model(examples, TransitionTrainingConfig(epochs=50, seed=0))
+        rollout = result.metrics["rollout"]
+        assert rollout["steps"] == 5
+        assert rollout["bounded"] is True
+        assert rollout["max_state_norm"] <= rollout["norm_bound"]
+
+    def test_save_load_roundtrip(self, tmp_path: Path) -> None:
+        examples = _synthetic_examples(n=80)
+        result = fit_transition_model(examples, TransitionTrainingConfig(epochs=3))
+        path = tmp_path / "model.pt"
+        result.model.save(path)
+        loaded = TransitionModel.load(path)
+        state = np.random.default_rng(5).random(STATE_DIM).astype(np.float32)
+        expected_next, expected_reward = result.model.predict(state, 1)
+        got_next, got_reward = loaded.predict(state, 1)
+        np.testing.assert_array_equal(expected_next, got_next)
+        assert expected_reward == got_reward
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluation:
+    def test_metrics_structure(self) -> None:
+        examples = _synthetic_examples(n=100)
+        model = TransitionModel()
+        metrics = evaluate_transition_model(model, examples)
+        assert metrics["n_examples"] == 100
+        assert metrics["n_state_examples"] == 90  # 10 terminal steps excluded
+        assert len(metrics["state_mse_per_dim"]) == STATE_DIM
+        assert metrics["state_mse_per_dim_mean"] >= 0.0
+        assert metrics["state_mse_per_dim_max"] >= metrics["state_mse_per_dim_mean"]
+        assert metrics["reward_mse"] >= 0.0
+        assert -1.0 <= metrics["reward_correlation"] <= 1.0
+        assert metrics["latency_ms_median"] > 0.0
+        # JSON-serializable end to end
+        json.dumps(metrics)
+
+    def test_constant_rewards_give_null_correlation(self) -> None:
+        examples = [
+            TrainingExample(
+                state=np.random.default_rng(i).random(STATE_DIM).astype(np.float32),
+                action=i % NUM_ACTIONS,
+                reward=0.5,
+                next_state=np.zeros(STATE_DIM, dtype=np.float32),
+                done=False,
+                discounted_return=0.5,
+                episode_id=f"ep-{i}",
+                decision_index=0,
+            )
+            for i in range(10)
+        ]
+        metrics = evaluate_transition_model(TransitionModel(), examples)
+        assert metrics["reward_correlation"] is None
+
+    def test_empty_examples_yield_null_metrics(self) -> None:
+        metrics = evaluate_transition_model(TransitionModel(), [])
+        assert metrics["n_examples"] == 0
+        assert metrics["state_mse_per_dim_mean"] is None
+        assert metrics["rollout"] is None
+
+    def test_forward_latency_under_2ms(self) -> None:
+        model = TransitionModel()
+        median_ms = measure_forward_latency(model)
+        assert median_ms < 2.0, f"forward pass median={median_ms:.3f}ms > 2ms"
+
+
+# ---------------------------------------------------------------------------
+# Integration: full harness from parquet episode files
+# ---------------------------------------------------------------------------
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "train_transition_model", _REPO_ROOT / "scripts" / "train_transition_model.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestIntegration:
+    def test_cli_end_to_end_on_synthetic_episodes(self, tmp_path: Path) -> None:
+        episodes = [
+            _synthetic_episode(num_turns=6, quality=0.2 + 0.1 * i, base_ts=1_000_000 + i * 60_000)
+            for i in range(5)
+        ]
+        parquet_path = tmp_path / "episodes.parquet"
+        episodes_to_parquet(episodes, str(parquet_path))
+
+        out_dir = tmp_path / "out"
+        cli = _load_cli()
+        rc = cli.main(
+            [str(parquet_path), "--out-dir", str(out_dir), "--epochs", "10", "--seed", "0"]
+        )
+        assert rc == 0
+
+        model_path = out_dir / "transition_model.pt"
+        metrics_path = out_dir / "metrics.json"
+        assert model_path.exists()
+        with metrics_path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        assert payload["data"]["n_episodes"] == 5
+        assert payload["data"]["n_train"] + payload["data"]["n_val"] == 30
+        assert set(payload["acceptance_criteria"]) == {
+            "state_mse_per_dim_mean_lt_0.1",
+            "reward_correlation_gt_0.4",
+            "rollout_5_step_bounded",
+            "forward_latency_lt_2ms",
+            "training_lt_30min_cpu",
+        }
+        # The mechanics-level ACs must hold even on tiny synthetic data.
+        assert payload["acceptance_criteria"]["forward_latency_lt_2ms"] is True
+        assert payload["acceptance_criteria"]["training_lt_30min_cpu"] is True
+
+        # Saved checkpoint loads and predicts.
+        loaded = TransitionModel.load(model_path)
+        next_state, reward = loaded.predict(np.zeros(STATE_DIM, dtype=np.float32), 0)
+        assert np.isfinite(next_state).all()
+        assert np.isfinite(reward)
+
+    @pytest.mark.skipif(
+        not (
+            _PARTIAL_DATA_DIR.exists()
+            and any(_PARTIAL_DATA_DIR.glob("*.parquet"))
+        ),
+        reason="partial baseline re-run data not present on this machine",
+    )
+    def test_smoke_fit_on_partial_baseline_rerun(self) -> None:
+        """Skippable smoke test: the harness fits on real pilot episodes."""
+        from bicameral_agent.serialization import episodes_from_parquet
+
+        episodes = []
+        for path in sorted(_PARTIAL_DATA_DIR.glob("*.parquet")):
+            episodes.extend(episodes_from_parquet(str(path)))
+        assert episodes, "parquet files present but contained no episodes"
+
+        examples = TrainingDataPipeline().process_episodes(episodes)
+        assert examples
+
+        result = fit_transition_model(examples, TransitionTrainingConfig(epochs=20, seed=0))
+        assert np.isfinite(result.epoch_losses[-1]["total"])
+        assert result.epoch_losses[-1]["total"] < result.epoch_losses[0]["total"]
+        metrics = result.metrics
+        assert metrics["n_examples"] > 0
+        assert np.isfinite(metrics["state_mse_per_dim_mean"])
+        json.dumps(metrics)

--- a/tests/test_transition_model.py
+++ b/tests/test_transition_model.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 
 import numpy as np
@@ -37,9 +38,14 @@ from bicameral_agent.transition_model import (
     split_examples,
 )
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+# Real pilot-episode directory for the smoke test: repo-relative by
+# default, overridable via BICAMERAL_BASELINE_DATA.
 _PARTIAL_DATA_DIR = Path(
-    "/Users/eli/Documents/Code/bicameral-agent/data/baseline_rerun_partial1"
+    os.environ.get(
+        "BICAMERAL_BASELINE_DATA",
+        _REPO_ROOT / "data" / "baseline_rerun_partial1",
+    )
 )
 
 


### PR DESCRIPTION
## Summary
Implements the learned environment model from #27: `TransitionModel` predicts `(next_state, reward)` from `(state, action one-hot)` so MCTS can simulate rollouts without running the real system. Includes a deterministic training/eval harness and a one-command CLI so the fit can be re-run on the completed #46 pilot data. **Partial** because #27's definitive acceptance-criteria verification depends on the #46 baseline re-run, which is still executing; all mechanics are implemented and verified on synthetic data plus the 11 valid episodes from the interrupted partial run.

## Work performed
- `src/bicameral_agent/transition_model.py`
  - `TransitionModel(nn.Module)`: input `STATE_DIM (108) + 4` action one-hot, trunk of 3 hidden layers x 128 units with ReLU, state head (108) + reward head (scalar), ~61K params. Numpy-in/numpy-out `predict`, multi-step `rollout`, `save`/`load` — following `policy_value_net.py` conventions (float32 casting, torch import at module level).
  - Training harness `fit_transition_model`: consumes `list[TrainingExample]` from `TrainingDataPipeline` (also compatible with `TrainingDataStore.load_examples()`; the store's mmap Dataset loaders are deliberately not used — transition fits are small one-shot reads, documented in the module docstring). MSE losses for both heads; terminal decision points are masked out of the state loss (their `next_state` is a zeros placeholder) while the reward head trains on all rows since terminal rewards carry the quality score. Fully deterministic for a fixed seed (init, split, batch shuffling).
  - Deterministic **episode-grouped** held-out split (`split_examples`) so temporally correlated decision points never straddle train/val.
  - `evaluate_transition_model`: per-dimension normalized next-state MSE, reward Pearson correlation (null-safe on constant rewards), 5-step feedback-rollout divergence check against a norm bound of `10*sqrt(state_dim)`, and median forward-pass latency.
- `scripts/train_transition_model.py`: end-to-end CLI — parquet episode files in, `transition_model.pt` + `metrics.json` (config, data stats, loss curve, eval metrics, per-AC pass/fail flags) out.
- `tests/test_transition_model.py`: 18 tests — shape/dtype contracts, architecture spec, seeded determinism (init, fit, split), training-loss-decreases on synthetic dynamics, rollout boundedness after fitting, save/load round-trip, evaluation metric structure/null-safety, latency, CLI integration on synthetic parquet episodes, and a skippable smoke fit on `data/baseline_rerun_partial1` (skips when absent, e.g. in CI).

## Test plan
- `uv run --extra dev --extra torch pytest -q` — 1268 passed, 34 skipped.
- `uv run --extra dev --extra torch ruff check src/ tests/ scripts/` — clean.
- CLI dry run on the 11 partial-run episodes (66 tuples): train loss 0.270 -> 0.043; held-out per-dim state MSE mean 0.0004; reward correlation r = 0.61; 5-step rollout max norm 4.2 (bound 103.9); forward latency 0.030 ms median; training 0.1 s.

Per-AC status (thresholds re-verified on the completed #46 data before closing #27):
- [ ] **Pending #46**: held-out next-state MSE < 0.1 per dim, normalized — *passes on partial data (0.0004), needs the full pilot run*
- [ ] **Pending #46**: reward correlation r > 0.4 — *passes on partial data (0.61), needs the full pilot run*
- [ ] **Pending #46**: 5-step rollouts bounded on real data — *passes on partial data; mechanics also verified on synthetic fits*
- [x] Forward pass latency < 2 ms (0.030 ms median; asserted in tests)
- [x] Training completes in < 30 min on CPU (seconds at pilot scale; recorded in metrics.json)
- [x] Model can be saved and loaded (round-trip tested)

Re-run on the finished pilot data with:

```
uv run --extra torch python scripts/train_transition_model.py data/baseline_rerun/*.parquet --out-dir data/transition_model
```

Note: #27 also lists #51 (state/pipeline leakage fixes) as a blocker; if #51 changes the state layout or reward shaping, re-running the command above refits against the updated pipeline with no code changes here.

Refs #27