### PR TITLE
Add PUCT MCTS engine over learned policy/value and transition models

### DIFF
--- a/src/bicameral_agent/mcts.py
+++ b/src/bicameral_agent/mcts.py
@@ -1,0 +1,309 @@
+"""Monte Carlo Tree Search over learned models (issue #28).
+
+Plans entirely inside the learned environment: the policy/value network
+(issue #25, :class:`~bicameral_agent.policy_value_net.PolicyValueNetwork`)
+provides action priors and leaf value estimates, and the transition model
+(issue #27, :class:`~bicameral_agent.transition_model.TransitionModel`)
+simulates ``(next_state, reward)`` for expansions — no real episodes are
+run during search.
+
+Algorithm
+---------
+Each simulation performs the four classic phases:
+
+- **Selection**: descend from the root by PUCT —
+  ``argmax_a Q(s, a) + c_puct * P(a) * sqrt(N(s)) / (1 + N(s, a))`` —
+  until an unexpanded child is reached. ``Q(s, a)`` is the immediate
+  predicted reward plus the discounted mean value of the child's subtree.
+- **Expansion**: the transition model predicts ``(next_state, reward)``
+  for the selected edge and the policy head supplies the new node's
+  child priors.
+- **Evaluation**: the value head estimates the new leaf's value; no
+  rollouts are performed.
+- **Backup**: the discounted leaf return is *averaged* into every node on
+  the path (``Q = W / N`` — mean value backup, not minimax). This domain
+  is single-agent control (choosing which subconscious tool to fire),
+  not an adversarial game: there is no opponent whose best response
+  should be propagated with a min step, so the expected return under
+  continued search is the correct target.
+
+Exploration noise
+-----------------
+For training-time self-play, Dirichlet noise can be mixed into the root
+priors (``P' = (1 - eps) * P + eps * Dir(alpha)``) so search occasionally
+explores actions the prior underweights; for evaluation the noise is
+toggled off via ``search(..., add_root_noise=False)`` (the default).
+
+Determinism
+-----------
+The models are used in inference mode only, and their forward passes are
+deterministic — no torch RNG is consumed anywhere in the search. The only
+stochastic step is the root Dirichlet noise, drawn from a private numpy
+generator seeded by the ``seed`` constructor argument, so a fixed seed
+(or noise disabled) yields bit-identical search results for the same
+root state.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import Protocol
+
+import numpy as np
+
+from bicameral_agent.training_pipeline import DISCOUNT_GAMMA
+
+DEFAULT_C_PUCT: float = 1.5
+"""PUCT exploration constant per the issue #28 spec."""
+
+DEFAULT_DIRICHLET_ALPHA: float = 0.3
+"""Concentration of the root Dirichlet noise (AlphaZero-style default)."""
+
+DEFAULT_DIRICHLET_EPSILON: float = 0.25
+"""Fraction of the root prior replaced by Dirichlet noise when enabled."""
+
+
+class SupportsPolicyValue(Protocol):
+    """Anything with a ``PolicyValueNetwork``-shaped ``predict``."""
+
+    num_actions: int
+
+    def predict(self, state: np.ndarray) -> tuple[np.ndarray, float]:
+        """Return ``(action_probs, value)`` for a single state."""
+        ...
+
+
+class SupportsTransition(Protocol):
+    """Anything with a ``TransitionModel``-shaped ``predict``."""
+
+    num_actions: int
+
+    def predict(self, state: np.ndarray, action: int) -> tuple[np.ndarray, float]:
+        """Return ``(next_state, reward)`` for a single ``(state, action)``."""
+        ...
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MCTSResult:
+    """Output of :meth:`MCTSEngine.search`.
+
+    Attributes
+    ----------
+    action_distribution:
+        Root visit counts normalized to a probability distribution,
+        shape ``(num_actions,)``, float32, sums to 1. Indexed by
+        :data:`~bicameral_agent.policy_value_net.ACTION_ORDER`.
+    root_value:
+        Mean backed-up value at the root (includes the value head's
+        initial estimate of the root state as one sample).
+    visit_counts:
+        Raw root visit counts, shape ``(num_actions,)``, int64; sums to
+        ``num_simulations``.
+    """
+
+    action_distribution: np.ndarray
+    root_value: float
+    visit_counts: np.ndarray
+
+
+class _Node:
+    """One tree node: statistics for the state reached via its edge."""
+
+    __slots__ = ("prior", "state", "reward", "visit_count", "value_sum", "children")
+
+    def __init__(self, prior: float) -> None:
+        self.prior = prior
+        self.state: np.ndarray | None = None  # None until expanded
+        self.reward = 0.0  # predicted reward on the edge into this node
+        self.visit_count = 0
+        self.value_sum = 0.0  # sum of backed-up returns from this state on
+        self.children: list[_Node] = []
+
+    @property
+    def mean_value(self) -> float:
+        return self.value_sum / self.visit_count if self.visit_count else 0.0
+
+
+class MCTSEngine:
+    """PUCT Monte Carlo Tree Search over learned policy/value/transition models.
+
+    Parameters
+    ----------
+    policy_value_net:
+        Provides action priors and leaf values; typically a
+        :class:`~bicameral_agent.policy_value_net.PolicyValueNetwork`.
+    transition_model:
+        Predicts ``(next_state, reward)`` per edge; typically a
+        :class:`~bicameral_agent.transition_model.TransitionModel`. Its
+        state dimensionality must match the policy network's input.
+    c_puct:
+        PUCT exploration constant (default 1.5). Higher values weight the
+        prior/visit-count exploration term over observed values.
+    discount:
+        Per-step discount applied during backup (default: the training
+        pipeline's ``DISCOUNT_GAMMA`` so search returns match the returns
+        the value head is trained on).
+    dirichlet_alpha:
+        Concentration of the root Dirichlet noise.
+    dirichlet_epsilon:
+        Mixing fraction of the noise into the root priors.
+    seed:
+        Seed for the private numpy generator that draws root noise. All
+        other computation is deterministic, so a fixed seed makes
+        :meth:`search` fully reproducible.
+    """
+
+    def __init__(
+        self,
+        policy_value_net: SupportsPolicyValue,
+        transition_model: SupportsTransition,
+        c_puct: float = DEFAULT_C_PUCT,
+        discount: float = DISCOUNT_GAMMA,
+        dirichlet_alpha: float = DEFAULT_DIRICHLET_ALPHA,
+        dirichlet_epsilon: float = DEFAULT_DIRICHLET_EPSILON,
+        seed: int | None = None,
+    ) -> None:
+        if policy_value_net.num_actions != transition_model.num_actions:
+            msg = (
+                "policy_value_net and transition_model disagree on num_actions: "
+                f"{policy_value_net.num_actions} != {transition_model.num_actions}"
+            )
+            raise ValueError(msg)
+        # A default PolicyValueNetwork is 64-dim (encoder FEATURE_DIM) while a
+        # default TransitionModel is 108-dim (pipeline STATE_DIM); catch that
+        # mismatch here instead of as a shape error mid-search.
+        policy_dim = getattr(policy_value_net, "input_dim", None)
+        transition_dim = getattr(transition_model, "state_dim", None)
+        if policy_dim is not None and transition_dim is not None and policy_dim != transition_dim:
+            msg = (
+                "policy_value_net and transition_model disagree on state dim: "
+                f"input_dim={policy_dim} != state_dim={transition_dim} "
+                "(construct the policy net with input_dim=STATE_DIM)"
+            )
+            raise ValueError(msg)
+        if c_puct <= 0.0:
+            msg = f"c_puct must be > 0, got {c_puct}"
+            raise ValueError(msg)
+        if not 0.0 <= discount <= 1.0:
+            msg = f"discount must be in [0, 1], got {discount}"
+            raise ValueError(msg)
+        if dirichlet_alpha <= 0.0:
+            msg = f"dirichlet_alpha must be > 0, got {dirichlet_alpha}"
+            raise ValueError(msg)
+        if not 0.0 <= dirichlet_epsilon <= 1.0:
+            msg = f"dirichlet_epsilon must be in [0, 1], got {dirichlet_epsilon}"
+            raise ValueError(msg)
+
+        self._policy = policy_value_net
+        self._transition = transition_model
+        self.num_actions = policy_value_net.num_actions
+        self.c_puct = c_puct
+        self.discount = discount
+        self.dirichlet_alpha = dirichlet_alpha
+        self.dirichlet_epsilon = dirichlet_epsilon
+        self._rng = np.random.default_rng(seed)
+
+    def search(
+        self,
+        root_state: np.ndarray,
+        num_simulations: int = 50,
+        add_root_noise: bool = False,
+    ) -> MCTSResult:
+        """Run MCTS from ``root_state`` and return the improved policy.
+
+        Parameters
+        ----------
+        root_state:
+            1-D state vector matching the models' state dimensionality.
+            Any float dtype is accepted; it is cast to float32.
+        num_simulations:
+            Simulation budget (e.g. 10 / 50 / 200). Each simulation adds
+            exactly one node to the tree.
+        add_root_noise:
+            Mix Dirichlet noise into the root priors (training-time
+            exploration). Leave off for deterministic evaluation.
+
+        Returns
+        -------
+        MCTSResult
+            Normalized root visit counts and the root value estimate.
+
+        Raises
+        ------
+        ValueError
+            If ``num_simulations`` is not >= 1.
+        """
+        if num_simulations < 1:
+            msg = f"num_simulations must be >= 1, got {num_simulations}"
+            raise ValueError(msg)
+
+        root = _Node(prior=1.0)
+        root.state = np.asarray(root_state, dtype=np.float32)
+        priors, root_raw_value = self._policy.predict(root.state)
+        priors = np.asarray(priors, dtype=np.float64)
+        if add_root_noise:
+            noise = self._rng.dirichlet(np.full(self.num_actions, self.dirichlet_alpha))
+            priors = (1.0 - self.dirichlet_epsilon) * priors + self.dirichlet_epsilon * noise
+        root.children = [_Node(prior=float(p)) for p in priors]
+        # The root's own evaluation counts as its first visit (MuZero
+        # convention): sqrt(N(root)) >= 1 on the first selection, and the
+        # root value averages the raw estimate with the simulated returns.
+        root.visit_count = 1
+        root.value_sum = float(root_raw_value)
+
+        for _ in range(num_simulations):
+            self._simulate(root)
+
+        visits = np.array([c.visit_count for c in root.children], dtype=np.int64)
+        distribution = (visits / visits.sum()).astype(np.float32)
+        return MCTSResult(
+            action_distribution=distribution,
+            root_value=root.value_sum / root.visit_count,
+            visit_counts=visits,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _simulate(self, root: _Node) -> None:
+        """One selection -> expansion -> evaluation -> backup pass."""
+        node = root
+        path = [root]
+        while True:
+            action, child = self._select_child(node)
+            path.append(child)
+            if child.state is None:
+                # Expansion: simulate the edge with the transition model.
+                next_state, reward = self._transition.predict(node.state, action)
+                child.state = np.asarray(next_state, dtype=np.float32)
+                child.reward = float(reward)
+                # Evaluation: priors + value for the new leaf.
+                priors, value = self._policy.predict(child.state)
+                child.children = [_Node(prior=float(p)) for p in np.asarray(priors)]
+                leaf_value = float(value)
+                break
+            node = child
+
+        # Backup: average the discounted return into every node on the
+        # path (mean backup — see module docstring).
+        value = leaf_value
+        for n in reversed(path):
+            n.visit_count += 1
+            n.value_sum += value
+            value = n.reward + self.discount * value
+
+    def _select_child(self, node: _Node) -> tuple[int, _Node]:
+        """PUCT argmax over ``node``'s children (deterministic tie-break)."""
+        sqrt_n = math.sqrt(node.visit_count)
+        scores = np.empty(self.num_actions, dtype=np.float64)
+        for i, child in enumerate(node.children):
+            if child.visit_count:
+                q = child.reward + self.discount * child.mean_value
+            else:
+                q = 0.0
+            u = self.c_puct * child.prior * sqrt_n / (1 + child.visit_count)
+            scores[i] = q + u
+        best = int(np.argmax(scores))
+        return best, node.children[best]

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,306 @@
+"""Tests for the MCTS engine (issue #28).
+
+The module requires torch for the real-network tests, so it is skipped
+wholesale when torch is unavailable (same pattern as
+test_transition_model.py).
+
+Synthetic construction for the search-quality ACs
+-------------------------------------------------
+Random-initialized networks give search nothing to discover: the value
+landscape is flat noise, so MCTS visit counts simply track the prior and
+the policy-improvement / budget-sensitivity ACs cannot be exercised.
+Instead those tests use deterministic stub models implementing the same
+``predict`` interfaces, built so the value landscape *contradicts* the
+prior:
+
+- ``_StubPolicyValue``: the prior always favors action 0 (probs
+  ``[0.7, 0.1, 0.1, 0.1]``); the value head returns 0, so the search
+  signal comes purely from predicted rewards.
+- ``_StubTransition``: taking the state-dependent "best" action
+  (``int(state[0] * num_actions)``) yields reward 1, every other action
+  yields 0; dynamics are static (``next_state == state``) so the
+  landscape is stationary down the tree.
+
+Raw-policy argmax is therefore always action 0, while the rewarding
+action is uniform over all 4 actions for uniformly random states — so a
+search that reads the transition model's rewards should disagree with
+the prior on ~75% of states (AC: >= 10%), concentrate more with a larger
+budget, and shift meaningfully between 10 and 50 simulations.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.mcts import MCTSEngine, MCTSResult
+from bicameral_agent.policy_value_net import NUM_ACTIONS, PolicyValueNetwork
+from bicameral_agent.training_pipeline import STATE_DIM
+from bicameral_agent.transition_model import TransitionModel
+
+# ---------------------------------------------------------------------------
+# Model builders
+# ---------------------------------------------------------------------------
+
+
+def _real_models(seed: int = 0) -> tuple[PolicyValueNetwork, TransitionModel]:
+    """Random-initialized real networks on a shared STATE_DIM state space."""
+    torch.manual_seed(seed)
+    policy = PolicyValueNetwork(input_dim=STATE_DIM)
+    transition = TransitionModel()
+    policy.eval()
+    transition.eval()
+    return policy, transition
+
+
+def _random_states(n: int, dim: int = STATE_DIM, seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).random((n, dim)).astype(np.float32)
+
+
+_STUB_DIM = 8
+
+
+def _best_action(state: np.ndarray) -> int:
+    """State-dependent rewarding action, uniform over actions for U[0,1) states."""
+    return min(int(float(state[0]) * NUM_ACTIONS), NUM_ACTIONS - 1)
+
+
+class _StubPolicyValue:
+    """Prior always favors action 0; value head contributes nothing.
+
+    See the module docstring for the full construction rationale.
+    """
+
+    num_actions = NUM_ACTIONS
+
+    def predict(self, state: np.ndarray) -> tuple[np.ndarray, float]:
+        probs = np.full(NUM_ACTIONS, 0.1, dtype=np.float32)
+        probs[0] = 0.7
+        return probs, 0.0
+
+
+class _StubTransition:
+    """Reward 1 for the state-dependent best action, 0 otherwise; static dynamics."""
+
+    num_actions = NUM_ACTIONS
+
+    def predict(self, state: np.ndarray, action: int) -> tuple[np.ndarray, float]:
+        reward = 1.0 if action == _best_action(state) else 0.0
+        return np.asarray(state, dtype=np.float32), reward
+
+
+def _stub_engine(seed: int = 0, **kwargs) -> MCTSEngine:
+    return MCTSEngine(_StubPolicyValue(), _StubTransition(), seed=seed, **kwargs)
+
+
+def _kl(p: np.ndarray, q: np.ndarray, eps: float = 1e-6) -> float:
+    """KL(p || q) with epsilon smoothing so zero visit counts stay finite."""
+    p = np.asarray(p, dtype=np.float64) + eps
+    q = np.asarray(q, dtype=np.float64) + eps
+    p /= p.sum()
+    q /= q.sum()
+    return float(np.sum(p * np.log(p / q)))
+
+
+def _entropy(p: np.ndarray) -> float:
+    p = np.asarray(p, dtype=np.float64)
+    nz = p[p > 0]
+    return float(-np.sum(nz * np.log(nz)))
+
+
+# ---------------------------------------------------------------------------
+# Result contract
+# ---------------------------------------------------------------------------
+
+
+class TestSearchContract:
+    def test_result_shapes_and_dtypes(self) -> None:
+        policy, transition = _real_models()
+        engine = MCTSEngine(policy, transition, seed=0)
+        state = _random_states(1)[0]
+        result = engine.search(state, num_simulations=10)
+        assert isinstance(result, MCTSResult)
+        assert result.action_distribution.shape == (NUM_ACTIONS,)
+        assert result.action_distribution.dtype == np.float32
+        assert (result.action_distribution >= 0).all()
+        assert abs(float(result.action_distribution.sum()) - 1.0) < 1e-5
+        assert result.visit_counts.shape == (NUM_ACTIONS,)
+        assert result.visit_counts.dtype == np.int64
+        assert int(result.visit_counts.sum()) == 10
+        assert isinstance(result.root_value, float)
+        assert math.isfinite(result.root_value)
+
+    def test_accepts_float64_state(self) -> None:
+        policy, transition = _real_models()
+        engine = MCTSEngine(policy, transition, seed=0)
+        state64 = np.random.default_rng(0).random(STATE_DIM)  # float64
+        result = engine.search(state64, num_simulations=5)
+        assert int(result.visit_counts.sum()) == 5
+
+    def test_rejects_zero_simulations(self) -> None:
+        engine = _stub_engine()
+        state = np.zeros(_STUB_DIM, dtype=np.float32)
+        with pytest.raises(ValueError, match="num_simulations"):
+            engine.search(state, num_simulations=0)
+
+    def test_constructor_validation(self) -> None:
+        policy, transition = _StubPolicyValue(), _StubTransition()
+        with pytest.raises(ValueError, match="c_puct"):
+            MCTSEngine(policy, transition, c_puct=0.0)
+        with pytest.raises(ValueError, match="discount"):
+            MCTSEngine(policy, transition, discount=1.5)
+        with pytest.raises(ValueError, match="dirichlet_alpha"):
+            MCTSEngine(policy, transition, dirichlet_alpha=0.0)
+        with pytest.raises(ValueError, match="dirichlet_epsilon"):
+            MCTSEngine(policy, transition, dirichlet_epsilon=2.0)
+
+    def test_rejects_mismatched_num_actions(self) -> None:
+        policy = _StubPolicyValue()
+        transition = _StubTransition()
+        transition.num_actions = NUM_ACTIONS + 1
+        with pytest.raises(ValueError, match="num_actions"):
+            MCTSEngine(policy, transition)
+
+    def test_rejects_mismatched_state_dims(self) -> None:
+        # Default PolicyValueNetwork is FEATURE_DIM (64) while the default
+        # TransitionModel is STATE_DIM (108); the engine must refuse the pair.
+        torch.manual_seed(0)
+        with pytest.raises(ValueError, match="state dim"):
+            MCTSEngine(PolicyValueNetwork(), TransitionModel())
+
+
+# ---------------------------------------------------------------------------
+# AC1: determinism — same state + same seed -> identical distributions
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_same_seed_identical_distributions_with_noise(self) -> None:
+        policy, transition = _real_models()
+        states = _random_states(5)
+
+        def run(seed: int) -> list[MCTSResult]:
+            engine = MCTSEngine(policy, transition, seed=seed)
+            return [engine.search(s, num_simulations=25, add_root_noise=True) for s in states]
+
+        for r1, r2 in zip(run(7), run(7), strict=True):
+            np.testing.assert_array_equal(r1.action_distribution, r2.action_distribution)
+            np.testing.assert_array_equal(r1.visit_counts, r2.visit_counts)
+            assert r1.root_value == r2.root_value
+
+    def test_noise_off_is_seed_independent(self) -> None:
+        policy, transition = _real_models()
+        state = _random_states(1)[0]
+        r1 = MCTSEngine(policy, transition, seed=1).search(state, num_simulations=25)
+        r2 = MCTSEngine(policy, transition, seed=2).search(state, num_simulations=25)
+        np.testing.assert_array_equal(r1.action_distribution, r2.action_distribution)
+        assert r1.root_value == r2.root_value
+
+    def test_root_noise_changes_search(self) -> None:
+        """The noise toggle must actually perturb the root priors."""
+        policy, transition = _real_models()
+        states = _random_states(5, seed=3)
+        engine_noisy = MCTSEngine(policy, transition, seed=0, dirichlet_epsilon=0.5)
+        engine_clean = MCTSEngine(policy, transition, seed=0)
+        differs = any(
+            not np.array_equal(
+                engine_noisy.search(s, num_simulations=25, add_root_noise=True).visit_counts,
+                engine_clean.search(s, num_simulations=25).visit_counts,
+            )
+            for s in states
+        )
+        assert differs, "Dirichlet root noise never changed the visit counts"
+
+
+# ---------------------------------------------------------------------------
+# AC2: policy improvement — search disagrees with the raw prior argmax
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyImprovement:
+    def test_mcts_differs_from_raw_policy_on_at_least_10pct(self) -> None:
+        engine = _stub_engine()
+        states = _random_states(40, dim=_STUB_DIM, seed=1)
+        raw_argmax = 0  # the stub prior always peaks at action 0
+        n_differ = sum(
+            int(np.argmax(engine.search(s, num_simulations=50).action_distribution))
+            != raw_argmax
+            for s in states
+        )
+        assert n_differ / len(states) >= 0.10, (
+            f"MCTS argmax differed from the prior on only {n_differ}/{len(states)} states"
+        )
+
+    def test_mcts_finds_the_rewarding_action(self) -> None:
+        """Stronger than the AC: search should recover the true best action."""
+        engine = _stub_engine()
+        states = _random_states(40, dim=_STUB_DIM, seed=1)
+        for s in states:
+            result = engine.search(s, num_simulations=50)
+            assert int(np.argmax(result.action_distribution)) == _best_action(s)
+
+
+# ---------------------------------------------------------------------------
+# AC3: budget sensitivity — KL(10-sim || 50-sim) > 0.01 on average
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetSensitivity:
+    def test_kl_between_10_and_50_simulations(self) -> None:
+        engine = _stub_engine()
+        states = _random_states(20, dim=_STUB_DIM, seed=2)
+        kls = []
+        for s in states:
+            d10 = engine.search(s, num_simulations=10).action_distribution
+            d50 = engine.search(s, num_simulations=50).action_distribution
+            kls.append(_kl(d10, d50))
+        mean_kl = float(np.mean(kls))
+        assert mean_kl > 0.01, f"mean KL(10 || 50) = {mean_kl:.4f} <= 0.01"
+
+    # AC4: larger budgets concentrate the distribution.
+    def test_200_sims_lower_entropy_than_10(self) -> None:
+        engine = _stub_engine()
+        states = _random_states(20, dim=_STUB_DIM, seed=2)
+        h10 = np.mean([_entropy(engine.search(s, 10).action_distribution) for s in states])
+        h200 = np.mean([_entropy(engine.search(s, 200).action_distribution) for s in states])
+        assert h200 < h10, f"entropy did not drop with budget: h10={h10:.3f}, h200={h200:.3f}"
+
+
+# ---------------------------------------------------------------------------
+# AC5 / AC6: latency and root-value sanity on the real networks
+# ---------------------------------------------------------------------------
+
+
+class TestRealNetworkBehavior:
+    def test_50_simulations_under_200ms(self) -> None:
+        import time
+
+        policy, transition = _real_models()
+        engine = MCTSEngine(policy, transition, seed=0)
+        state = _random_states(1)[0]
+        engine.search(state, num_simulations=50)  # warm up
+        times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            engine.search(state, num_simulations=50)
+            times.append(time.perf_counter() - start)
+        median_ms = sorted(times)[len(times) // 2] * 1000
+        assert median_ms < 200, f"50-sim search median={median_ms:.1f}ms > 200ms"
+
+    def test_root_value_near_raw_value_estimate(self) -> None:
+        policy, transition = _real_models()
+        engine = MCTSEngine(policy, transition, seed=0)
+        states = _random_states(10, seed=4)
+        diffs = []
+        for s in states:
+            _, raw_value = policy.predict(s)
+            result = engine.search(s, num_simulations=50)
+            diffs.append(abs(result.root_value - raw_value))
+        mean_diff = float(np.mean(diffs))
+        assert mean_diff < 0.5, f"mean |root_value - raw value| = {mean_diff:.3f} >= 0.5"


### PR DESCRIPTION
## Summary
Implements the MCTS engine from issue #28: `MCTSEngine` in `src/bicameral_agent/mcts.py` runs PUCT search using the policy/value network (#25) as prior + leaf evaluator and the transition model (#27) as the simulated environment, returning normalized root visit counts plus a root value estimate.

## Work performed
- `MCTSEngine.search(root_state, num_simulations=50, add_root_noise=False) -> MCTSResult` (action distribution as normalized visit counts, float32; raw visit counts; mean-backed-up root value).
- Selection: PUCT with the policy prior, `c_puct=1.5` tunable via the constructor. Q on an edge is the predicted immediate reward plus the discounted mean subtree value.
- Expansion: transition model predicts `(next_state, reward)` per edge; Evaluation: value head at leaves (no rollouts).
- Backup: mean value backup (`Q = W / N`), not minimax — this is single-agent control with no opponent, documented in the module docstring. Discounting defaults to the pipeline's `DISCOUNT_GAMMA` so search returns match the value head's training targets.
- Configurable simulation budget (any `>= 1`; exercised at 10/50/200 in tests) and toggleable root Dirichlet noise (`dirichlet_alpha`/`dirichlet_epsilon` constructor params, per-search `add_root_noise` flag for training vs eval).
- Determinism: networks are inference-only (no torch RNG consumed); the only stochastic step is root noise drawn from a private numpy generator seeded by the `seed` constructor arg.
- Guardrails: validates `c_puct`, `discount`, noise params, matching `num_actions`, and rejects the default 64-dim policy net paired with the 108-dim transition model up front instead of failing with a torch shape error mid-search.
- Models are consumed through small `Protocol`s (`SupportsPolicyValue` / `SupportsTransition`) — the engine only needs the numpy `predict` interfaces, which also lets tests use controlled stub models.

## Test plan
`tests/test_mcts.py` (module-level `pytest.importorskip("torch")`, matching test_transition_model.py) maps to the issue ACs:
- **Consistency**: same state + same seed gives identical distributions/visit counts/root value with noise on; noise off is seed-independent; the noise toggle demonstrably perturbs search.
- **Policy improvement**: on a synthetic landscape where the prior always peaks at action 0 but the transition model rewards a state-dependent action (uniform over all 4), MCTS argmax disagrees with the prior argmax on >= 10% of states (~75% by construction) and recovers the true rewarding action on every state. Construction rationale documented in the test module docstring (random-init nets have a flat value landscape, so search quality ACs need a landscape that contradicts the prior).
- **Budget sensitivity**: mean KL(10-sim || 50-sim) > 0.01 over a 20-state batch (epsilon-smoothed KL).
- **Entropy**: mean entropy at 200 sims < mean entropy at 10 sims.
- **Latency**: 50 simulations complete in < 200ms median on the real STATE_DIM networks.
- **Root value sanity**: mean |root_value - raw value estimate| < 0.5 over 10 states on real networks.

Gates run locally:
- `uv run --extra dev --extra torch pytest -q` — 1282 passed, 35 skipped
- `uv run --extra dev --extra torch ruff check src/ tests/` — clean

Closes #28