### PR TITLE
Partial: Supervised pre-training of the policy/value network on heuristic data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",
+    "matplotlib>=3.7",
 ]
 ml = [
     "fastembed>=0.3",

--- a/scripts/pretrain_policy.py
+++ b/scripts/pretrain_policy.py
@@ -1,0 +1,266 @@
+"""Pre-train the policy/value network on heuristic episodes (issue #26).
+
+Loads heuristic-condition episodes from parquet files (and/or training
+examples from a :class:`~bicameral_agent.training_data_store.TrainingDataStore`),
+converts episodes to (state, action, discounted-return) examples with
+:class:`~bicameral_agent.training_pipeline.TrainingDataPipeline`, trains
+:class:`~bicameral_agent.policy_value_net.PolicyValueNetwork` with a
+deterministic episode-grouped 80/20 split and early stopping on the
+validation loss, and writes:
+
+- ``<out-dir>/policy_value_pretrained.pt`` — model checkpoint
+- ``<out-dir>/metrics.json``               — config, data stats, per-epoch
+  history, held-out evaluation and per-AC pass/fail flags
+- ``<out-dir>/training_curves.png``        — loss / action accuracy /
+  value correlation vs. epoch
+
+Usage (on the completed #46 baseline re-run)::
+
+    uv run --extra dev --extra torch python scripts/pretrain_policy.py \\
+        data/baseline_rerun/heuristic.parquet --out-dir data/pretrain
+
+Exit code is 0 whenever training itself succeeds; acceptance-criteria
+outcomes are data-dependent and reported in ``metrics.json`` / stdout
+rather than via the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+from bicameral_agent.pretrain import (
+    PretrainConfig,
+    PretrainResult,
+    pretrain_policy_value,
+)
+from bicameral_agent.serialization import episodes_from_parquet
+from bicameral_agent.training_pipeline import DEFAULT_MAX_TURNS, TrainingDataPipeline
+
+# Issue #26 acceptance-criteria thresholds.
+AC_ACTION_ACCURACY_MIN = 0.8
+AC_VALUE_CORR_MIN = 0.3
+AC_MONOTONIC_EPOCHS = 10
+AC_OVERFIT_GAP_MAX = 0.2
+AC_TRAIN_SECONDS_MAX = 30 * 60
+
+# Series colors: categorical slots 1 (blue) and 2 (aqua) of the
+# reference palette, light mode (PNGs render on a white surface).
+_C_TRAIN = "#2a78d6"
+_C_VAL = "#1baf7a"
+_C_THRESHOLD = "#52514e"
+
+
+def acceptance_criteria(result: PretrainResult) -> dict[str, bool | None]:
+    """Per-AC pass/fail flags (*None* = not evaluable on this data)."""
+    accuracy = result.metrics.get("action_accuracy")
+    corr = result.metrics.get("value_correlation")
+    train_losses = [e["train_loss"] for e in result.history]
+    monotonic = len(train_losses) >= AC_MONOTONIC_EPOCHS and all(
+        train_losses[i + 1] < train_losses[i] for i in range(AC_MONOTONIC_EPOCHS - 1)
+    )
+    best = result.history[result.best_epoch - 1]
+    no_overfit = best["val_loss"] <= (1.0 + AC_OVERFIT_GAP_MAX) * best["train_loss"]
+    return {
+        "action_accuracy_ge_0.8": None if accuracy is None else accuracy >= AC_ACTION_ACCURACY_MIN,
+        "value_correlation_gt_0.3": None if corr is None else corr > AC_VALUE_CORR_MIN,
+        "train_loss_monotonic_10_epochs": monotonic,
+        "val_loss_within_20pct_of_train": bool(no_overfit),
+        "training_lt_30min_cpu": result.train_seconds < AC_TRAIN_SECONDS_MAX,
+    }
+
+
+def save_training_curves(result: PretrainResult, path: Path) -> None:
+    """Plot loss / accuracy / correlation vs. epoch and save as one PNG."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    epochs = list(range(1, len(result.history) + 1))
+    fig, (ax_loss, ax_acc, ax_corr) = plt.subplots(1, 3, figsize=(11.0, 3.4))
+
+    def style(ax, title: str) -> None:
+        ax.set_title(title, fontsize=10, color="#0b0b0b")
+        ax.set_xlabel("epoch", fontsize=9)
+        ax.spines[["top", "right"]].set_visible(False)
+        ax.grid(axis="y", linewidth=0.5, alpha=0.25)
+        ax.tick_params(labelsize=8)
+
+    ax_loss.plot(
+        epochs, [e["train_loss"] for e in result.history],
+        color=_C_TRAIN, linewidth=2, label="train",
+    )
+    ax_loss.plot(
+        epochs, [e["val_loss"] for e in result.history],
+        color=_C_VAL, linewidth=2, label="validation",
+    )
+    ax_loss.axvline(
+        result.best_epoch, color=_C_THRESHOLD, linewidth=1, linestyle="--", alpha=0.6
+    )
+    style(ax_loss, "Loss (best epoch dashed)")
+    ax_loss.legend(fontsize=8, frameon=False)
+
+    ax_acc.plot(
+        epochs, [e["val_action_accuracy"] for e in result.history],
+        color=_C_TRAIN, linewidth=2,
+    )
+    ax_acc.axhline(
+        AC_ACTION_ACCURACY_MIN, color=_C_THRESHOLD, linewidth=1, linestyle="--", alpha=0.6
+    )
+    ax_acc.set_ylim(0.0, 1.05)  # headroom so a 1.0 line is not clipped
+    style(ax_acc, "Validation action accuracy (AC: 0.8)")
+
+    # Correlation can be None on degenerate epochs; plot those as gaps.
+    corr = [
+        e["val_value_correlation"] if e["val_value_correlation"] is not None else float("nan")
+        for e in result.history
+    ]
+    ax_corr.plot(epochs, corr, color=_C_TRAIN, linewidth=2)
+    ax_corr.axhline(
+        AC_VALUE_CORR_MIN, color=_C_THRESHOLD, linewidth=1, linestyle="--", alpha=0.6
+    )
+    ax_corr.set_ylim(-1.0, 1.0)
+    style(ax_corr, "Validation value correlation (AC: 0.3)")
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "episodes", nargs="*",
+        help="Parquet episode files for the heuristic condition "
+        "(e.g. data/baseline_rerun/heuristic.parquet).",
+    )
+    parser.add_argument(
+        "--store", default=None,
+        help="Optional TrainingDataStore root to load training examples from, "
+        "in addition to (or instead of) parquet episode files.",
+    )
+    parser.add_argument(
+        "--out-dir", default="data/pretrain",
+        help="Directory for the checkpoint, metrics.json and training_curves.png "
+        "(default: %(default)s).",
+    )
+    parser.add_argument("--max-epochs", type=int, default=300)
+    parser.add_argument("--min-epochs", type=int, default=10)
+    parser.add_argument("--patience", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--hidden-dim", type=int, default=160)
+    parser.add_argument("--value-loss-weight", type=float, default=0.5)
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--max-turns", type=int, default=DEFAULT_MAX_TURNS,
+        help="EpisodeConfig.max_turns used when the episodes were generated "
+        "(default: %(default)s).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.episodes and args.store is None:
+        parser.error("provide parquet episode files and/or --store")
+
+    examples = []
+    n_episodes = 0
+    if args.episodes:
+        episodes = []
+        for path in args.episodes:
+            loaded = episodes_from_parquet(path)
+            print(f"loaded {len(loaded):3d} episodes from {path}")
+            episodes.extend(loaded)
+        n_episodes = len(episodes)
+        pipeline = TrainingDataPipeline(max_turns=args.max_turns)
+        examples.extend(pipeline.process_episodes(episodes))
+    if args.store is not None:
+        from bicameral_agent.training_data_store import TrainingDataStore
+
+        stored = TrainingDataStore(args.store).load_examples()
+        print(f"loaded {len(stored):3d} examples from store {args.store}")
+        examples.extend(stored)
+    if not examples:
+        print("error: inputs produced no training examples", file=sys.stderr)
+        return 1
+    print(f"{n_episodes} episodes -> {len(examples)} (state, action, return) examples")
+
+    config = PretrainConfig(
+        hidden_dim=args.hidden_dim,
+        max_epochs=args.max_epochs,
+        min_epochs=args.min_epochs,
+        patience=args.patience,
+        batch_size=args.batch_size,
+        learning_rate=args.lr,
+        value_loss_weight=args.value_loss_weight,
+        train_ratio=args.train_ratio,
+        seed=args.seed,
+    )
+    result = pretrain_policy_value(examples, config)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model_path = out_dir / "policy_value_pretrained.pt"
+    result.model.save(model_path)
+    curves_path = out_dir / "training_curves.png"
+    save_training_curves(result, curves_path)
+
+    acs = acceptance_criteria(result)
+    payload = {
+        "config": dataclasses.asdict(config),
+        "data": {
+            "episode_files": list(args.episodes),
+            "store": args.store,
+            "n_episodes": n_episodes,
+            "n_examples": len(examples),
+            "n_train": result.n_train,
+            "n_val": result.n_val,
+        },
+        "train": {
+            "train_seconds": result.train_seconds,
+            "epochs_run": len(result.history),
+            "best_epoch": result.best_epoch,
+            "first_epoch": result.history[0],
+            "final_epoch": result.history[-1],
+            "history": result.history,
+        },
+        "eval": result.metrics,
+        "acceptance_criteria": acs,
+        "model_path": str(model_path),
+        "curves_path": str(curves_path),
+        "param_count": result.model.param_count,
+    }
+    metrics_path = out_dir / "metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    m = result.metrics
+    print(f"\nsaved {model_path} ({result.model.param_count} params), "
+          f"{metrics_path} and {curves_path}")
+    print(f"train: {result.n_train} examples, val: {result.n_val}, "
+          f"{len(result.history)} epochs (best: {result.best_epoch}) "
+          f"in {result.train_seconds:.1f}s")
+    print(f"train loss: {result.history[0]['train_loss']:.4f} -> "
+          f"{result.history[-1]['train_loss']:.4f}, "
+          f"best val loss: {result.history[result.best_epoch - 1]['val_loss']:.4f}")
+    print(f"val action accuracy: {fmt(m['action_accuracy'])}  "
+          f"(constant-majority baseline: {fmt(m['majority_action_fraction'])})")
+    print(f"val value correlation r: {fmt(m['value_correlation'])}, "
+          f"value MSE: {fmt(m['value_mse'])}")
+    print("\nacceptance criteria:")
+    for name, ok in acs.items():
+        status = "PASS" if ok else ("FAIL" if ok is not None else "N/A ")
+        print(f"  [{status}] {name}")
+    return 0
+
+
+def fmt(v: float | None) -> str:
+    return "n/a" if v is None else f"{v:.4f}"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bicameral_agent/pretrain.py
+++ b/src/bicameral_agent/pretrain.py
@@ -1,0 +1,304 @@
+"""Supervised pre-training of the policy/value network (issue #26).
+
+Trains :class:`~bicameral_agent.policy_value_net.PolicyValueNetwork` on
+heuristic-controller episodes to imitate the heuristic's actions:
+
+- Policy head: cross-entropy against the heuristic's action at each
+  decision point.
+- Value head: MSE against the discounted return
+  (:attr:`~bicameral_agent.training_pipeline.TrainingExample.discounted_return`,
+  γ = 0.95 per the pipeline).
+
+This validates that the network can learn from the 108-dim state
+representation before attempting RL.
+
+Training data
+-------------
+The fit/eval helpers consume ``list[TrainingExample]`` — produced either
+by :class:`~bicameral_agent.training_pipeline.TrainingDataPipeline`
+(directly from parquet episode files) or by
+:meth:`~bicameral_agent.training_data_store.TrainingDataStore.load_examples`
+— mirroring :mod:`~bicameral_agent.transition_model`, whose
+episode-grouped deterministic :func:`~bicameral_agent.transition_model.split_examples`
+is reused for the 80/20 train/validation split.
+
+Early stopping
+--------------
+Training runs until the validation loss plateaus: after ``min_epochs``
+epochs, it stops once the best validation loss has not improved by more
+than ``min_delta`` for ``patience`` consecutive epochs. The returned
+model carries the weights from the best-validation-loss epoch.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import time
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from bicameral_agent.policy_value_net import NUM_ACTIONS, PolicyValueNetwork
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingExample
+from bicameral_agent.transition_model import split_examples
+
+DEFAULT_HIDDEN_DIM: int = 160
+"""Hidden-layer width, matching the PolicyValueNetwork default."""
+
+DEFAULT_VALUE_LOSS_WEIGHT: float = 0.5
+"""Weight of the value-head MSE in the combined training loss."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PretrainConfig:
+    """Hyperparameters for :func:`pretrain_policy_value`."""
+
+    hidden_dim: int = DEFAULT_HIDDEN_DIM
+    max_epochs: int = 300
+    min_epochs: int = 10
+    patience: int = 20
+    min_delta: float = 1e-4
+    batch_size: int = 64
+    learning_rate: float = 1e-3
+    value_loss_weight: float = DEFAULT_VALUE_LOSS_WEIGHT
+    train_ratio: float = 0.8
+    seed: int = 0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PretrainResult:
+    """Output of :func:`pretrain_policy_value`.
+
+    ``history`` holds one dict per completed epoch with keys
+    ``train_loss``, ``train_policy_loss``, ``train_value_loss``,
+    ``val_loss``, ``val_policy_loss``, ``val_value_loss``,
+    ``val_action_accuracy`` and ``val_value_correlation`` (*None* when
+    undefined). ``best_epoch`` is the 1-indexed epoch whose weights the
+    returned model carries. ``metrics`` is the held-out evaluation from
+    :func:`evaluate_policy_value` at those weights.
+    """
+
+    model: PolicyValueNetwork
+    history: list[dict[str, float | None]]
+    best_epoch: int
+    metrics: dict
+    n_train: int
+    n_val: int
+    train_seconds: float
+
+
+def _to_tensors(
+    examples: list[TrainingExample],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Stack examples into ``(states, actions, returns)`` tensors."""
+    states = torch.from_numpy(np.stack([e.state for e in examples])).float()
+    actions = torch.tensor([e.action for e in examples], dtype=torch.long)
+    returns = torch.tensor([e.discounted_return for e in examples], dtype=torch.float32)
+    return states, actions, returns
+
+
+def _losses(
+    model: PolicyValueNetwork,
+    states: torch.Tensor,
+    actions: torch.Tensor,
+    returns: torch.Tensor,
+    value_loss_weight: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """(total, policy CE, value MSE) for a batch.
+
+    Uses the network's pre-softmax logits (``_shared_forward``) so the
+    cross-entropy is computed in a numerically stable way instead of
+    re-deriving log-probs from the softmax output.
+    """
+    logits, values = model._shared_forward(states)  # noqa: SLF001 — same package
+    policy_loss = F.cross_entropy(logits, actions)
+    value_loss = F.mse_loss(values, returns)
+    return policy_loss + value_loss_weight * value_loss, policy_loss, value_loss
+
+
+def _pearson_r(a: np.ndarray, b: np.ndarray) -> float | None:
+    """Pearson correlation, or *None* when undefined (constant inputs, n < 2)."""
+    if len(a) < 2 or a.std() == 0 or b.std() == 0:
+        return None
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+@torch.no_grad()
+def evaluate_policy_value(
+    model: PolicyValueNetwork,
+    examples: list[TrainingExample],
+    value_loss_weight: float = DEFAULT_VALUE_LOSS_WEIGHT,
+) -> dict:
+    """Evaluate policy/value predictions on held-out examples.
+
+    Returns a JSON-serializable dict with:
+
+    - ``action_accuracy``: fraction of examples where the policy head's
+      argmax matches the heuristic's action.
+    - ``majority_action_fraction``: frequency of the most common true
+      action — the accuracy a constant predictor would achieve, for
+      calibrating the 80%-accuracy AC.
+    - ``value_correlation``: Pearson r between predicted values and
+      discounted returns (*None* when undefined) plus ``value_mse``.
+    - ``policy_loss`` / ``value_loss`` / ``loss``: the training losses.
+    - ``true_action_counts`` / ``predicted_action_counts``: per-action
+      index histograms (length ``NUM_ACTIONS``).
+    """
+    was_training = model.training
+    model.eval()
+    out: dict = {
+        "n_examples": len(examples),
+        "action_accuracy": None,
+        "majority_action_fraction": None,
+        "value_correlation": None,
+        "value_mse": None,
+        "policy_loss": None,
+        "value_loss": None,
+        "loss": None,
+        "true_action_counts": None,
+        "predicted_action_counts": None,
+    }
+    if examples:
+        states, actions, returns = _to_tensors(examples)
+        logits, values = model._shared_forward(states)  # noqa: SLF001 — same package
+        predicted = logits.argmax(dim=-1)
+        policy_loss = F.cross_entropy(logits, actions)
+        value_loss = F.mse_loss(values, returns)
+        true_counts = torch.bincount(actions, minlength=NUM_ACTIONS)
+        out.update(
+            action_accuracy=float((predicted == actions).float().mean()),
+            majority_action_fraction=float(true_counts.max()) / len(examples),
+            value_correlation=_pearson_r(values.numpy(), returns.numpy()),
+            value_mse=float(value_loss),
+            policy_loss=float(policy_loss),
+            value_loss=float(value_loss),
+            loss=float(policy_loss) + value_loss_weight * float(value_loss),
+            true_action_counts=true_counts.tolist(),
+            predicted_action_counts=torch.bincount(
+                predicted, minlength=NUM_ACTIONS
+            ).tolist(),
+        )
+    if was_training:
+        model.train()
+    return out
+
+
+def pretrain_policy_value(
+    examples: list[TrainingExample],
+    config: PretrainConfig | None = None,
+) -> PretrainResult:
+    """Pre-train a :class:`PolicyValueNetwork` to imitate logged actions.
+
+    Deterministic for a fixed ``config.seed`` and example list: weight
+    initialization, the episode-grouped split and batch shuffling are
+    all seeded.
+
+    Raises
+    ------
+    ValueError
+        If ``examples`` is empty or covers fewer than two distinct
+        episodes (an episode-grouped train/val split needs at least one
+        whole episode on each side).
+    """
+    config = config or PretrainConfig()
+    if not examples:
+        msg = "cannot pre-train on an empty example list"
+        raise ValueError(msg)
+    n_episodes = len({e.episode_id for e in examples})
+    if n_episodes < 2:
+        msg = (
+            "pre-training needs examples from >= 2 episodes for an "
+            f"episode-grouped train/val split, got {n_episodes}"
+        )
+        raise ValueError(msg)
+
+    torch.manual_seed(config.seed)
+    model = PolicyValueNetwork(input_dim=STATE_DIM, hidden_dim=config.hidden_dim)
+
+    train, val = split_examples(examples, config.train_ratio, config.seed)
+    train_states, train_actions, train_returns = _to_tensors(train)
+    val_states, val_actions, val_returns = _to_tensors(val)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    rng = np.random.default_rng(config.seed)
+    n = len(train)
+
+    best_val = float("inf")
+    best_epoch = 0
+    best_state: dict | None = None
+    epochs_since_best = 0
+
+    start = time.perf_counter()
+    history: list[dict[str, float | None]] = []
+    for epoch in range(1, config.max_epochs + 1):
+        model.train()
+        perm = rng.permutation(n)
+        sums = {"total": 0.0, "policy": 0.0, "value": 0.0}
+        n_batches = 0
+        for lo in range(0, n, config.batch_size):
+            idx = torch.from_numpy(perm[lo : lo + config.batch_size])
+            loss, policy_loss, value_loss = _losses(
+                model,
+                train_states[idx],
+                train_actions[idx],
+                train_returns[idx],
+                config.value_loss_weight,
+            )
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            sums["total"] += loss.item()
+            sums["policy"] += policy_loss.item()
+            sums["value"] += value_loss.item()
+            n_batches += 1
+
+        model.eval()
+        with torch.no_grad():
+            val_total, val_policy, val_value = _losses(
+                model, val_states, val_actions, val_returns, config.value_loss_weight
+            )
+            val_logits, val_values = model._shared_forward(val_states)  # noqa: SLF001
+            val_accuracy = float((val_logits.argmax(dim=-1) == val_actions).float().mean())
+            val_corr = _pearson_r(val_values.numpy(), val_returns.numpy())
+
+        val_loss = float(val_total)
+        history.append(
+            {
+                "train_loss": sums["total"] / n_batches,
+                "train_policy_loss": sums["policy"] / n_batches,
+                "train_value_loss": sums["value"] / n_batches,
+                "val_loss": val_loss,
+                "val_policy_loss": float(val_policy),
+                "val_value_loss": float(val_value),
+                "val_action_accuracy": val_accuracy,
+                "val_value_correlation": val_corr,
+            }
+        )
+
+        if best_state is None or val_loss < best_val - config.min_delta:
+            best_val = val_loss
+            best_epoch = epoch
+            best_state = copy.deepcopy(model.state_dict())
+            epochs_since_best = 0
+        else:
+            epochs_since_best += 1
+
+        if epoch >= config.min_epochs and epochs_since_best > config.patience:
+            break
+    train_seconds = time.perf_counter() - start
+
+    assert best_state is not None  # at least one epoch always runs
+    model.load_state_dict(best_state)
+    model.eval()
+    metrics = evaluate_policy_value(model, val, config.value_loss_weight)
+    return PretrainResult(
+        model=model,
+        history=history,
+        best_epoch=best_epoch,
+        metrics=metrics,
+        n_train=len(train),
+        n_val=len(val),
+        train_seconds=train_seconds,
+    )

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -1,0 +1,365 @@
+"""Tests for supervised policy/value pre-training (issue #26).
+
+The whole module requires torch (``bicameral_agent.pretrain`` imports it
+at module level, matching policy_value_net), so it is skipped wholesale
+when torch is unavailable.
+
+The AC-threshold verification (80% action accuracy, r > 0.3 value
+correlation, ...) is data-dependent and pending the completed #46
+baseline re-run; these tests verify the training mechanics on synthetic
+data plus a skippable smoke test on the partial pilot episodes.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.heuristic_controller import TOOL_IDS
+from bicameral_agent.policy_value_net import NUM_ACTIONS, PolicyValueNetwork
+from bicameral_agent.pretrain import (
+    PretrainConfig,
+    evaluate_policy_value,
+    pretrain_policy_value,
+)
+from bicameral_agent.schema import Episode, EpisodeOutcome, Message, ToolInvocation
+from bicameral_agent.serialization import episodes_to_parquet
+from bicameral_agent.training_data_store import TrainingDataStore
+from bicameral_agent.training_pipeline import (
+    STATE_DIM,
+    TrainingDataPipeline,
+    TrainingExample,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+# Real pilot-episode directory for the smoke test: repo-relative by
+# default, overridable via BICAMERAL_BASELINE_DATA.
+_PARTIAL_DATA_DIR = Path(
+    os.environ.get(
+        "BICAMERAL_BASELINE_DATA",
+        _REPO_ROOT / "data" / "baseline_rerun_partial1",
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data builders
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_examples(
+    n: int = 300,
+    n_episodes: int = 15,
+    seed: int = 0,
+) -> list[TrainingExample]:
+    """Learnable synthetic (state, action, return) examples.
+
+    The "heuristic policy" is ``action = argmax(W @ state)`` for a fixed
+    random projection ``W`` and the return is a fixed linear function of
+    the state — deterministic functions a small MLP can fit, so training
+    loss must decrease and validation accuracy must beat chance.
+    """
+    rng = np.random.default_rng(seed)
+    w_policy = rng.standard_normal((NUM_ACTIONS, STATE_DIM)).astype(np.float32)
+    w_value = rng.standard_normal(STATE_DIM).astype(np.float32) / np.sqrt(STATE_DIM)
+    examples: list[TrainingExample] = []
+    per_ep = n // n_episodes
+    for i in range(n):
+        state = rng.random(STATE_DIM).astype(np.float32)
+        action = int(np.argmax(w_policy @ state))
+        ret = float(w_value @ state)
+        done = (i % per_ep) == per_ep - 1
+        examples.append(
+            TrainingExample(
+                state=state,
+                action=action,
+                reward=ret,
+                next_state=np.zeros(STATE_DIM, dtype=np.float32),
+                done=done,
+                discounted_return=ret,
+                episode_id=f"ep-{i // per_ep}",
+                decision_index=i % per_ep,
+            )
+        )
+    return examples
+
+
+def _synthetic_episode(num_turns: int, quality: float, base_ts: int) -> Episode:
+    """Minimal valid Episode with ``num_turns`` user/assistant pairs."""
+    messages: list[Message] = []
+    tools: list[ToolInvocation] = []
+    tool_ids = list(TOOL_IDS.values())
+    for turn in range(1, num_turns + 1):
+        user_ts = base_ts + (turn - 1) * 1000
+        messages.append(
+            Message(role="user", content=f"user {turn}", timestamp_ms=user_ts, token_count=10)
+        )
+        if turn % 2 == 0:  # alternate tool use so actions vary
+            tools.append(
+                ToolInvocation(
+                    tool_id=tool_ids[turn % len(tool_ids)],
+                    invoked_at_ms=user_ts + 100,
+                    completed_at_ms=user_ts + 300,
+                    input_tokens=20,
+                    output_tokens=30,
+                    result_deposited=False,
+                )
+            )
+        messages.append(
+            Message(
+                role="assistant",
+                content=f"assistant {turn}",
+                timestamp_ms=user_ts + 500,
+                token_count=20,
+            )
+        )
+    return Episode(
+        messages=messages,
+        tool_invocations=tools,
+        outcome=EpisodeOutcome(
+            quality_score=quality,
+            total_tokens=sum(m.token_count for m in messages),
+            total_turns=num_turns,
+            wall_clock_ms=num_turns * 1000,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Training behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTraining:
+    def test_loss_decreases_and_beats_chance_on_learnable_policy(self) -> None:
+        examples = _synthetic_examples(n=300)
+        config = PretrainConfig(max_epochs=60, patience=60, seed=0)
+        result = pretrain_policy_value(examples, config)
+        first = result.history[0]["train_loss"]
+        last = result.history[-1]["train_loss"]
+        assert last < first * 0.5, f"loss did not decrease: {first:.4f} -> {last:.4f}"
+        # Learnable deterministic policy: accuracy well above 1/4 chance.
+        assert result.metrics["action_accuracy"] > 0.5
+        # Learnable linear value target: strong correlation.
+        assert result.metrics["value_correlation"] > 0.5
+
+    def test_fit_rejects_empty_examples(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            pretrain_policy_value([])
+
+    def test_fit_rejects_single_episode(self) -> None:
+        examples = _synthetic_examples(n=20, n_episodes=1)
+        with pytest.raises(ValueError, match="2 episodes"):
+            pretrain_policy_value(examples)
+
+    def test_fit_is_deterministic_for_fixed_seed(self) -> None:
+        examples = _synthetic_examples(n=120)
+        config = PretrainConfig(max_epochs=5, min_epochs=5, seed=42)
+        r1 = pretrain_policy_value(examples, config)
+        r2 = pretrain_policy_value(examples, config)
+        assert r1.history == r2.history
+        assert r1.n_train == r2.n_train and r1.n_val == r2.n_val
+        for p1, p2 in zip(r1.model.parameters(), r2.model.parameters(), strict=True):
+            assert torch.equal(p1, p2)
+
+    def test_early_stopping_plateau(self) -> None:
+        # A huge min_delta means no epoch ever counts as an improvement,
+        # so training must stop at min_epochs, well before max_epochs.
+        examples = _synthetic_examples(n=120)
+        config = PretrainConfig(
+            max_epochs=100, min_epochs=8, patience=3, min_delta=1e9, seed=0
+        )
+        result = pretrain_policy_value(examples, config)
+        assert len(result.history) == 8
+        assert result.best_epoch == 1
+
+    def test_best_weights_are_restored(self) -> None:
+        examples = _synthetic_examples(n=120)
+        config = PretrainConfig(max_epochs=30, patience=30, seed=1)
+        result = pretrain_policy_value(examples, config)
+        best = result.history[result.best_epoch - 1]["val_loss"]
+        assert all(e["val_loss"] >= best for e in result.history)
+        # The returned model reproduces the best epoch's validation loss.
+        assert result.metrics["loss"] == pytest.approx(best, rel=1e-5)
+
+    def test_checkpoint_roundtrip(self, tmp_path: Path) -> None:
+        examples = _synthetic_examples(n=120)
+        result = pretrain_policy_value(
+            examples, PretrainConfig(max_epochs=3, min_epochs=3)
+        )
+        path = tmp_path / "model.pt"
+        result.model.save(path)
+        loaded = PolicyValueNetwork.load(path, input_dim=STATE_DIM)
+        state = np.random.default_rng(5).random(STATE_DIM).astype(np.float32)
+        expected_probs, expected_value = result.model.predict(state)
+        got_probs, got_value = loaded.predict(state)
+        np.testing.assert_array_equal(expected_probs, got_probs)
+        assert expected_value == got_value
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluation:
+    def test_metrics_structure(self) -> None:
+        examples = _synthetic_examples(n=100)
+        model = PolicyValueNetwork(input_dim=STATE_DIM)
+        metrics = evaluate_policy_value(model, examples)
+        assert metrics["n_examples"] == 100
+        assert 0.0 <= metrics["action_accuracy"] <= 1.0
+        assert 0.25 <= metrics["majority_action_fraction"] <= 1.0
+        assert -1.0 <= metrics["value_correlation"] <= 1.0
+        assert metrics["value_mse"] >= 0.0
+        assert sum(metrics["true_action_counts"]) == 100
+        assert sum(metrics["predicted_action_counts"]) == 100
+        assert len(metrics["true_action_counts"]) == NUM_ACTIONS
+        # JSON-serializable end to end
+        json.dumps(metrics)
+
+    def test_constant_returns_give_null_correlation(self) -> None:
+        examples = [
+            TrainingExample(
+                state=np.random.default_rng(i).random(STATE_DIM).astype(np.float32),
+                action=i % NUM_ACTIONS,
+                reward=0.5,
+                next_state=np.zeros(STATE_DIM, dtype=np.float32),
+                done=False,
+                discounted_return=0.5,
+                episode_id=f"ep-{i}",
+                decision_index=0,
+            )
+            for i in range(10)
+        ]
+        metrics = evaluate_policy_value(PolicyValueNetwork(input_dim=STATE_DIM), examples)
+        assert metrics["value_correlation"] is None
+
+    def test_empty_examples_yield_null_metrics(self) -> None:
+        metrics = evaluate_policy_value(PolicyValueNetwork(input_dim=STATE_DIM), [])
+        assert metrics["n_examples"] == 0
+        assert metrics["action_accuracy"] is None
+        assert metrics["value_correlation"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: full harness from parquet episode files
+# ---------------------------------------------------------------------------
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "pretrain_policy", _REPO_ROOT / "scripts" / "pretrain_policy.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestIntegration:
+    def test_cli_end_to_end_on_synthetic_episodes(self, tmp_path: Path) -> None:
+        pytest.importorskip("matplotlib")
+        episodes = [
+            _synthetic_episode(num_turns=6, quality=0.2 + 0.1 * i, base_ts=1_000_000 + i * 60_000)
+            for i in range(5)
+        ]
+        parquet_path = tmp_path / "episodes.parquet"
+        episodes_to_parquet(episodes, str(parquet_path))
+
+        out_dir = tmp_path / "out"
+        cli = _load_cli()
+        rc = cli.main(
+            [
+                str(parquet_path),
+                "--out-dir", str(out_dir),
+                "--max-epochs", "12",
+                "--patience", "12",
+                "--seed", "0",
+            ]
+        )
+        assert rc == 0
+
+        model_path = out_dir / "policy_value_pretrained.pt"
+        metrics_path = out_dir / "metrics.json"
+        curves_path = out_dir / "training_curves.png"
+        assert model_path.exists()
+        assert curves_path.exists() and curves_path.stat().st_size > 0
+        with metrics_path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        assert payload["data"]["n_episodes"] == 5
+        assert payload["data"]["n_train"] + payload["data"]["n_val"] == 30
+        assert payload["train"]["epochs_run"] == len(payload["train"]["history"])
+        assert set(payload["acceptance_criteria"]) == {
+            "action_accuracy_ge_0.8",
+            "value_correlation_gt_0.3",
+            "train_loss_monotonic_10_epochs",
+            "val_loss_within_20pct_of_train",
+            "training_lt_30min_cpu",
+        }
+        # The mechanics-level AC must hold even on tiny synthetic data.
+        assert payload["acceptance_criteria"]["training_lt_30min_cpu"] is True
+
+        # Saved checkpoint loads and predicts.
+        loaded = PolicyValueNetwork.load(model_path, input_dim=STATE_DIM)
+        probs, value = loaded.predict(np.zeros(STATE_DIM, dtype=np.float32))
+        assert probs.shape == (NUM_ACTIONS,)
+        assert np.isfinite(probs).all() and np.isfinite(value)
+
+    def test_cli_loads_examples_from_store(self, tmp_path: Path) -> None:
+        pytest.importorskip("matplotlib")
+        store_root = tmp_path / "store"
+        TrainingDataStore(store_root).save_examples(
+            _synthetic_examples(n=100, n_episodes=5), iteration=0
+        )
+        out_dir = tmp_path / "out"
+        cli = _load_cli()
+        rc = cli.main(
+            [
+                "--store", str(store_root),
+                "--out-dir", str(out_dir),
+                "--max-epochs", "3",
+                "--min-epochs", "3",
+            ]
+        )
+        assert rc == 0
+        with (out_dir / "metrics.json").open(encoding="utf-8") as f:
+            payload = json.load(f)
+        assert payload["data"]["n_examples"] == 100
+        assert payload["data"]["store"] == str(store_root)
+
+    @pytest.mark.skipif(
+        not (
+            _PARTIAL_DATA_DIR.exists()
+            and any(_PARTIAL_DATA_DIR.glob("*.parquet"))
+        ),
+        reason="partial baseline re-run data not present on this machine",
+    )
+    def test_smoke_pretrain_on_partial_baseline_rerun(self) -> None:
+        """Skippable smoke test: the harness trains on real pilot episodes."""
+        from bicameral_agent.serialization import episodes_from_parquet
+
+        episodes = []
+        for path in sorted(_PARTIAL_DATA_DIR.glob("*.parquet")):
+            episodes.extend(episodes_from_parquet(str(path)))
+        assert episodes, "parquet files present but contained no episodes"
+
+        examples = TrainingDataPipeline().process_episodes(episodes)
+        assert examples
+
+        result = pretrain_policy_value(
+            examples, PretrainConfig(max_epochs=20, min_epochs=10, patience=20, seed=0)
+        )
+        assert np.isfinite(result.history[-1]["train_loss"])
+        assert result.history[-1]["train_loss"] < result.history[0]["train_loss"]
+        assert result.metrics["n_examples"] > 0
+        assert 0.0 <= result.metrics["action_accuracy"] <= 1.0
+        json.dumps(result.metrics)

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "matplotlib" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -70,6 +71,7 @@ viz = [
 requires-dist = [
     { name = "fastembed", marker = "extra == 'ml'", specifier = ">=0.3" },
     { name = "google-genai", specifier = ">=1.0" },
+    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.7" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pyarrow", specifier = ">=15.0" },


### PR DESCRIPTION
## Summary
Implements the full supervised pre-training harness for issue #26: trains `PolicyValueNetwork` on heuristic baseline episodes (policy head via cross-entropy on the heuristic's actions, value head via MSE on discounted returns), with a deterministic episode-grouped 80/20 split, early stopping on validation-loss plateau, and checkpoint + metrics + training-curve-plot outputs.

**Partial** because #26 is blocked by #46: the pilot baseline re-run is still executing, so the AC-threshold verification (80% action accuracy, r > 0.3 value correlation) on real heuristic-condition data is pending. Mechanics are fully verified on synthetic data and the 11 partial pilot episodes.

## Work performed
- `src/bicameral_agent/pretrain.py`: `PretrainConfig` / `PretrainResult` / `pretrain_policy_value` / `evaluate_policy_value`. Reuses `transition_model.split_examples` (episode-grouped, deterministic — no leakage across the split) and `TorchCheckpointMixin` for checkpoints. Early stopping: after `min_epochs` (default 10), stops when validation loss has not improved by `min_delta` for `patience` epochs; best-epoch weights are restored.
- `scripts/pretrain_policy.py`: CLI that loads episodes from parquet (and/or examples from a `TrainingDataStore` via `--store`), processes them through `TrainingDataPipeline`, trains, and writes `policy_value_pretrained.pt`, `metrics.json` (config, data stats, per-epoch history, held-out eval, per-AC pass/fail flags) and `training_curves.png` (loss / accuracy / correlation vs. epoch).
- `tests/test_pretrain.py`: 13 tests — loss decrease + above-chance accuracy on a learnable synthetic policy, seeded determinism, early-stopping plateau, best-weight restore, checkpoint round-trip, metrics schema, CLI end-to-end (parquet and store sources, PNG produced), plus a skippable smoke test on `data/baseline_rerun_partial1` (repo-relative, `BICAMERAL_BASELINE_DATA` override).
- `pyproject.toml`: added `matplotlib>=3.7` to the dev extras (it was only in `viz`) so the plot path runs under the standard test gate.

## Test plan
- [x] `uv run --extra dev --extra torch pytest -q` — 1280 passed, 35 skipped
- [x] `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- [x] Smoke test on the 11 real partial pilot episodes (via `BICAMERAL_BASELINE_DATA`) — passes
- [x] Full CLI run on the partial pilot episodes — checkpoint, metrics.json and readable curve plots produced; training completes in <1s on CPU

ACs pending the completed #46 pilot data (the pilot's partial episodes are no-subconscious/random conditions with degenerate DO_NOTHING actions — majority baseline 1.0 — so accuracy/correlation numbers there are not meaningful):
- [ ] Policy head ≥ 80% action accuracy on validation (heuristic condition)
- [ ] Value head correlation r > 0.3 with episode returns on validation
- [ ] Train loss decreases monotonically ≥ 10 epochs / no >20% train-val divergence / < 30 min CPU — flags computed and reported in `metrics.json` per run

Re-run on the finished pilot:
```
uv run --extra dev --extra torch python scripts/pretrain_policy.py \
    data/baseline_rerun/heuristic.parquet --out-dir data/pretrain
```

Refs #26