### PR TITLE
Partial: MCTS Training Loop (LearnedPolicyController + MCTSTrainer + CLI)

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -27,9 +27,9 @@ from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDiffi
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
 from bicameral_agent.eval_report import EvalReport
-from bicameral_agent.model_client import build_client, default_model, provider_names
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
+from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
 
@@ -69,24 +69,7 @@ def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default="data/baseline")
-    parser.add_argument("--config", default=None,
-                        help="Hyperparameter TOML file (defaults to the bundled "
-                             "config; BICAMERAL_ env overrides always apply, "
-                             "CLI flags win over both).")
-    parser.add_argument("--provider", choices=list(provider_names()), default=None,
-                        help="Model backend to run the answerer against "
-                             "(overrides the config file).")
-    parser.add_argument("--model", default=None,
-                        help="Model id/tag (overrides the config file).")
-    parser.add_argument("--judge-provider", choices=list(provider_names()),
-                        default=None,
-                        help="Model backend for the measurement roles (LLM "
-                             "judge and simulated user), held fixed while "
-                             "--provider varies. Defaults to the config's "
-                             "[measurement_model], else gemini.")
-    parser.add_argument("--judge-model", default=None,
-                        help="Measurement model id/tag (overrides the config "
-                             "file; unset uses the judge provider's default).")
+    add_model_args(parser)
     parser.add_argument("--dataset", choices=dataset_names(), default="builtin",
                         help="Evaluation dataset to run against. External "
                              "datasets must be fetched first via "
@@ -98,8 +81,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
     parser.add_argument("--random-probability", type=float, default=0.2)
-    parser.add_argument("--episode-budget", type=float, default=None,
-                        help="Optional per-episode cost ceiling in USD.")
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)
 
@@ -127,32 +108,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.episode_budget is not None:
         cost_tracker.set_episode_budget(args.episode_budget)
 
-    provider = args.provider or hyper.model.provider
-    # The configured model name only applies to the configured provider.
-    model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
-    client = build_client(provider, model)
-
-    # Measurement roles (LLM judge + simulated user) are pinned independently
-    # of the answerer so cross-model comparisons stay on one judging scale
-    # (issue #53). Precedence mirrors the answerer's: CLI > config > gemini.
-    measurement = hyper.measurement_model
-    judge_provider = args.judge_provider or (
-        measurement.provider if measurement is not None else "gemini"
-    )
-    judge_model = args.judge_model or (
-        measurement.name
-        if measurement is not None and judge_provider == measurement.provider
-        else None
-    )
-    resolved_judge_model = judge_model or default_model(judge_provider)
-    if judge_provider == provider and resolved_judge_model == client.model:
-        judge_client = client
-    else:
-        judge_client = build_client(judge_provider, judge_model)
-    logger.info(
-        "Answerer: %s/%s; measurement (judge + sim-user): %s/%s",
-        provider, client.model, judge_provider, judge_client.model,
-    )
+    client, judge_client, provenance = resolve_runner_clients(args, hyper)
 
     runner = EpisodeRunner(
         client,
@@ -198,8 +154,8 @@ def main(argv: list[str] | None = None) -> int:
         result,
         dataset=args.dataset,
         metric=metric,
-        answerer={"provider": provider, "model": client.model},
-        measurement={"provider": judge_provider, "model": judge_client.model},
+        answerer=provenance["answerer"],
+        measurement=provenance["measurement"],
         tasks_per_condition=args.tasks_per_condition,
         max_turns=args.max_turns,
     )

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -1,0 +1,287 @@
+"""Run the Issue #29 MCTS training loop.
+
+Live mode (default) collects episodes with the current learned policy via
+the EpisodeRunner (real API calls; budget accordingly), generates MCTS
+targets, trains the policy/value network, evaluates against the heuristic
+on held-out tasks, and checkpoints every iteration:
+
+    GEMINI_API_KEY=... uv run python scripts/train_mcts.py \\
+        --output-dir data/mcts_training \\
+        --iterations 10 --episodes-per-iteration 50 --simulations 50
+
+Offline mode consumes pre-collected episode parquet files instead (no LLM
+client needed; collection and held-out evaluation are skipped):
+
+    uv run python scripts/train_mcts.py \\
+        --output-dir data/mcts_training \\
+        --episodes-parquet data/baseline/heuristic.parquet \\
+        --iterations 3 --simulations 50
+
+Outputs under --output-dir: iteration-NNN/{policy_value.pt,transition.pt,
+metrics.json}, metrics_history.json, store/ (training examples), and
+episodes/iteration-NNN.parquet for live-collected episodes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+from bicameral_agent.config import HyperConfig
+from bicameral_agent.dataset import (
+    ResearchQADataset,
+    ResearchQATask,
+    TaskDifficulty,
+)
+from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.mcts_trainer import MCTSTrainer, MCTSTrainerConfig
+from bicameral_agent.model_client import build_client, default_model, provider_names
+from bicameral_agent.policy_value_net import PolicyValueNetwork
+from bicameral_agent.schema import Episode
+from bicameral_agent.serialization import episodes_from_parquet
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
+from bicameral_agent.transition_model import TransitionModel
+
+logger = logging.getLogger(__name__)
+
+
+def select_eval_tasks(
+    dataset: ResearchQADataset, total: int
+) -> list[ResearchQATask]:
+    """Stratified held-out pick across typical / hard / tricky (50/25/25)."""
+    eval_tasks = dataset.eval_tasks()
+    by_diff = {
+        d: [t for t in eval_tasks if t.difficulty == d]
+        for d in (TaskDifficulty.TYPICAL, TaskDifficulty.HARD, TaskDifficulty.TRICKY)
+    }
+    quotas = {
+        TaskDifficulty.TYPICAL: total // 2,
+        TaskDifficulty.HARD: total // 4,
+        TaskDifficulty.TRICKY: total - total // 2 - total // 4,
+    }
+    selected: list[ResearchQATask] = []
+    for diff, n in quotas.items():
+        selected.extend(by_diff[diff][:n])
+    if len(selected) < total:
+        seen = {t.task_id for t in selected}
+        for t in eval_tasks:
+            if t.task_id not in seen:
+                selected.append(t)
+                if len(selected) == total:
+                    break
+    return selected[:total]
+
+
+def load_models(args: argparse.Namespace) -> tuple[PolicyValueNetwork, TransitionModel]:
+    """Build (or load from checkpoints) the policy/value and transition nets."""
+    if args.policy_checkpoint:
+        policy = PolicyValueNetwork.load(
+            args.policy_checkpoint,
+            input_dim=STATE_DIM,
+            hidden_dim=args.policy_hidden_dim,
+        )
+    else:
+        policy = PolicyValueNetwork(
+            input_dim=STATE_DIM, hidden_dim=args.policy_hidden_dim
+        )
+    if args.transition_checkpoint:
+        transition = TransitionModel.load(
+            args.transition_checkpoint, hidden_dim=args.transition_hidden_dim
+        )
+    else:
+        transition = TransitionModel(hidden_dim=args.transition_hidden_dim)
+    return policy, transition
+
+
+def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeRunner, object]:
+    """Build the live EpisodeRunner (answerer + pinned measurement roles)."""
+    cost_tracker = hyper.to_cost_tracker()
+    if args.episode_budget is not None:
+        cost_tracker.set_episode_budget(args.episode_budget)
+
+    provider = args.provider or hyper.model.provider
+    model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
+    client = build_client(provider, model)
+
+    measurement = hyper.measurement_model
+    judge_provider = args.judge_provider or (
+        measurement.provider if measurement is not None else "gemini"
+    )
+    judge_model = args.judge_model or (
+        measurement.name
+        if measurement is not None and judge_provider == measurement.provider
+        else None
+    )
+    resolved_judge_model = judge_model or default_model(judge_provider)
+    if judge_provider == provider and resolved_judge_model == client.model:
+        judge_client = client
+    else:
+        judge_client = build_client(judge_provider, judge_model)
+    logger.info(
+        "Answerer: %s/%s; measurement (judge + sim-user): %s/%s",
+        provider, client.model, judge_provider, judge_client.model,
+    )
+
+    runner = EpisodeRunner(
+        client,
+        config=hyper.to_episode_config(
+            max_turns=args.max_turns,
+            score_episode=True,
+            metric=args.metric,
+        ),
+        hyper_config=hyper,
+        cost_tracker=cost_tracker,
+        judge_client=judge_client,
+        sim_user_client=judge_client,
+    )
+    return runner, cost_tracker
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="data/mcts_training")
+    parser.add_argument("--config", default=None,
+                        help="Hyperparameter TOML file (defaults to the bundled "
+                             "config; BICAMERAL_ env overrides always apply, "
+                             "CLI flags win over both).")
+    parser.add_argument("--provider", choices=list(provider_names()), default=None,
+                        help="Model backend for episode collection/evaluation "
+                             "(overrides the config file).")
+    parser.add_argument("--model", default=None,
+                        help="Model id/tag (overrides the config file).")
+    parser.add_argument("--judge-provider", choices=list(provider_names()),
+                        default=None,
+                        help="Model backend for the measurement roles (LLM "
+                             "judge and simulated user).")
+    parser.add_argument("--judge-model", default=None,
+                        help="Measurement model id/tag.")
+    parser.add_argument("--metric", default="llm_judge",
+                        help="Verification metric used to score episodes.")
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--episodes-per-iteration", type=int, default=50)
+    parser.add_argument("--simulations", type=int, default=50,
+                        help="MCTS budget per decision point.")
+    parser.add_argument("--eval-tasks", type=int, default=20,
+                        help="Held-out evaluation tasks per iteration "
+                             "(0 disables evaluation).")
+    parser.add_argument("--max-turns", type=int, default=10,
+                        help="Episode turn limit; also configures the "
+                             "pipeline's completion-fraction features.")
+    parser.add_argument("--episodes-parquet", nargs="*", default=None,
+                        help="Pre-collected episode parquet file(s): run "
+                             "offline iterations on these episodes instead "
+                             "of collecting (no LLM client needed).")
+    parser.add_argument("--policy-checkpoint", default=None,
+                        help="Initial policy/value weights (e.g. from the "
+                             "issue #26 pre-training run).")
+    parser.add_argument("--policy-hidden-dim", type=int, default=160)
+    parser.add_argument("--transition-checkpoint", default=None,
+                        help="Initial transition-model weights (issue #27).")
+    parser.add_argument("--transition-hidden-dim", type=int, default=128)
+    parser.add_argument("--retrain-transition", action="store_true",
+                        help="Refit the transition model on all stored "
+                             "examples each iteration.")
+    parser.add_argument("--no-search", action="store_true",
+                        help="Collect and evaluate with the raw policy "
+                             "instead of MCTS-improved actions.")
+    parser.add_argument("--episode-budget", type=float, default=None,
+                        help="Optional per-episode cost ceiling in USD.")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.WARNING if args.quiet else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    offline = bool(args.episodes_parquet)
+
+    policy, transition = load_models(args)
+
+    trainer_config = MCTSTrainerConfig(
+        collect_with_search=not args.no_search,
+        eval_with_search=not args.no_search,
+        retrain_transition=args.retrain_transition,
+        max_turns=args.max_turns,
+        seed=args.seed,
+    )
+    pipeline = TrainingDataPipeline(max_turns=args.max_turns)
+
+    offline_episodes: list[Episode] | None = None
+    runner = None
+    cost_tracker = None
+    train_tasks: list[ResearchQATask] = []
+    eval_tasks: list[ResearchQATask] = []
+    hyper = (
+        HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
+    ).with_env_overrides()
+
+    if offline:
+        offline_episodes = []
+        for path in args.episodes_parquet:
+            offline_episodes.extend(episodes_from_parquet(path))
+        logger.info(
+            "Offline mode: %d episodes from %d parquet file(s); collection "
+            "and held-out evaluation are skipped",
+            len(offline_episodes), len(args.episodes_parquet),
+        )
+    else:
+        runner, cost_tracker = build_runner(args, hyper)
+        dataset = ResearchQADataset()
+        eval_tasks = select_eval_tasks(dataset, args.eval_tasks)
+        held_out = {t.task_id for t in eval_tasks}
+        train_tasks = [t for t in dataset.tasks() if t.task_id not in held_out]
+        logger.info(
+            "Live mode: %d collection tasks, %d held-out eval tasks",
+            len(train_tasks), len(eval_tasks),
+        )
+
+    trainer = MCTSTrainer(
+        policy,
+        transition,
+        checkpoint_dir=output_dir,
+        config=trainer_config,
+        runner=runner,
+        train_tasks=train_tasks,
+        eval_tasks=eval_tasks,
+        heuristic_factory=hyper.to_heuristic_controller,
+        pipeline=pipeline,
+    )
+
+    start = time.perf_counter()
+    for _ in range(args.iterations):
+        metrics = trainer.run_iteration(
+            args.episodes_per_iteration,
+            args.simulations,
+            episodes=offline_episodes,
+        )
+        line = (
+            f"iteration {metrics.iteration}: loss={metrics.train_loss:.4f} "
+            f"entropy={metrics.policy_entropy:.3f} "
+            f"kl_from_heuristic={metrics.kl_from_heuristic:.4f} "
+            f"agreement={metrics.heuristic_agreement:.3f} "
+            f"eval={metrics.eval_score} heuristic={metrics.heuristic_eval_score}"
+        )
+        sys.stdout.write(line + "\n")
+    total_seconds = time.perf_counter() - start
+
+    sys.stdout.write(
+        f"completed {args.iterations} iteration(s) in {total_seconds:.1f}s; "
+        f"checkpoints + metrics_history.json under {output_dir}\n"
+    )
+    if cost_tracker is not None:
+        report = cost_tracker.get_total()
+        sys.stdout.write(
+            f"session API cost: ${report.total:.4f} across {report.call_count} calls\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -38,8 +38,8 @@ from bicameral_agent.dataset import (
 )
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.mcts_trainer import MCTSTrainer, MCTSTrainerConfig
-from bicameral_agent.model_client import build_client, default_model, provider_names
 from bicameral_agent.policy_value_net import PolicyValueNetwork
+from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_from_parquet
 from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
@@ -102,28 +102,7 @@ def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeR
     if args.episode_budget is not None:
         cost_tracker.set_episode_budget(args.episode_budget)
 
-    provider = args.provider or hyper.model.provider
-    model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
-    client = build_client(provider, model)
-
-    measurement = hyper.measurement_model
-    judge_provider = args.judge_provider or (
-        measurement.provider if measurement is not None else "gemini"
-    )
-    judge_model = args.judge_model or (
-        measurement.name
-        if measurement is not None and judge_provider == measurement.provider
-        else None
-    )
-    resolved_judge_model = judge_model or default_model(judge_provider)
-    if judge_provider == provider and resolved_judge_model == client.model:
-        judge_client = client
-    else:
-        judge_client = build_client(judge_provider, judge_model)
-    logger.info(
-        "Answerer: %s/%s; measurement (judge + sim-user): %s/%s",
-        provider, client.model, judge_provider, judge_client.model,
-    )
+    client, judge_client, _provenance = resolve_runner_clients(args, hyper)
 
     runner = EpisodeRunner(
         client,
@@ -143,21 +122,7 @@ def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeR
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default="data/mcts_training")
-    parser.add_argument("--config", default=None,
-                        help="Hyperparameter TOML file (defaults to the bundled "
-                             "config; BICAMERAL_ env overrides always apply, "
-                             "CLI flags win over both).")
-    parser.add_argument("--provider", choices=list(provider_names()), default=None,
-                        help="Model backend for episode collection/evaluation "
-                             "(overrides the config file).")
-    parser.add_argument("--model", default=None,
-                        help="Model id/tag (overrides the config file).")
-    parser.add_argument("--judge-provider", choices=list(provider_names()),
-                        default=None,
-                        help="Model backend for the measurement roles (LLM "
-                             "judge and simulated user).")
-    parser.add_argument("--judge-model", default=None,
-                        help="Measurement model id/tag.")
+    add_model_args(parser)
     parser.add_argument("--metric", default="llm_judge",
                         help="Verification metric used to score episodes.")
     parser.add_argument("--iterations", type=int, default=10)
@@ -187,8 +152,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-search", action="store_true",
                         help="Collect and evaluate with the raw policy "
                              "instead of MCTS-improved actions.")
-    parser.add_argument("--episode-budget", type=float, default=None,
-                        help="Optional per-episode cost ceiling in USD.")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -292,7 +292,15 @@ class EpisodeRunner:
                 predicted_latencies=predicted_latencies,
             )
 
-            # (i) Controller decides
+            # (i) Controller decides. Controllers that encode the full
+            # episode context at decision time (LearnedPolicyController,
+            # issue #29) expose an ``observe_episode`` hook; give them a
+            # snapshot of everything logged so far, which at this point
+            # ends with the current assistant message — exactly the last
+            # decision point a post-hoc EpisodeReplayer would yield.
+            observe = getattr(controller, "observe_episode", None)
+            if observe is not None:
+                observe(log.snapshot())
             action = controller.decide(state)
 
             # Set when a cost-budget trip mid-turn must end the episode after

--- a/src/bicameral_agent/learned_controller.py
+++ b/src/bicameral_agent/learned_controller.py
@@ -1,0 +1,241 @@
+"""Learned-policy controller for the episode runner (issue #29).
+
+Wraps a policy/value network — optionally improved by
+:class:`~bicameral_agent.mcts.MCTSEngine` search — as a
+:class:`~bicameral_agent.episode_runner.Controller`, so the EpisodeRunner
+can collect episodes with the current learned policy.
+
+Encode-at-decision-time (train/serve consistency)
+-------------------------------------------------
+Training states are 108-dim vectors built by
+:class:`~bicameral_agent.training_pipeline.TrainingDataPipeline` from
+*replayed* episodes: each decision point is an assistant message, and its
+state is everything logged strictly before that message. To guarantee the
+network sees the same encoding at serve time, this controller does not
+derive features from the (much thinner)
+:class:`~bicameral_agent.heuristic_controller.FullState` the runner passes
+to ``decide``. Instead the runner hands it a live episode snapshot via
+:meth:`observe_episode` (``ConversationLogger.snapshot()``), and the
+controller replays that snapshot with the *same*
+:class:`~bicameral_agent.replay.EpisodeReplayer` +
+``TrainingDataPipeline.build_state_vector`` code path the pipeline uses:
+the snapshot's last decision point is exactly the decision being made now.
+
+With the default BREAKPOINT injection mode this yields bit-identical
+vectors to the ones the pipeline later builds from the finalized episode.
+The SYNCHRONOUS/INTERRUPT modes can regenerate the assistant message after
+the decision (``replace_last_message`` moves its timestamp past this
+turn's tool events), which shifts the post-hoc cutoff; the serve-time
+encoding then reflects the state actually seen at decision time.
+
+Action selection
+----------------
+- Raw-policy mode (``mcts_engine=None``): the network's action
+  probabilities are the decision distribution.
+- MCTS mode: ``mcts_engine.search`` (with the configured simulation
+  budget and optional root Dirichlet noise) produces the visit-count
+  distribution.
+
+Either distribution is then reduced to an action: greedy argmax when
+``temperature == 0`` (evaluation), else a sample from
+``dist ** (1 / temperature)`` (training-time exploration), drawn from a
+private seeded numpy generator so decisions are reproducible.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from bicameral_agent.heuristic_controller import (
+    Action,
+    DecisionLoggingController,
+    FullState,
+)
+from bicameral_agent.mcts import MCTSEngine, SupportsPolicyValue
+from bicameral_agent.replay import DecisionPoint, EpisodeReplayer
+from bicameral_agent.schema import Episode
+from bicameral_agent.training_pipeline import (
+    _ACTION_ORDER,  # cross-checked identical to policy_value_net.ACTION_ORDER
+    STATE_DIM,
+    TrainingDataPipeline,
+)
+
+logger = logging.getLogger(__name__)
+
+LEARNED_RULE_ID: int = 0
+"""``DecisionLog.rule_fired`` value for learned decisions (no rule fired;
+matches the RandomController convention)."""
+
+
+class LearnedPolicyController(DecisionLoggingController):
+    """Policy-network controller (optionally MCTS-improved) for EpisodeRunner.
+
+    Parameters
+    ----------
+    policy_value_net:
+        Network with a ``predict(state) -> (probs, value)`` method over
+        the 108-dim pipeline state (construct
+        ``PolicyValueNetwork(input_dim=STATE_DIM)``). Used directly in
+        raw-policy mode; in MCTS mode the engine holds its own reference,
+        but this one is kept for diagnostics.
+    mcts_engine:
+        Optional :class:`MCTSEngine`. When given, decisions use the
+        engine's visit-count distribution instead of the raw policy.
+    num_simulations:
+        Search budget per decision in MCTS mode.
+    add_root_noise:
+        Mix Dirichlet noise into the root priors in MCTS mode
+        (training-time exploration; leave off for evaluation).
+    temperature:
+        0 (default) selects the argmax action; > 0 samples from
+        ``dist ** (1 / temperature)``.
+    pipeline:
+        The :class:`TrainingDataPipeline` used to encode decision states.
+        Pass the same encoder/latency-model/max_turns configuration used
+        when processing episodes for training. Defaults to a fresh
+        pipeline with default components (matching how episodes are
+        processed by default).
+    seed:
+        Seed for the private sampling generator (only consumed when
+        ``temperature > 0``).
+    """
+
+    def __init__(
+        self,
+        policy_value_net: SupportsPolicyValue,
+        *,
+        mcts_engine: MCTSEngine | None = None,
+        num_simulations: int = 50,
+        add_root_noise: bool = False,
+        temperature: float = 0.0,
+        pipeline: TrainingDataPipeline | None = None,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__()
+        input_dim = getattr(policy_value_net, "input_dim", None)
+        if input_dim is not None and input_dim != STATE_DIM:
+            msg = (
+                f"policy_value_net.input_dim must be STATE_DIM ({STATE_DIM}) "
+                f"to consume pipeline states, got {input_dim} "
+                "(construct the network with input_dim=STATE_DIM)"
+            )
+            raise ValueError(msg)
+        if num_simulations < 1:
+            msg = f"num_simulations must be >= 1, got {num_simulations}"
+            raise ValueError(msg)
+        if temperature < 0.0:
+            msg = f"temperature must be >= 0, got {temperature}"
+            raise ValueError(msg)
+
+        self._policy = policy_value_net
+        self._engine = mcts_engine
+        self._num_simulations = num_simulations
+        self._add_root_noise = add_root_noise
+        self._temperature = temperature
+        self._pipeline = pipeline or TrainingDataPipeline()
+        self._rng = np.random.default_rng(seed)
+        self._snapshot: Episode | None = None
+        self._encoded_states: list[np.ndarray] = []
+        self._distributions: list[np.ndarray] = []
+
+    # ------------------------------------------------------------------
+    # EpisodeRunner integration
+    # ------------------------------------------------------------------
+
+    def observe_episode(self, snapshot: Episode) -> None:
+        """Receive the live episode snapshot for the next ``decide`` call.
+
+        The EpisodeRunner calls this immediately before ``decide`` with
+        ``ConversationLogger.snapshot()``; the snapshot must end with the
+        assistant message of the decision being made.
+        """
+        self._snapshot = snapshot
+
+    def decide(self, state: FullState) -> Action:
+        """Encode the current decision point and select an action."""
+        vec = self._encode_decision_point(state)
+        distribution = self._action_distribution(vec)
+
+        idx = self._select_index(distribution)
+        action = _ACTION_ORDER[idx]
+
+        self._encoded_states.append(vec)
+        self._distributions.append(distribution.astype(np.float32))
+        self._record_decision(action, LEARNED_RULE_ID, state)
+        logger.debug(
+            "learned action=%s turn=%d dist=%s",
+            action.value,
+            state.turn_number,
+            np.round(distribution, 3),
+        )
+        return action
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    @property
+    def encoded_states(self) -> list[np.ndarray]:
+        """Copies of the 108-dim state vectors encoded at each decision."""
+        return [s.copy() for s in self._encoded_states]
+
+    @property
+    def distributions(self) -> list[np.ndarray]:
+        """Copies of the action distribution used at each decision."""
+        return [d.copy() for d in self._distributions]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _encode_decision_point(self, state: FullState) -> np.ndarray:
+        """Build the pipeline state vector for the current decision."""
+        if self._snapshot is None:
+            msg = (
+                "LearnedPolicyController.decide called without an episode "
+                "snapshot; it must run under an EpisodeRunner (which calls "
+                "observe_episode before each decision)"
+            )
+            raise RuntimeError(msg)
+
+        dp = self._last_decision_point(self._snapshot)
+        if dp is None:
+            msg = "episode snapshot contains no assistant message to decide on"
+            raise RuntimeError(msg)
+        if dp.state.turn_number != state.turn_number:
+            msg = (
+                f"snapshot decision point is at turn {dp.state.turn_number} "
+                f"but the runner reports turn {state.turn_number}; the "
+                "snapshot is stale"
+            )
+            raise RuntimeError(msg)
+        return self._pipeline.build_state_vector(dp.state, dp.action.timestamp_ms)
+
+    @staticmethod
+    def _last_decision_point(snapshot: Episode) -> DecisionPoint | None:
+        last: DecisionPoint | None = None
+        for dp in EpisodeReplayer(snapshot).iter_decision_points():
+            last = dp
+        return last
+
+    def _action_distribution(self, vec: np.ndarray) -> np.ndarray:
+        if self._engine is not None:
+            result = self._engine.search(
+                vec,
+                num_simulations=self._num_simulations,
+                add_root_noise=self._add_root_noise,
+            )
+            return np.asarray(result.action_distribution, dtype=np.float64)
+        probs, _value = self._policy.predict(vec)
+        return np.asarray(probs, dtype=np.float64)
+
+    def _select_index(self, distribution: np.ndarray) -> int:
+        if self._temperature == 0.0:
+            return int(np.argmax(distribution))
+        scaled = np.power(distribution, 1.0 / self._temperature)
+        total = scaled.sum()
+        if total <= 0.0 or not np.isfinite(total):  # degenerate distribution
+            return int(np.argmax(distribution))
+        return int(self._rng.choice(len(scaled), p=scaled / total))

--- a/src/bicameral_agent/logger.py
+++ b/src/bicameral_agent/logger.py
@@ -251,6 +251,41 @@ class ConversationLogger:
                 update={"consumed": True, "consumed_at_turn": turn_number}
             )
 
+    def snapshot(self) -> Episode:
+        """Return a non-finalizing Episode view of everything logged so far.
+
+        Used by controllers that need the live episode context at decision
+        time (issue #29): the returned Episode contains the messages, user
+        events, context injections, and *completed* tool invocations logged
+        so far — the same records a post-hoc
+        :class:`~bicameral_agent.replay.EpisodeReplayer` would see at this
+        point. Pending (started, uncompleted) tool invocations are excluded,
+        matching how they would appear mid-flight. The outcome carries
+        placeholder totals; it exists only to satisfy the Episode schema.
+
+        Does not finalize: logging can continue afterwards.
+        """
+        with self._lock:
+            tool_invocations = [
+                t
+                for _, t in sorted(
+                    self._tool_invocations, key=lambda pair: (pair[1].invoked_at_ms, pair[0])
+                )
+            ]
+            return Episode(
+                messages=list(self._messages),
+                user_events=list(self._user_events),
+                context_injections=list(self._context_injections),
+                tool_invocations=tool_invocations,
+                outcome=EpisodeOutcome(
+                    quality_score=None,
+                    total_tokens=0,
+                    total_turns=sum(1 for m in self._messages if m.role == "user"),
+                    wall_clock_ms=0,
+                ),
+                metadata=dict(self._metadata),
+            )
+
     def finalize(self, quality_score: float | None = None) -> Episode:
         """Finalize the episode and return a validated Episode object.
 

--- a/src/bicameral_agent/mcts_trainer.py
+++ b/src/bicameral_agent/mcts_trainer.py
@@ -1,0 +1,609 @@
+"""MCTS training loop: the self-improvement cycle of issue #29.
+
+Each :meth:`MCTSTrainer.run_iteration` performs:
+
+1. **Collect** ``n_episodes`` episodes with the current policy via
+   :class:`~bicameral_agent.episode_runner.EpisodeRunner` +
+   :class:`~bicameral_agent.learned_controller.LearnedPolicyController`
+   (or consumes pre-collected episodes for offline runs).
+2. **Targets**: run :class:`~bicameral_agent.mcts.MCTSEngine` search on
+   every decision-point state; the normalized visit counts are the
+   improved policy targets.
+3. **Train**: policy head cross-entropy against the MCTS visit
+   distributions (soft targets), value head MSE against the pipeline's
+   discounted returns.
+4. Optionally **retrain the transition model** on all stored examples.
+5. **Evaluate** the updated policy against the heuristic baseline on
+   held-out tasks (requires a live runner; skipped offline).
+6. **Checkpoint** the networks and metrics; append to the metrics
+   history JSON.
+
+Live acceptance criteria (monotonic eval improvement, KL shift from the
+heuristic, no catastrophic forgetting, entropy convergence, budget) are
+data/LLM-dependent: this module implements their *measurement* — every
+iteration records training loss, policy entropy, value accuracy, eval
+scores (overall and per difficulty), and KL/agreement vs the heuristic —
+so the criteria can be verified from ``metrics_history.json`` once live
+training data exists (post-#46). Verification itself is pending.
+
+Determinism: for a fixed config seed, fixed initial weights, and a fixed
+episode list, an iteration is fully reproducible — MCTS noise, batch
+shuffling, and collection-time sampling all draw from seeded generators,
+and no torch RNG is consumed (the networks have no stochastic layers).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Callable, Sequence
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from bicameral_agent.dataset import ResearchQATask
+from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.heuristic_controller import FullState, HeuristicController
+from bicameral_agent.learned_controller import LearnedPolicyController
+from bicameral_agent.mcts import MCTSEngine
+from bicameral_agent.policy_value_net import NUM_ACTIONS, PolicyValueNetwork
+from bicameral_agent.pretrain import evaluate_policy_value
+from bicameral_agent.replay import EpisodeReplayer
+from bicameral_agent.schema import Episode
+from bicameral_agent.serialization import episodes_to_parquet
+from bicameral_agent.signal_classifier import SignalClassifier
+from bicameral_agent.training_data_store import TrainingDataStore
+from bicameral_agent.training_pipeline import (
+    _ACTION_INDEX,  # shared action indexing (cross-checked with ACTION_ORDER)
+    STATE_DIM,
+    TrainingDataPipeline,
+    TrainingExample,
+)
+from bicameral_agent.transition_model import (
+    TransitionModel,
+    TransitionTrainingConfig,
+    fit_transition_model,
+    split_examples,
+)
+
+logger = logging.getLogger(__name__)
+
+_HISTORY_FILENAME = "metrics_history.json"
+_EPS = 1e-8  # smoothing for entropy logs
+_KL_SMOOTHING = 1e-3
+"""Additive smoothing for the policy/heuristic action marginals before the
+KL divergence. Larger than machine epsilon on purpose: actions the
+deterministic heuristic never takes would otherwise contribute
+``log(p / eps)`` terms that dwarf the actual distribution shift the
+"KL from heuristic increases" AC tracks."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MCTSTrainerConfig:
+    """Hyperparameters for :class:`MCTSTrainer`.
+
+    ``max_turns`` must match the ``EpisodeConfig.max_turns`` used by the
+    runner so the pipeline's completion-fraction features are consistent
+    between collection and training.
+    """
+
+    epochs: int = 50
+    batch_size: int = 64
+    learning_rate: float = 1e-3
+    value_loss_weight: float = 0.5
+    collect_with_search: bool = True
+    collect_temperature: float = 1.0
+    collect_root_noise: bool = True
+    target_root_noise: bool = True
+    eval_with_search: bool = True
+    retrain_transition: bool = False
+    transition_config: TransitionTrainingConfig | None = None
+    train_ratio: float = 0.8
+    max_turns: int = 25
+    seed: int = 0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TrainingMetrics:
+    """Per-iteration metrics; JSON-serializable via :meth:`to_dict`.
+
+    ``eval_score`` / ``heuristic_eval_score`` / ``eval_scores_by_difficulty``
+    are *None* when no evaluation ran (offline mode). ``holdout`` is the
+    :func:`~bicameral_agent.pretrain.evaluate_policy_value` dict on the
+    episode-grouped validation split (*None* with fewer than 2 episodes).
+    """
+
+    iteration: int
+    n_episodes: int
+    n_examples: int
+    epoch_losses: list[dict[str, float]]
+    train_loss: float
+    train_policy_loss: float
+    train_value_loss: float
+    policy_entropy: float
+    value_mse: float
+    value_correlation: float | None
+    holdout: dict | None
+    kl_from_heuristic: float
+    heuristic_agreement: float
+    mcts_root_value_mean: float
+    eval_score: float | None
+    heuristic_eval_score: float | None
+    eval_scores_by_difficulty: dict[str, float] | None
+    transition_metrics: dict | None
+    collect_seconds: float
+    train_seconds: float
+    eval_seconds: float
+
+    def to_dict(self) -> dict:
+        """Plain-dict form for JSON serialization."""
+        return dataclasses.asdict(self)
+
+
+class MCTSTrainer:
+    """Self-improvement training loop over learned policy/value/transition models.
+
+    Parameters
+    ----------
+    policy_value_net:
+        The network being trained (``input_dim`` must be ``STATE_DIM``).
+    transition_model:
+        Environment model for MCTS search; replaced in place when
+        ``config.retrain_transition`` is set.
+    checkpoint_dir:
+        Root directory for per-iteration checkpoints, the metrics history,
+        and (by default) the training-data store.
+    runner, train_tasks, eval_tasks:
+        Live-collection dependencies. ``runner`` drives real episodes (its
+        client makes paid LLM calls); ``train_tasks`` feed collection and
+        ``eval_tasks`` the held-out evaluation. All optional: offline
+        iterations pass pre-collected ``episodes`` to
+        :meth:`run_iteration` instead.
+    heuristic_factory:
+        Zero-arg factory for the heuristic baseline controller (defaults
+        to a stock :class:`HeuristicController`).
+    pipeline:
+        Episode-to-example pipeline; defaults to one built with
+        ``config.max_turns``. The same pipeline instance is handed to the
+        learned controllers so serve-time encoding matches training.
+    store:
+        Append-only example store; defaults to ``checkpoint_dir / "store"``.
+    """
+
+    def __init__(
+        self,
+        policy_value_net: PolicyValueNetwork,
+        transition_model: TransitionModel,
+        *,
+        checkpoint_dir: str | Path,
+        config: MCTSTrainerConfig | None = None,
+        runner: EpisodeRunner | None = None,
+        train_tasks: Sequence[ResearchQATask] | None = None,
+        eval_tasks: Sequence[ResearchQATask] | None = None,
+        heuristic_factory: Callable[[], HeuristicController] | None = None,
+        pipeline: TrainingDataPipeline | None = None,
+        store: TrainingDataStore | None = None,
+    ) -> None:
+        if policy_value_net.input_dim != STATE_DIM:
+            msg = (
+                f"policy_value_net.input_dim must be STATE_DIM ({STATE_DIM}), "
+                f"got {policy_value_net.input_dim}"
+            )
+            raise ValueError(msg)
+        self._policy = policy_value_net
+        self._transition = transition_model
+        self._config = config or MCTSTrainerConfig()
+        self._checkpoint_dir = Path(checkpoint_dir)
+        self._checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        self._runner = runner
+        self._train_tasks = list(train_tasks) if train_tasks else []
+        self._eval_tasks = list(eval_tasks) if eval_tasks else []
+        self._heuristic_factory = heuristic_factory or HeuristicController
+        self._pipeline = pipeline or TrainingDataPipeline(max_turns=self._config.max_turns)
+        self._store = store or TrainingDataStore(self._checkpoint_dir / "store")
+        self._history_path = self._checkpoint_dir / _HISTORY_FILENAME
+        self._iteration = len(self._load_history())
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def iteration(self) -> int:
+        """Index of the next iteration (== completed iterations so far)."""
+        return self._iteration
+
+    @property
+    def transition_model(self) -> TransitionModel:
+        """The current transition model (replaced by retraining)."""
+        return self._transition
+
+    def run_iteration(
+        self,
+        n_episodes: int,
+        n_simulations: int,
+        episodes: Sequence[Episode] | None = None,
+    ) -> TrainingMetrics:
+        """Run one collect → target → train → evaluate → checkpoint cycle.
+
+        Parameters
+        ----------
+        n_episodes:
+            Number of episodes to collect with the current policy.
+            Ignored when ``episodes`` is given.
+        n_simulations:
+            MCTS budget per decision point, used for target generation
+            and (per config) for search-based collection and evaluation.
+        episodes:
+            Pre-collected episodes for offline iterations. When given, no
+            collection happens and ``runner``/``train_tasks`` are not
+            required.
+
+        Raises
+        ------
+        ValueError
+            If a live collection is requested without a runner and train
+            tasks, or if the episodes yield no training examples.
+        """
+        cfg = self._config
+        iteration = self._iteration
+        base_seed = cfg.seed + 1000 * iteration
+
+        collect_start = time.perf_counter()
+        collected_live = episodes is None
+        if episodes is None:
+            if self._runner is None or not self._train_tasks:
+                msg = (
+                    "live collection needs a runner and train_tasks; pass "
+                    "pre-collected episodes for offline iterations"
+                )
+                raise ValueError(msg)
+            episodes = self._collect(n_episodes, n_simulations, base_seed)
+        episodes = list(episodes)
+        collect_seconds = time.perf_counter() - collect_start
+        if collected_live:
+            # Live episodes are expensive; persist them for offline reuse.
+            episodes_dir = self._checkpoint_dir / "episodes"
+            episodes_dir.mkdir(parents=True, exist_ok=True)
+            episodes_to_parquet(
+                episodes, str(episodes_dir / f"iteration-{iteration:03d}.parquet")
+            )
+
+        examples = self._pipeline.process_episodes(episodes)
+        if not examples:
+            msg = "episodes produced no training examples"
+            raise ValueError(msg)
+        self._store.save_examples(
+            examples,
+            iteration,
+            metadata={"controller": "learned_policy", "n_episodes": len(episodes)},
+        )
+
+        targets, root_values = self.build_mcts_targets(
+            examples, n_simulations, seed=base_seed + 1
+        )
+
+        train_start = time.perf_counter()
+        epoch_losses = self._train(examples, targets, seed=base_seed + 2)
+        transition_metrics: dict | None = None
+        if cfg.retrain_transition:
+            transition_metrics = self._retrain_transition()
+        train_seconds = time.perf_counter() - train_start
+
+        # Post-training measurements on the collected decision points.
+        states = torch.from_numpy(np.stack([e.state for e in examples])).float()
+        policy_entropy = self._policy_entropy(states)
+        kl_from_heuristic, heuristic_agreement = self._heuristic_comparison(
+            episodes, states
+        )
+        value_metrics = self._value_metrics(examples)
+
+        eval_start = time.perf_counter()
+        eval_score, heuristic_eval_score, by_difficulty = self._evaluate(
+            n_simulations, base_seed + 3
+        )
+        eval_seconds = time.perf_counter() - eval_start
+
+        metrics = TrainingMetrics(
+            iteration=iteration,
+            n_episodes=len(episodes),
+            n_examples=len(examples),
+            epoch_losses=epoch_losses,
+            train_loss=epoch_losses[-1]["total"],
+            train_policy_loss=epoch_losses[-1]["policy"],
+            train_value_loss=epoch_losses[-1]["value"],
+            policy_entropy=policy_entropy,
+            value_mse=value_metrics["value_mse"],
+            value_correlation=value_metrics["value_correlation"],
+            holdout=value_metrics["holdout"],
+            kl_from_heuristic=kl_from_heuristic,
+            heuristic_agreement=heuristic_agreement,
+            mcts_root_value_mean=float(np.mean(root_values)),
+            eval_score=eval_score,
+            heuristic_eval_score=heuristic_eval_score,
+            eval_scores_by_difficulty=by_difficulty,
+            transition_metrics=transition_metrics,
+            collect_seconds=collect_seconds,
+            train_seconds=train_seconds,
+            eval_seconds=eval_seconds,
+        )
+
+        self._checkpoint(metrics)
+        self._iteration += 1
+        return metrics
+
+    def build_mcts_targets(
+        self,
+        examples: Sequence[TrainingExample],
+        n_simulations: int,
+        seed: int = 0,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """MCTS-improved action targets for every example state.
+
+        Returns ``(distributions, root_values)`` with shapes
+        ``(n, NUM_ACTIONS)`` and ``(n,)`` (float32). Deterministic for a
+        fixed seed and fixed model weights.
+        """
+        engine = self._make_engine(seed)
+        distributions = np.zeros((len(examples), NUM_ACTIONS), dtype=np.float32)
+        root_values = np.zeros(len(examples), dtype=np.float32)
+        for i, example in enumerate(examples):
+            result = engine.search(
+                example.state,
+                num_simulations=n_simulations,
+                add_root_noise=self._config.target_root_noise,
+            )
+            distributions[i] = result.action_distribution
+            root_values[i] = result.root_value
+        return distributions, root_values
+
+    # ------------------------------------------------------------------
+    # Collection / evaluation
+    # ------------------------------------------------------------------
+
+    def _make_engine(self, seed: int) -> MCTSEngine:
+        return MCTSEngine(self._policy, self._transition, seed=seed)
+
+    def _make_controller(
+        self, *, training: bool, n_simulations: int, seed: int
+    ) -> LearnedPolicyController:
+        cfg = self._config
+        with_search = cfg.collect_with_search if training else cfg.eval_with_search
+        return LearnedPolicyController(
+            self._policy,
+            mcts_engine=self._make_engine(seed) if with_search else None,
+            num_simulations=n_simulations,
+            add_root_noise=training and cfg.collect_root_noise,
+            temperature=cfg.collect_temperature if training else 0.0,
+            pipeline=self._pipeline,
+            seed=seed,
+        )
+
+    def _collect(
+        self, n_episodes: int, n_simulations: int, base_seed: int
+    ) -> list[Episode]:
+        if n_episodes < 1:
+            msg = f"n_episodes must be >= 1, got {n_episodes}"
+            raise ValueError(msg)
+        episodes: list[Episode] = []
+        for i in range(n_episodes):
+            task = self._train_tasks[i % len(self._train_tasks)]
+            controller = self._make_controller(
+                training=True, n_simulations=n_simulations, seed=base_seed + 10 + i
+            )
+            episodes.append(self._runner.run_episode(task, controller))
+            logger.info(
+                "collected episode %d/%d (task %s)", i + 1, n_episodes, task.task_id
+            )
+        return episodes
+
+    def _evaluate(
+        self, n_simulations: int, seed: int
+    ) -> tuple[float | None, float | None, dict[str, float] | None]:
+        """Mean quality of learned vs heuristic policy on held-out tasks."""
+        if self._runner is None or not self._eval_tasks:
+            return None, None, None
+
+        def _mean(scores: list[float]) -> float | None:
+            return float(np.mean(scores)) if scores else None
+
+        learned_scores: list[float] = []
+        by_difficulty: dict[str, list[float]] = {}
+        for i, task in enumerate(self._eval_tasks):
+            controller = self._make_controller(
+                training=False, n_simulations=n_simulations, seed=seed + i
+            )
+            episode = self._runner.run_episode(task, controller)
+            if episode.outcome.quality_score is not None:
+                learned_scores.append(episode.outcome.quality_score)
+                by_difficulty.setdefault(task.difficulty.value, []).append(
+                    episode.outcome.quality_score
+                )
+
+        heuristic_scores: list[float] = []
+        for task in self._eval_tasks:
+            episode = self._runner.run_episode(task, self._heuristic_factory())
+            if episode.outcome.quality_score is not None:
+                heuristic_scores.append(episode.outcome.quality_score)
+
+        difficulty_means = {
+            k: float(np.mean(v)) for k, v in sorted(by_difficulty.items())
+        }
+        return (
+            _mean(learned_scores),
+            _mean(heuristic_scores),
+            difficulty_means or None,
+        )
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def _train(
+        self,
+        examples: Sequence[TrainingExample],
+        targets: np.ndarray,
+        seed: int,
+    ) -> list[dict[str, float]]:
+        """Fit the policy head to MCTS targets and the value head to returns.
+
+        Soft-target cross-entropy: ``-(target * log_softmax(logits)).sum()``
+        averaged over the batch, plus ``value_loss_weight`` × MSE of the
+        value head against the discounted returns.
+        """
+        cfg = self._config
+        states = torch.from_numpy(np.stack([e.state for e in examples])).float()
+        returns = torch.tensor(
+            [e.discounted_return for e in examples], dtype=torch.float32
+        )
+        target_dists = torch.from_numpy(np.asarray(targets, dtype=np.float32))
+
+        optimizer = torch.optim.Adam(self._policy.parameters(), lr=cfg.learning_rate)
+        rng = np.random.default_rng(seed)
+        n = len(examples)
+
+        self._policy.train()
+        epoch_losses: list[dict[str, float]] = []
+        for _ in range(cfg.epochs):
+            perm = rng.permutation(n)
+            sums = {"total": 0.0, "policy": 0.0, "value": 0.0}
+            n_batches = 0
+            for lo in range(0, n, cfg.batch_size):
+                idx = torch.from_numpy(perm[lo : lo + cfg.batch_size])
+                logits, values = self._policy._shared_forward(states[idx])  # noqa: SLF001
+                policy_loss = -(
+                    target_dists[idx] * F.log_softmax(logits, dim=-1)
+                ).sum(dim=-1).mean()
+                value_loss = F.mse_loss(values, returns[idx])
+                loss = policy_loss + cfg.value_loss_weight * value_loss
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                sums["total"] += loss.item()
+                sums["policy"] += policy_loss.item()
+                sums["value"] += value_loss.item()
+                n_batches += 1
+            epoch_losses.append({k: v / n_batches for k, v in sums.items()})
+        self._policy.eval()
+        return epoch_losses
+
+    def _retrain_transition(self) -> dict:
+        """Refit the transition model on all stored examples."""
+        all_examples = self._store.load_examples()
+        result = fit_transition_model(
+            all_examples,
+            self._config.transition_config
+            or TransitionTrainingConfig(seed=self._config.seed),
+        )
+        self._transition = result.model
+        return {
+            "n_train": result.n_train,
+            "n_val": result.n_val,
+            "state_mse_per_dim_mean": result.metrics.get("state_mse_per_dim_mean"),
+            "reward_mse": result.metrics.get("reward_mse"),
+            "reward_correlation": result.metrics.get("reward_correlation"),
+        }
+
+    # ------------------------------------------------------------------
+    # Measurement
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def _policy_entropy(self, states: torch.Tensor) -> float:
+        """Mean policy entropy (nats) over the given states."""
+        probs, _ = self._policy(states)
+        entropy = -(probs * torch.log(probs + _EPS)).sum(dim=-1)
+        return float(entropy.mean())
+
+    def _value_metrics(self, examples: list[TrainingExample]) -> dict:
+        """Value accuracy on the episode-grouped holdout split when possible."""
+        holdout: dict | None = None
+        eval_examples = examples
+        if len({e.episode_id for e in examples}) >= 2:
+            _, val = split_examples(examples, self._config.train_ratio, self._config.seed)
+            holdout = evaluate_policy_value(
+                self._policy, val, self._config.value_loss_weight
+            )
+            eval_examples = val
+        in_sample = evaluate_policy_value(
+            self._policy, list(eval_examples), self._config.value_loss_weight
+        )
+        return {
+            "value_mse": in_sample["value_mse"],
+            "value_correlation": in_sample["value_correlation"],
+            "holdout": holdout,
+        }
+
+    @torch.no_grad()
+    def _heuristic_comparison(
+        self, episodes: Sequence[Episode], states: torch.Tensor
+    ) -> tuple[float, float]:
+        """(KL, agreement) between the trained policy and the heuristic.
+
+        The heuristic decides on FullStates reconstructed from each
+        episode's decision points; the policy's distributions come from
+        the pipeline states for the same points (``states`` row order
+        matches ``process_episodes``). KL is computed between the
+        policy's mean action distribution and the heuristic's empirical
+        action frequencies (with light smoothing); agreement is the
+        fraction of decision points where the policy argmax matches the
+        heuristic's action. Tracking measures the "distributions shift
+        away from the heuristic" AC over iterations.
+        """
+        heuristic_actions: list[int] = []
+        for episode in episodes:
+            controller = self._heuristic_factory()
+            for dp in EpisodeReplayer(episode).iter_decision_points():
+                signals = SignalClassifier.classify(
+                    list(dp.state.messages), list(dp.state.user_events)
+                )
+                full_state = FullState(
+                    turn_number=dp.state.turn_number,
+                    stop_count=signals.stop_count.value,
+                    followup_type=signals.followup_type,
+                    queue_depth=len(dp.state.pending_injections),
+                    executing_tools=(),
+                    predicted_latencies={},
+                )
+                heuristic_actions.append(_ACTION_INDEX[controller.decide(full_state)])
+
+        probs, _ = self._policy(states)
+        probs_np = probs.numpy()
+        actions = np.asarray(heuristic_actions, dtype=np.int64)
+
+        agreement = float(np.mean(probs_np.argmax(axis=1) == actions))
+
+        policy_marginal = probs_np.mean(axis=0).astype(np.float64) + _KL_SMOOTHING
+        policy_marginal /= policy_marginal.sum()
+        heuristic_marginal = (
+            np.bincount(actions, minlength=NUM_ACTIONS).astype(np.float64) / len(actions)
+            + _KL_SMOOTHING
+        )
+        heuristic_marginal /= heuristic_marginal.sum()
+        kl = float(np.sum(policy_marginal * np.log(policy_marginal / heuristic_marginal)))
+        return kl, agreement
+
+    # ------------------------------------------------------------------
+    # Checkpointing
+    # ------------------------------------------------------------------
+
+    def _checkpoint(self, metrics: TrainingMetrics) -> None:
+        it_dir = self._checkpoint_dir / f"iteration-{metrics.iteration:03d}"
+        it_dir.mkdir(parents=True, exist_ok=True)
+        self._policy.save(it_dir / "policy_value.pt")
+        self._transition.save(it_dir / "transition.pt")
+        (it_dir / "metrics.json").write_text(
+            json.dumps(metrics.to_dict(), indent=2), encoding="utf-8"
+        )
+        history = self._load_history()
+        history.append(metrics.to_dict())
+        self._history_path.write_text(json.dumps(history, indent=2), encoding="utf-8")
+
+    def _load_history(self) -> list[dict]:
+        if not self._history_path.exists():
+            return []
+        return json.loads(self._history_path.read_text(encoding="utf-8"))

--- a/src/bicameral_agent/runner_setup.py
+++ b/src/bicameral_agent/runner_setup.py
@@ -1,0 +1,97 @@
+"""Shared CLI flags and client resolution for episode-running scripts.
+
+``scripts/run_baseline_benchmark.py`` and ``scripts/train_mcts.py`` both
+need the same model/provider flags and the same answerer/measurement
+client resolution (provider precedence, the issue #53 measurement-pinning
+rule, and the judge-client-reuse optimization). This module is the single
+home for that logic so the two scripts cannot drift (PR #79 review).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from bicameral_agent.config import HyperConfig
+from bicameral_agent.model_client import (
+    ModelClient,
+    build_client,
+    default_model,
+    provider_names,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def add_model_args(parser: argparse.ArgumentParser) -> None:
+    """Register the model/provider flags shared by episode-running CLIs.
+
+    Adds ``--config``, ``--provider``, ``--model``, ``--judge-provider``,
+    ``--judge-model`` and ``--episode-budget``; consume them with
+    :func:`resolve_runner_clients`.
+    """
+    parser.add_argument("--config", default=None,
+                        help="Hyperparameter TOML file (defaults to the bundled "
+                             "config; BICAMERAL_ env overrides always apply, "
+                             "CLI flags win over both).")
+    parser.add_argument("--provider", choices=list(provider_names()), default=None,
+                        help="Model backend to run the answerer against "
+                             "(overrides the config file).")
+    parser.add_argument("--model", default=None,
+                        help="Model id/tag (overrides the config file).")
+    parser.add_argument("--judge-provider", choices=list(provider_names()),
+                        default=None,
+                        help="Model backend for the measurement roles (LLM "
+                             "judge and simulated user), held fixed while "
+                             "--provider varies. Defaults to the config's "
+                             "[measurement_model], else gemini.")
+    parser.add_argument("--judge-model", default=None,
+                        help="Measurement model id/tag (overrides the config "
+                             "file; unset uses the judge provider's default).")
+    parser.add_argument("--episode-budget", type=float, default=None,
+                        help="Optional per-episode cost ceiling in USD.")
+
+
+def resolve_runner_clients(
+    args: argparse.Namespace, hyper: HyperConfig
+) -> tuple[ModelClient, ModelClient, dict[str, dict[str, str]]]:
+    """Resolve the answerer and measurement clients from CLI args + config.
+
+    Precedence for both roles: CLI > config > provider default; a
+    configured model name only applies to its configured provider. The
+    measurement roles (LLM judge + simulated user) are pinned
+    independently of the answerer so cross-model comparisons stay on one
+    judging scale (issue #53); when they resolve to the answerer's exact
+    provider/model, the answerer's client instance is reused.
+
+    Returns ``(client, judge_client, provenance)`` where ``provenance`` is
+    ``{"answerer": {"provider", "model"}, "measurement": {...}}`` for
+    reports and logging.
+    """
+    provider = args.provider or hyper.model.provider
+    model = args.model or (hyper.model.name if provider == hyper.model.provider else None)
+    client = build_client(provider, model)
+
+    measurement = hyper.measurement_model
+    judge_provider = args.judge_provider or (
+        measurement.provider if measurement is not None else "gemini"
+    )
+    judge_model = args.judge_model or (
+        measurement.name
+        if measurement is not None and judge_provider == measurement.provider
+        else None
+    )
+    resolved_judge_model = judge_model or default_model(judge_provider)
+    if judge_provider == provider and resolved_judge_model == client.model:
+        judge_client = client
+    else:
+        judge_client = build_client(judge_provider, judge_model)
+    logger.info(
+        "Answerer: %s/%s; measurement (judge + sim-user): %s/%s",
+        provider, client.model, judge_provider, judge_client.model,
+    )
+    provenance = {
+        "answerer": {"provider": provider, "model": client.model},
+        "measurement": {"provider": judge_provider, "model": judge_client.model},
+    }
+    return client, judge_client, provenance

--- a/src/bicameral_agent/training_pipeline.py
+++ b/src/bicameral_agent/training_pipeline.py
@@ -245,7 +245,7 @@ class TrainingDataPipeline:
         # Build state vectors and per-step rewards
         n = len(decision_points)
         states = [
-            self._build_state_vector(dp.state, dp.action)
+            self.build_state_vector(dp.state, dp.action.timestamp_ms)
             for dp in decision_points
         ]
         next_states = [
@@ -319,16 +319,21 @@ class TrainingDataPipeline:
     # State vector construction
     # ------------------------------------------------------------------
 
-    def _build_state_vector(
+    def build_state_vector(
         self,
         state: ReplayState,
-        action_msg: Message,
+        cutoff_ms: int,
     ) -> np.ndarray:
         """Build the 108-dim state vector at a decision point.
 
-        ``state`` reflects everything before ``action_msg`` (the assistant
-        message about to be produced). No information from after
-        ``action_msg.timestamp_ms`` is used.
+        ``state`` reflects everything before the decision (the assistant
+        message about to be produced); ``cutoff_ms`` is that message's
+        timestamp. No information from after ``cutoff_ms`` is used.
+
+        Public so the serve-time
+        :class:`~bicameral_agent.learned_controller.LearnedPolicyController`
+        can encode live decision points with the exact code path used to
+        build training states (train/serve consistency, issue #29).
         """
         vec = np.zeros(STATE_DIM, dtype=np.float32)
 
@@ -336,7 +341,7 @@ class TrainingDataPipeline:
         user_events = list(state.user_events)
         tool_history = list(state.completed_tool_invocations)
         queue_snapshot = self._reconstruct_queue_state(
-            state.pending_injections, action_msg.timestamp_ms
+            state.pending_injections, cutoff_ms
         )
 
         # Latency context features need ContextFeatures from the
@@ -380,7 +385,7 @@ class TrainingDataPipeline:
 
         # 94–96: time since each of the last 3 invocations
         vec[_OFF_TOOL_TIMES : _OFF_TOOL_TIMES + _TOOL_HISTORY_TIME] = (
-            self._encode_tool_history_times(tool_history, action_msg.timestamp_ms)
+            self._encode_tool_history_times(tool_history, cutoff_ms)
         )
 
         # 97–102: queue state (shared encoding with the StateEncoder slice)

--- a/tests/test_learned_controller.py
+++ b/tests/test_learned_controller.py
@@ -1,0 +1,312 @@
+"""Tests for the learned-policy controller (issue #29).
+
+The module requires torch (it exercises the real PolicyValueNetwork /
+TransitionModel), so it is skipped wholesale when torch is unavailable.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.episode_runner import Controller, EpisodeConfig, EpisodeRunner
+from bicameral_agent.followup_classifier import FollowUpType
+from bicameral_agent.gemini import GeminiClient, GeminiResponse
+from bicameral_agent.heuristic_controller import FullState
+from bicameral_agent.learned_controller import LEARNED_RULE_ID, LearnedPolicyController
+from bicameral_agent.mcts import MCTSEngine
+from bicameral_agent.policy_value_net import ACTION_ORDER, PolicyValueNetwork
+from bicameral_agent.queue import Priority, QueueItem
+from bicameral_agent.schema import Episode, EpisodeOutcome, Message
+from bicameral_agent.simulated_user import ActionType, UserAction
+from bicameral_agent.tool_primitive import ToolMetadata, ToolResult
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
+from bicameral_agent.transition_model import TransitionModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_policy(seed: int = 0) -> PolicyValueNetwork:
+    torch.manual_seed(seed)
+    net = PolicyValueNetwork(input_dim=STATE_DIM, hidden_dim=32)
+    net.eval()
+    return net
+
+
+def _make_transition(seed: int = 0) -> TransitionModel:
+    torch.manual_seed(seed)
+    model = TransitionModel(hidden_dim=32)
+    model.eval()
+    return model
+
+
+def _make_task(**overrides) -> ResearchQATask:
+    defaults = dict(
+        task_id="test-001",
+        difficulty=TaskDifficulty.TYPICAL,
+        split=TaskSplit.EVAL,
+        question="What is photosynthesis?",
+        gold_answer="Plants convert light energy into chemical energy.",
+        known_gaps=None,
+        known_assumptions=None,
+        scoring_rubric="5: Complete explanation. 3: Partial. 1: Wrong.",
+    )
+    defaults.update(overrides)
+    return ResearchQATask(**defaults)
+
+
+def _make_mock_client():
+    client = MagicMock(spec=GeminiClient)
+    client.generate.return_value = GeminiResponse(
+        content="Test response with some detail.",
+        input_tokens=10,
+        output_tokens=20,
+        duration_ms=100.0,
+        finish_reason="STOP",
+    )
+    return client
+
+
+def _tool_result(tool_id: str, deposit: bool) -> ToolResult:
+    queue_deposit = None
+    if deposit:
+        queue_deposit = QueueItem(
+            content="context from " + tool_id,
+            priority=Priority.MEDIUM,
+            source_tool_id=tool_id,
+            token_count=12,
+        )
+    return ToolResult(
+        queue_deposit=queue_deposit,
+        metadata=ToolMetadata(
+            tool_id=tool_id,
+            action_taken="ran",
+            confidence=0.8,
+            items_found=1,
+            estimated_relevance=0.5,
+            tokens_consumed=40,
+        ),
+    )
+
+
+def _run_real_runner_episode(
+    controller: LearnedPolicyController, max_turns: int, n_followups: int = 3
+) -> Episode:
+    """Run a full episode through the real EpisodeRunner with mocked LLM roles."""
+    client = _make_mock_client()
+    runner = EpisodeRunner(client, EpisodeConfig(max_turns=max_turns))
+
+    def sim_respond(task, response, history, *, turn_number):
+        if turn_number <= n_followups:
+            return UserAction(
+                action_type=ActionType.FOLLOW_UP,
+                message=f"Tell me more, please ({turn_number}).",
+                followup_type=FollowUpType.ELABORATION,
+                response_delay_ms=100,
+                confidence=0.8,
+            )
+        return UserAction(
+            action_type=ActionType.TASK_COMPLETE, response_delay_ms=100, confidence=0.9
+        )
+
+    with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+        mock_sim = MagicMock()
+        mock_sim.respond.side_effect = sim_respond
+        MockSimUser.return_value = mock_sim
+        with (
+            patch("bicameral_agent.episode_runner.ResearchGapScanner") as MockScanner,
+            patch("bicameral_agent.episode_runner.AssumptionAuditor") as MockAuditor,
+            patch("bicameral_agent.episode_runner.ContextRefresher") as MockRefresher,
+        ):
+            for mock_cls, tool_id in (
+                (MockScanner, "research_gap_scanner"),
+                (MockAuditor, "assumption_auditor"),
+                (MockRefresher, "context_refresher"),
+            ):
+                mock_tool = MagicMock()
+                mock_tool.execute.return_value = _tool_result(tool_id, deposit=True)
+                mock_cls.return_value = mock_tool
+            return runner.run_episode(_make_task(), controller)
+
+
+def _synthetic_snapshot(num_turns: int = 2) -> Episode:
+    """Episode ending with an assistant message, as a live snapshot would."""
+    messages: list[Message] = []
+    base_ts = 1_000_000
+    for turn in range(1, num_turns + 1):
+        messages.append(
+            Message(
+                role="user",
+                content=f"question part {turn}",
+                timestamp_ms=base_ts + (turn - 1) * 1000,
+                token_count=10,
+            )
+        )
+        messages.append(
+            Message(
+                role="assistant",
+                content=f"answer part {turn}",
+                timestamp_ms=base_ts + (turn - 1) * 1000 + 500,
+                token_count=20,
+            )
+        )
+    return Episode(
+        messages=messages,
+        outcome=EpisodeOutcome(
+            quality_score=None, total_tokens=0, total_turns=num_turns, wall_clock_ms=0
+        ),
+    )
+
+
+def _full_state(turn_number: int) -> FullState:
+    return FullState(
+        turn_number=turn_number,
+        stop_count=0,
+        followup_type=FollowUpType.ELABORATION,
+        queue_depth=0,
+        executing_tools=(),
+        predicted_latencies={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+
+class TestContract:
+    def test_satisfies_controller_protocol(self):
+        ctrl = LearnedPolicyController(_make_policy())
+        assert isinstance(ctrl, Controller)
+
+    def test_rejects_encoder_dim_network(self):
+        """A default (64-dim) PolicyValueNetwork cannot consume pipeline states."""
+        with pytest.raises(ValueError, match="input_dim"):
+            LearnedPolicyController(PolicyValueNetwork())
+
+    def test_rejects_bad_temperature_and_budget(self):
+        with pytest.raises(ValueError, match="temperature"):
+            LearnedPolicyController(_make_policy(), temperature=-0.1)
+        with pytest.raises(ValueError, match="num_simulations"):
+            LearnedPolicyController(_make_policy(), num_simulations=0)
+
+    def test_decide_without_snapshot_raises(self):
+        ctrl = LearnedPolicyController(_make_policy())
+        with pytest.raises(RuntimeError, match="observe_episode"):
+            ctrl.decide(_full_state(1))
+
+    def test_stale_snapshot_raises(self):
+        ctrl = LearnedPolicyController(_make_policy())
+        ctrl.observe_episode(_synthetic_snapshot(num_turns=2))
+        with pytest.raises(RuntimeError, match="stale"):
+            ctrl.decide(_full_state(5))
+
+    def test_decisions_logged(self):
+        ctrl = LearnedPolicyController(_make_policy())
+        ctrl.observe_episode(_synthetic_snapshot(num_turns=1))
+        action = ctrl.decide(_full_state(1))
+        assert len(ctrl.decisions) == 1
+        assert ctrl.decisions[0].action == action
+        assert ctrl.decisions[0].rule_fired == LEARNED_RULE_ID
+        assert ctrl.decisions[0].state.turn_number == 1
+        assert len(ctrl.encoded_states) == 1
+        assert ctrl.encoded_states[0].shape == (STATE_DIM,)
+        assert len(ctrl.distributions) == 1
+        assert ctrl.distributions[0].shape == (len(ACTION_ORDER),)
+
+
+# ---------------------------------------------------------------------------
+# Action selection
+# ---------------------------------------------------------------------------
+
+
+class TestActionSelection:
+    def test_temperature_zero_is_policy_argmax(self):
+        policy = _make_policy(seed=1)
+        ctrl = LearnedPolicyController(policy)
+        ctrl.observe_episode(_synthetic_snapshot(num_turns=1))
+        action = ctrl.decide(_full_state(1))
+        probs, _ = policy.predict(ctrl.encoded_states[0])
+        assert action == ACTION_ORDER[int(np.argmax(probs))]
+
+    def test_sampling_deterministic_with_seed(self):
+        snapshot = _synthetic_snapshot(num_turns=2)
+        actions = []
+        for _ in range(2):
+            ctrl = LearnedPolicyController(
+                _make_policy(seed=2), temperature=1.5, seed=99
+            )
+            run: list = []
+            for turn in (1, 2):
+                partial = Episode(
+                    messages=snapshot.messages[: turn * 2],
+                    outcome=snapshot.outcome,
+                )
+                ctrl.observe_episode(partial)
+                run.append(ctrl.decide(_full_state(turn)))
+            actions.append(run)
+        assert actions[0] == actions[1]
+
+    def test_mcts_mode_matches_engine_search(self):
+        """The MCTS decision equals argmax of an identical engine's search."""
+        policy = _make_policy(seed=3)
+        transition = _make_transition(seed=3)
+        ctrl = LearnedPolicyController(
+            policy,
+            mcts_engine=MCTSEngine(policy, transition, seed=7),
+            num_simulations=16,
+        )
+        ctrl.observe_episode(_synthetic_snapshot(num_turns=1))
+        action = ctrl.decide(_full_state(1))
+
+        fresh_engine = MCTSEngine(policy, transition, seed=7)
+        result = fresh_engine.search(ctrl.encoded_states[0], num_simulations=16)
+        assert action == ACTION_ORDER[int(np.argmax(result.action_distribution))]
+        np.testing.assert_allclose(ctrl.distributions[0], result.action_distribution)
+
+
+# ---------------------------------------------------------------------------
+# Train/serve consistency through the real runner
+# ---------------------------------------------------------------------------
+
+
+class TestTrainServeConsistency:
+    def test_serve_time_encoding_matches_pipeline(self):
+        """Live encodings equal the pipeline's post-hoc encodings bit-for-bit.
+
+        Runs a real EpisodeRunner episode (mocked LLM roles, real logger /
+        queue / replay) with a sampling controller so tool actions occur,
+        then re-encodes the finalized episode with an independent
+        TrainingDataPipeline and compares state vectors per decision point.
+        """
+        max_turns = 6
+        ctrl = LearnedPolicyController(
+            _make_policy(seed=4),
+            temperature=1.0,
+            seed=11,
+            pipeline=TrainingDataPipeline(max_turns=max_turns),
+        )
+        episode = _run_real_runner_episode(ctrl, max_turns=max_turns, n_followups=4)
+
+        pipeline = TrainingDataPipeline(max_turns=max_turns)
+        examples = pipeline.process_episode(episode)
+
+        assert len(examples) == len(ctrl.encoded_states) > 1
+        for example, served in zip(examples, ctrl.encoded_states):
+            np.testing.assert_array_equal(example.state, served)
+
+    def test_runner_calls_observe_episode_each_turn(self):
+        ctrl = LearnedPolicyController(_make_policy(seed=5))
+        episode = _run_real_runner_episode(ctrl, max_turns=4, n_followups=2)
+        assistant_msgs = [m for m in episode.messages if m.role == "assistant"]
+        assert len(ctrl.decisions) == len(assistant_msgs) == 3

--- a/tests/test_mcts_trainer.py
+++ b/tests/test_mcts_trainer.py
@@ -1,0 +1,393 @@
+"""Tests for the MCTS training loop (issue #29).
+
+Everything here is mechanically verifiable without live LLM calls:
+episode collection runs through the real EpisodeRunner with mocked model
+clients, and target generation / training / checkpointing operate on
+synthetic episodes. The live acceptance criteria (monotonic eval
+improvement, KL shift from the heuristic, no catastrophic forgetting,
+entropy convergence, budget) are data/LLM-dependent; their *measurement*
+is verified here (metrics computed and persisted per iteration) while
+their verification is pending the #46 data era.
+
+The module requires torch and is skipped wholesale when unavailable.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.episode_runner import EpisodeConfig, EpisodeRunner
+from bicameral_agent.followup_classifier import FollowUpType
+from bicameral_agent.gemini import GeminiClient, GeminiResponse
+from bicameral_agent.heuristic_controller import TOOL_IDS, Action
+from bicameral_agent.mcts_trainer import (
+    MCTSTrainer,
+    MCTSTrainerConfig,
+    TrainingMetrics,
+)
+from bicameral_agent.policy_value_net import NUM_ACTIONS, PolicyValueNetwork
+from bicameral_agent.schema import (
+    Episode,
+    EpisodeOutcome,
+    Message,
+    UserEvent,
+    UserEventType,
+)
+from bicameral_agent.simulated_user import ActionType, UserAction
+from bicameral_agent.tool_primitive import ToolMetadata, ToolResult
+from bicameral_agent.training_data_store import TrainingDataStore
+from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
+from bicameral_agent.transition_model import TransitionModel, TransitionTrainingConfig
+
+_HIDDEN_DIM = 32
+_TEST_CONFIG = MCTSTrainerConfig(epochs=12, batch_size=32, seed=0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_policy(seed: int = 0) -> PolicyValueNetwork:
+    torch.manual_seed(seed)
+    net = PolicyValueNetwork(input_dim=STATE_DIM, hidden_dim=_HIDDEN_DIM)
+    net.eval()
+    return net
+
+
+def _make_transition(seed: int = 0) -> TransitionModel:
+    torch.manual_seed(seed)
+    model = TransitionModel(hidden_dim=_HIDDEN_DIM)
+    model.eval()
+    return model
+
+
+def _make_trainer(tmp_path, seed: int = 0, **kwargs) -> MCTSTrainer:
+    return MCTSTrainer(
+        _make_policy(seed),
+        _make_transition(seed),
+        checkpoint_dir=tmp_path / "run",
+        config=kwargs.pop("config", _TEST_CONFIG),
+        **kwargs,
+    )
+
+
+def _build_episode(
+    *, num_turns: int, quality: float | None = 0.6, tool_turns: dict[int, str] | None = None
+) -> Episode:
+    """Synthetic episode with ``num_turns`` user/assistant pairs."""
+    messages: list[Message] = []
+    tools = []
+    base_ts = 1_000_000
+    for turn in range(1, num_turns + 1):
+        user_ts = base_ts + (turn - 1) * 1000
+        messages.append(
+            Message(
+                role="user",
+                content=f"user msg {turn} with varied words {turn * 7}",
+                timestamp_ms=user_ts,
+                token_count=10,
+            )
+        )
+        if tool_turns and turn in tool_turns:
+            from bicameral_agent.schema import ToolInvocation
+
+            tools.append(
+                ToolInvocation(
+                    tool_id=tool_turns[turn],
+                    invoked_at_ms=user_ts + 100,
+                    completed_at_ms=user_ts + 300,
+                    input_tokens=50,
+                    output_tokens=80,
+                )
+            )
+        messages.append(
+            Message(
+                role="assistant",
+                content=f"assistant msg {turn}",
+                timestamp_ms=user_ts + 500,
+                token_count=20,
+            )
+        )
+    user_events = [
+        UserEvent(
+            event_type=UserEventType.TASK_COMPLETE,
+            timestamp_ms=base_ts + (num_turns - 1) * 1000 + 600,
+        )
+    ]
+    return Episode(
+        messages=messages,
+        user_events=user_events,
+        tool_invocations=tools,
+        outcome=EpisodeOutcome(
+            quality_score=quality,
+            total_tokens=30 * num_turns,
+            total_turns=num_turns,
+            wall_clock_ms=num_turns * 1000,
+        ),
+    )
+
+
+def _synthetic_episodes() -> list[Episode]:
+    return [
+        _build_episode(num_turns=3, quality=0.8, tool_turns={1: TOOL_IDS[Action.SCANNER]}),
+        _build_episode(num_turns=4, quality=0.4, tool_turns={2: TOOL_IDS[Action.AUDITOR]}),
+        _build_episode(num_turns=2, quality=0.6),
+    ]
+
+
+def _make_task(task_id: str = "task-1") -> ResearchQATask:
+    return ResearchQATask(
+        task_id=task_id,
+        difficulty=TaskDifficulty.TYPICAL,
+        split=TaskSplit.EVAL,
+        question="What is photosynthesis?",
+        gold_answer="Plants convert light energy into chemical energy.",
+        known_gaps=None,
+        known_assumptions=None,
+        scoring_rubric="5: Complete. 3: Partial. 1: Wrong.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCTS target generation
+# ---------------------------------------------------------------------------
+
+
+class TestMCTSTargets:
+    def test_shapes_normalization_and_determinism(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        pipeline = TrainingDataPipeline()
+        examples = pipeline.process_episodes(_synthetic_episodes())
+        assert examples
+
+        dists_a, values_a = trainer.build_mcts_targets(examples, 8, seed=5)
+        dists_b, values_b = trainer.build_mcts_targets(examples, 8, seed=5)
+
+        assert dists_a.shape == (len(examples), NUM_ACTIONS)
+        assert values_a.shape == (len(examples),)
+        np.testing.assert_allclose(dists_a.sum(axis=1), 1.0, atol=1e-5)
+        assert (dists_a >= 0).all()
+        np.testing.assert_array_equal(dists_a, dists_b)
+        np.testing.assert_array_equal(values_a, values_b)
+
+    def test_different_seed_changes_noisy_targets(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        examples = TrainingDataPipeline().process_episodes(_synthetic_episodes())
+        dists_a, _ = trainer.build_mcts_targets(examples, 8, seed=1)
+        dists_b, _ = trainer.build_mcts_targets(examples, 8, seed=2)
+        # Root Dirichlet noise is on by default for targets, so different
+        # seeds should produce at least one different distribution.
+        assert not np.array_equal(dists_a, dists_b)
+
+
+# ---------------------------------------------------------------------------
+# Offline iterations
+# ---------------------------------------------------------------------------
+
+
+class TestOfflineIteration:
+    def test_run_iteration_populates_metrics_and_checkpoints(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        metrics = trainer.run_iteration(0, 8, episodes=_synthetic_episodes())
+
+        assert isinstance(metrics, TrainingMetrics)
+        assert metrics.iteration == 0
+        assert metrics.n_episodes == 3
+        assert metrics.n_examples == 9
+        assert len(metrics.epoch_losses) == _TEST_CONFIG.epochs
+        assert metrics.policy_entropy > 0.0
+        assert metrics.value_mse is not None
+        assert isinstance(metrics.kl_from_heuristic, float)
+        assert 0.0 <= metrics.heuristic_agreement <= 1.0
+        # >= 2 episodes -> episode-grouped holdout metrics exist.
+        assert metrics.holdout is not None
+        assert metrics.holdout["n_examples"] > 0
+        # Offline: no live evaluation.
+        assert metrics.eval_score is None
+        assert metrics.heuristic_eval_score is None
+        assert metrics.eval_scores_by_difficulty is None
+        assert metrics.transition_metrics is None
+
+        run_dir = tmp_path / "run"
+        it_dir = run_dir / "iteration-000"
+        assert (it_dir / "policy_value.pt").exists()
+        assert (it_dir / "transition.pt").exists()
+        saved = json.loads((it_dir / "metrics.json").read_text())
+        assert saved["iteration"] == 0
+        history = json.loads((run_dir / "metrics_history.json").read_text())
+        assert len(history) == 1
+
+        store = TrainingDataStore(run_dir / "store")
+        assert len(store) == metrics.n_examples
+        assert store.iterations == [0]
+
+    def test_training_reduces_loss(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        metrics = trainer.run_iteration(0, 8, episodes=_synthetic_episodes())
+        assert metrics.epoch_losses[-1]["total"] < metrics.epoch_losses[0]["total"]
+        assert metrics.train_loss == metrics.epoch_losses[-1]["total"]
+
+    def test_checkpoint_round_trip(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        trainer.run_iteration(0, 8, episodes=_synthetic_episodes())
+
+        path = tmp_path / "run" / "iteration-000" / "policy_value.pt"
+        reloaded = PolicyValueNetwork.load(
+            path, input_dim=STATE_DIM, hidden_dim=_HIDDEN_DIM
+        )
+        state = np.random.default_rng(0).random(STATE_DIM).astype(np.float32)
+        probs_a, value_a = trainer._policy.predict(state)  # noqa: SLF001
+        probs_b, value_b = reloaded.predict(state)
+        np.testing.assert_allclose(probs_a, probs_b)
+        assert value_a == pytest.approx(value_b)
+
+        transition_path = tmp_path / "run" / "iteration-000" / "transition.pt"
+        reloaded_t = TransitionModel.load(transition_path, hidden_dim=_HIDDEN_DIM)
+        next_a, reward_a = trainer.transition_model.predict(state, 0)
+        next_b, reward_b = reloaded_t.predict(state, 0)
+        np.testing.assert_allclose(next_a, next_b)
+        assert reward_a == pytest.approx(reward_b)
+
+    def test_iteration_counter_and_history_append(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        episodes = _synthetic_episodes()
+        m0 = trainer.run_iteration(0, 4, episodes=episodes)
+        m1 = trainer.run_iteration(0, 4, episodes=episodes)
+        assert (m0.iteration, m1.iteration) == (0, 1)
+        history = json.loads((tmp_path / "run" / "metrics_history.json").read_text())
+        assert [h["iteration"] for h in history] == [0, 1]
+        # A fresh trainer over the same directory resumes the counter.
+        resumed = MCTSTrainer(
+            _make_policy(),
+            _make_transition(),
+            checkpoint_dir=tmp_path / "run",
+            config=_TEST_CONFIG,
+        )
+        assert resumed.iteration == 2
+
+    def test_deterministic_across_trainers(self, tmp_path):
+        episodes = _synthetic_episodes()
+        metrics = []
+        for name in ("a", "b"):
+            trainer = _make_trainer(tmp_path / name)
+            metrics.append(trainer.run_iteration(0, 8, episodes=episodes))
+        assert metrics[0].train_loss == metrics[1].train_loss
+        assert metrics[0].policy_entropy == metrics[1].policy_entropy
+        assert metrics[0].kl_from_heuristic == metrics[1].kl_from_heuristic
+
+    def test_retrain_transition(self, tmp_path):
+        config = MCTSTrainerConfig(
+            epochs=3,
+            seed=0,
+            retrain_transition=True,
+            transition_config=TransitionTrainingConfig(epochs=5),
+        )
+        trainer = _make_trainer(tmp_path, config=config)
+        original = trainer.transition_model
+        metrics = trainer.run_iteration(0, 4, episodes=_synthetic_episodes())
+        assert metrics.transition_metrics is not None
+        assert metrics.transition_metrics["n_train"] > 0
+        assert trainer.transition_model is not original
+
+    def test_empty_episodes_raise(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        with pytest.raises(ValueError, match="no training examples"):
+            trainer.run_iteration(0, 4, episodes=[])
+
+    def test_live_collection_without_runner_raises(self, tmp_path):
+        trainer = _make_trainer(tmp_path)
+        with pytest.raises(ValueError, match="runner"):
+            trainer.run_iteration(2, 4)
+
+
+# ---------------------------------------------------------------------------
+# Live-style collection through the real runner (mocked model client)
+# ---------------------------------------------------------------------------
+
+
+class TestMockedCollection:
+    def _make_runner(self, max_turns: int) -> EpisodeRunner:
+        client = MagicMock(spec=GeminiClient)
+        client.generate.return_value = GeminiResponse(
+            content="Mocked answer with enough words to count.",
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=50.0,
+            finish_reason="STOP",
+        )
+        return EpisodeRunner(client, EpisodeConfig(max_turns=max_turns))
+
+    def test_collects_episodes_through_real_runner(self, tmp_path):
+        max_turns = 5
+        config = MCTSTrainerConfig(epochs=5, seed=0, max_turns=max_turns)
+        trainer = MCTSTrainer(
+            _make_policy(),
+            _make_transition(),
+            checkpoint_dir=tmp_path / "run",
+            config=config,
+            runner=self._make_runner(max_turns),
+            train_tasks=[_make_task("task-1"), _make_task("task-2")],
+        )
+
+        def sim_respond(task, response, history, *, turn_number):
+            if turn_number < 3:
+                return UserAction(
+                    action_type=ActionType.FOLLOW_UP,
+                    message="Tell me more.",
+                    followup_type=FollowUpType.ELABORATION,
+                    response_delay_ms=100,
+                    confidence=0.8,
+                )
+            return UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.side_effect = sim_respond
+            MockSimUser.return_value = mock_sim
+            with (
+                patch("bicameral_agent.episode_runner.ResearchGapScanner") as m1,
+                patch("bicameral_agent.episode_runner.AssumptionAuditor") as m2,
+                patch("bicameral_agent.episode_runner.ContextRefresher") as m3,
+            ):
+                for mock_cls, tool_id in (
+                    (m1, "research_gap_scanner"),
+                    (m2, "assumption_auditor"),
+                    (m3, "context_refresher"),
+                ):
+                    mock_tool = MagicMock()
+                    mock_tool.execute.return_value = ToolResult(
+                        queue_deposit=None,
+                        metadata=ToolMetadata(
+                            tool_id=tool_id,
+                            action_taken="ran",
+                            confidence=0.8,
+                            items_found=0,
+                            estimated_relevance=0.0,
+                            tokens_consumed=30,
+                        ),
+                    )
+                    mock_cls.return_value = mock_tool
+
+                metrics = trainer.run_iteration(2, 4)
+
+        assert metrics.n_episodes == 2
+        assert metrics.n_examples == 6  # 3 decision points per episode
+        # Collected episodes are persisted for offline reuse.
+        parquet = tmp_path / "run" / "episodes" / "iteration-000.parquet"
+        assert parquet.exists()
+        # No eval tasks -> live evaluation skipped.
+        assert metrics.eval_score is None

--- a/tests/test_runner_setup.py
+++ b/tests/test_runner_setup.py
@@ -1,0 +1,113 @@
+"""Tests for the shared CLI flag registration / client resolution helpers."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from bicameral_agent.config import HyperConfig
+from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+
+
+@dataclass
+class _FakeClient:
+    model: str
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    add_model_args(parser)
+    return parser.parse_args(argv)
+
+
+@pytest.fixture
+def hyper() -> HyperConfig:
+    return HyperConfig.from_defaults()
+
+
+class TestAddModelArgs:
+    def test_registers_shared_flags_with_none_defaults(self):
+        args = _parse([])
+        assert args.config is None
+        assert args.provider is None
+        assert args.model is None
+        assert args.judge_provider is None
+        assert args.judge_model is None
+        assert args.episode_budget is None
+
+    def test_parses_values(self):
+        args = _parse(
+            [
+                "--provider", "gemini",
+                "--model", "tag-a",
+                "--judge-provider", "gemini",
+                "--judge-model", "tag-b",
+                "--episode-budget", "0.5",
+            ]
+        )
+        assert (args.provider, args.model) == ("gemini", "tag-a")
+        assert (args.judge_provider, args.judge_model) == ("gemini", "tag-b")
+        assert args.episode_budget == 0.5
+
+    def test_rejects_unknown_provider(self):
+        with pytest.raises(SystemExit):
+            _parse(["--provider", "not-a-provider"])
+
+
+class TestResolveRunnerClients:
+    def test_cli_overrides_config(self, hyper):
+        args = _parse(["--provider", "gemini", "--model", "tag-a"])
+        with patch(
+            "bicameral_agent.runner_setup.build_client",
+            side_effect=lambda provider, model: _FakeClient(model=model or "default"),
+        ) as mock_build:
+            resolve_runner_clients(args, hyper)
+        assert mock_build.call_args_list[0].args == ("gemini", "tag-a")
+
+    def test_config_used_when_no_cli_flags(self, hyper):
+        args = _parse([])
+        with patch(
+            "bicameral_agent.runner_setup.build_client",
+            side_effect=lambda provider, model: _FakeClient(model=model or "default"),
+        ) as mock_build:
+            resolve_runner_clients(args, hyper)
+        assert mock_build.call_args_list[0].args == (
+            hyper.model.provider,
+            hyper.model.name,
+        )
+
+    def test_judge_client_reused_when_roles_match(self, hyper):
+        args = _parse(
+            [
+                "--provider", "gemini", "--model", "tag-a",
+                "--judge-provider", "gemini", "--judge-model", "tag-a",
+            ]
+        )
+        with patch(
+            "bicameral_agent.runner_setup.build_client",
+            side_effect=lambda provider, model: _FakeClient(model=model),
+        ) as mock_build:
+            client, judge_client, provenance = resolve_runner_clients(args, hyper)
+        assert judge_client is client
+        assert mock_build.call_count == 1
+        assert provenance["answerer"] == {"provider": "gemini", "model": "tag-a"}
+        assert provenance["measurement"] == {"provider": "gemini", "model": "tag-a"}
+
+    def test_distinct_judge_gets_own_client(self, hyper):
+        args = _parse(
+            [
+                "--provider", "gemini", "--model", "tag-a",
+                "--judge-provider", "gemini", "--judge-model", "tag-b",
+            ]
+        )
+        with patch(
+            "bicameral_agent.runner_setup.build_client",
+            side_effect=lambda provider, model: _FakeClient(model=model),
+        ) as mock_build:
+            client, judge_client, provenance = resolve_runner_clients(args, hyper)
+        assert judge_client is not client
+        assert mock_build.call_count == 2
+        assert provenance["measurement"] == {"provider": "gemini", "model": "tag-b"}


### PR DESCRIPTION
## Summary

Implements the issue #29 self-improvement cycle: collect episodes with the current learned policy → MCTS visit-distribution targets per decision point → policy CE + value MSE training → optional transition-model refit → held-out evaluation vs the heuristic → per-iteration checkpoints and metrics history.

Marked **Partial**: the live acceptance criteria (monotonic eval improvement, KL shift from heuristic, no catastrophic forgetting, entropy convergence, 500-episode budget) are data/LLM-dependent. Their **measurement** is implemented and persisted per iteration in `metrics_history.json`; verification pends the #46 data era.

## Work performed

- **`src/bicameral_agent/learned_controller.py`** — `LearnedPolicyController` (extends `DecisionLoggingController`, satisfies the `Controller` protocol). Two modes: raw policy (argmax / seeded temperature sampling) and MCTS-improved (configurable simulation budget, optional root Dirichlet noise). Train/serve consistency: it encodes each live decision point by replaying a `ConversationLogger.snapshot()` through the *same* `EpisodeReplayer` + `TrainingDataPipeline.build_state_vector` code path the pipeline uses post-hoc — encodings are bit-identical under the default BREAKPOINT injection mode (regen modes shift the post-hoc cutoff; documented).
- **`src/bicameral_agent/mcts_trainer.py`** — `MCTSTrainer.run_iteration(n_episodes, n_simulations) -> TrainingMetrics`. Collect (live via `EpisodeRunner`, or pre-collected episodes for offline runs; live episodes persisted to `episodes/iteration-NNN.parquet`), MCTS targets, soft-target policy CE + value MSE, optional transition refit, learned-vs-heuristic eval on held-out tasks with per-difficulty scores (forgetting measurement), and per-iteration checkpoints (`policy_value.pt`, `transition.pt`, `metrics.json`) plus an append-only `metrics_history.json`. Metrics per iteration: loss curves, policy entropy, value MSE/correlation + episode-grouped holdout metrics, KL and agreement vs the heuristic, MCTS root value, eval scores, wall-clock timings. Deterministic for fixed seed/weights/episodes.
- **`scripts/train_mcts.py`** — end-to-end CLI: `--provider/--model/--judge-provider/--judge-model` reusing `build_client`/`HyperConfig` like `run_baseline_benchmark.py`; `--policy-checkpoint`/`--transition-checkpoint` to start from the #26/#27 fits; `--episodes-parquet` for offline iterations without any LLM client; stratified held-out eval task selection; session cost reporting.
- **Supporting changes**: `ConversationLogger.snapshot()` (non-finalizing Episode view), `observe_episode` hook in `EpisodeRunner` immediately before each controller decision, `TrainingDataPipeline.build_state_vector` made public with an explicit `cutoff_ms`.

### Observed pre-existing issue (not fixed here)

`TrainingDataPipeline._infer_actions` attributes a tool invocation to a turn only if `invoked_at_ms <= assistant_ts`, but the live runner logs the assistant message *before* invoking the tool — live-logged invocations that cross a millisecond boundary get labeled DO_NOTHING. This affects behavior-action labels (transition-model action one-hots, action-accuracy diagnostics), not the MCTS targets. Worth a follow-up issue.

## Test plan

- [x] `uv run --extra dev --extra torch pytest -q` — 1317 passed, 35 skipped
- [x] `uv run --extra dev --extra torch ruff check src/ tests/ scripts/` — clean
- [x] Controller: protocol satisfaction, decision logging, dim/temperature validation, snapshot-required and stale-snapshot errors
- [x] Train/serve consistency: real `EpisodeRunner` episode (mocked LLM roles, real logger/queue/replay, tool deposits) — serve-time encodings equal the pipeline's post-hoc encodings bit-for-bit
- [x] Seeded determinism: controller sampling, MCTS-mode decision equals an identical engine's search, identical metrics across trainers
- [x] MCTS targets on synthetic states: shapes, normalization, seed determinism, noise sensitivity
- [x] Training step reduces loss on synthetic targets
- [x] Checkpoint round-trip (policy + transition), iteration counter resume, metrics-history append
- [x] Collection through the real runner with mocked clients; episodes persisted to parquet
- [x] Offline CLI smoke run (2 iterations over synthetic parquet)

**Pending (live, data/LLM-dependent — measurement implemented, verification deferred):**
- [ ] Training loss decreases over iterations / loss-curve plots
- [ ] Monotonic held-out improvement in first 5 iterations
- [ ] KL divergence from heuristic increases over training
- [ ] No catastrophic forgetting (per-difficulty eval scores recorded)
- [ ] Policy entropy stabilizes within 500 episodes
- [ ] 500-episode run wall-clock/cost budget estimate
- [x] All checkpoints saved and loadable (mechanics verified; live-run artifacts pending)

Refs #29.