### PR TITLE
Partial: Comparative evaluation harness across 5 controller conditions

### DIFF
--- a/scripts/run_comparative_eval.py
+++ b/scripts/run_comparative_eval.py
@@ -1,0 +1,180 @@
+"""Run the Issue #30 comparative evaluation across all five controllers.
+
+Runs {no_subconscious, random, heuristic, learned_no_search,
+learned_with_search} paired over the same evaluation task set and emits:
+
+  - Per-episode parquet files under ``--output-dir/<condition>.parquet``
+    (rewritten after every episode so a late crash keeps prior results)
+  - ``report.json`` (machine-readable: summaries, pairwise Welch t-tests
+    with p-values, per-difficulty breakdown)
+  - ``report.md`` (human-readable rendering of the same numbers)
+
+``--tasks`` takes either a total (split 50/25/25 across
+typical/hard/tricky) or an explicit mix, e.g. ``typical=50,hard=25,tricky=25``.
+The learned conditions need the ``torch`` extra and checkpoints from
+scripts/train_mcts.py (or scripts/pretrain_policy.py +
+scripts/train_transition_model.py).
+
+Usage:
+    GEMINI_API_KEY=… uv run --extra torch python scripts/run_comparative_eval.py \\
+        --output-dir data/comparative --dataset hard_benchmark \\
+        --tasks typical=50,hard=25,tricky=25 \\
+        --policy-checkpoint ckpt/policy_value.pt \\
+        --transition-checkpoint ckpt/transition.pt
+
+Real API calls are made; budget the run accordingly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from bicameral_agent.comparative_eval import (
+    ComparativeEvaluator,
+    baseline_condition_factories,
+    build_report,
+    learned_condition_factories,
+    parse_task_mix,
+    select_tasks,
+)
+from bicameral_agent.config import HyperConfig
+from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
+from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+from bicameral_agent.schema import Episode
+from bicameral_agent.serialization import episodes_to_parquet
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="data/comparative")
+    add_model_args(parser)
+    parser.add_argument("--dataset", choices=dataset_names(), default="builtin",
+                        help="Evaluation dataset to run against. External "
+                             "datasets must be fetched first via "
+                             "scripts/fetch_dataset.py.")
+    parser.add_argument("--metric", default=None,
+                        help="Verification metric (defaults to the dataset's "
+                             "default_metric; must be in its supported_metrics).")
+    parser.add_argument("--tasks", default="100",
+                        help="Task count (split 50/25/25 across "
+                             "typical/hard/tricky) or an explicit mix, e.g. "
+                             "'typical=50,hard=25,tricky=25'.")
+    parser.add_argument("--policy-checkpoint", required=True,
+                        help="PolicyValueNetwork checkpoint (.pt) for the "
+                             "learned conditions.")
+    parser.add_argument("--transition-checkpoint", required=True,
+                        help="TransitionModel checkpoint (.pt) for MCTS search.")
+    parser.add_argument("--policy-hidden-dim", type=int, default=160,
+                        help="Hidden width of the policy checkpoint "
+                             "(must match training).")
+    parser.add_argument("--transition-hidden-dim", type=int, default=128,
+                        help="Hidden width of the transition checkpoint "
+                             "(must match training).")
+    parser.add_argument("--num-simulations", type=int, default=50,
+                        help="MCTS budget per decision for learned_with_search.")
+    parser.add_argument("--max-turns", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Base seed; per-condition seeds are derived "
+                             "deterministically from it.")
+    parser.add_argument("--random-probability", type=float, default=0.2)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.WARNING if args.quiet else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    hyper = (
+        HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
+    ).with_env_overrides()
+
+    eval_dataset = build_dataset(args.dataset)
+    metric = resolve_metric(eval_dataset, args.metric)
+    dataset = eval_dataset.load()
+    mix = parse_task_mix(args.tasks)
+    tasks = select_tasks(dataset, mix)
+    logger.info(
+        "Selected %d tasks from dataset %r (metric %r, mix %s)",
+        len(tasks), args.dataset, metric,
+        {d.value: n for d, n in mix.items() if n},
+    )
+
+    conditions = {
+        **baseline_condition_factories(
+            hyper.to_heuristic_controller,
+            random_probability=args.random_probability,
+            base_seed=args.seed,
+        ),
+        **learned_condition_factories(
+            args.policy_checkpoint,
+            args.transition_checkpoint,
+            num_simulations=args.num_simulations,
+            max_turns=args.max_turns,
+            policy_hidden_dim=args.policy_hidden_dim,
+            transition_hidden_dim=args.transition_hidden_dim,
+            base_seed=args.seed,
+        ),
+    }
+
+    cost_tracker = hyper.to_cost_tracker()
+    if args.episode_budget is not None:
+        cost_tracker.set_episode_budget(args.episode_budget)
+
+    client, judge_client, provenance = resolve_runner_clients(args, hyper)
+
+    runner = EpisodeRunner(
+        client,
+        config=hyper.to_episode_config(
+            max_turns=args.max_turns,
+            score_episode=True,
+            metric=metric,
+        ),
+        hyper_config=hyper,
+        cost_tracker=cost_tracker,
+        judge_client=judge_client,
+        sim_user_client=judge_client,
+    )
+
+    # Persist episodes incrementally: rewrite the condition's parquet after
+    # every completed episode so a late crash keeps all prior results.
+    completed: dict[str, list[Episode]] = {}
+
+    def persist_episode(condition: str, _idx: int, episode: Episode) -> None:
+        completed.setdefault(condition, []).append(episode)
+        episodes_to_parquet(
+            completed[condition], str(output_dir / f"{condition}.parquet")
+        )
+
+    evaluator = ComparativeEvaluator(runner, on_episode=persist_episode)
+    result = evaluator.run(tasks, conditions)
+
+    report = build_report(
+        result,
+        dataset=args.dataset,
+        metric=metric,
+        answerer=provenance["answerer"],
+        measurement=provenance["measurement"],
+        max_turns=args.max_turns,
+        base_seed=args.seed,
+    )
+    (output_dir / "report.json").write_text(report.to_json())
+    markdown = report.to_markdown()
+    (output_dir / "report.md").write_text(markdown)
+    sys.stdout.write(markdown)
+    logger.info("Wrote report.json and report.md to %s", output_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bicameral_agent/comparative_eval.py
+++ b/src/bicameral_agent/comparative_eval.py
@@ -1,0 +1,776 @@
+"""Comparative evaluation harness across all five controller conditions.
+
+Issue #30: runs {no_subconscious, random, heuristic, learned_no_search,
+learned_with_search} on a fixed evaluation task set with a *paired* design
+(every condition sees the same tasks in the same order), aggregates the
+nine comparison metrics with mean / 95% CI, runs pairwise Welch t-tests
+with p-values, and breaks results down by task difficulty. Reports export
+as JSON (machine-readable) and markdown (human-readable).
+
+Metric mapping
+--------------
+The issue names nine metrics; each maps to what the episode metadata
+actually records (proxies are documented where the named quantity is not
+directly measured):
+
+- ``task_quality``: ``episode.outcome.quality_score`` (verifier score).
+- ``task_completed``: 1 if the simulated user marked the task complete.
+- ``token_efficiency``: ``episode.outcome.total_tokens``. Lower is
+  better; raw token consumption is the recorded quantity (no per-token
+  quality attribution exists), so this is a consumption proxy for
+  efficiency.
+- ``user_stops``: count of STOP user events.
+- ``time_to_completion_ms``: ``episode.outcome.wall_clock_ms``.
+- ``tool_precision``: consumed context injections / tool invocations.
+  Proxy: nothing judges whether an injection was *useful*, so
+  "deposited context that the conscious loop actually consumed" is the
+  recorded stand-in for a useful invocation. Undefined (skipped) for
+  episodes with no tool invocations.
+- ``interrupt_rate``: interrupts / total turns.
+- ``queue_expiry_rate``: expired queue items / (drained + expired)
+  queue items. Proxy: the episode records drain and expiry counts but
+  not end-of-episode still-pending items per se, so the rate is over
+  *resolved* queue items. Undefined when nothing was drained or expired.
+- ``latency_mape``: per-episode mean absolute percentage error of
+  predicted vs actual tool latency (from the controller decision log's
+  ``predicted_latencies`` paired against ToolInvocation durations).
+  Undefined for episodes with no valid prediction/actual pairs.
+
+The issue's checklist says "9 metrics" but names eight; ``task_completed``
+(completion rate) is the ninth, matching the baseline benchmark.
+
+Determinism boundary
+--------------------
+Episode *collection* calls an LLM and is inherently stochastic: re-running
+the harness against a live model will not reproduce episode content.
+What IS deterministic for a fixed seed and fixed inputs:
+
+- task selection and pairing (``select_tasks`` is order-based, no RNG;
+  every condition receives the identical task list in identical order);
+- controller-side randomness (per-condition, per-task seeds derived from
+  ``base_seed`` via :func:`condition_seed`);
+- everything downstream of collected episodes: metric extraction,
+  summaries, CIs, Welch t-tests / p-values, difficulty breakdown, and
+  both report serializations are pure functions of the episodes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import math
+from collections import Counter
+from typing import Callable, Sequence
+
+from pydantic import BaseModel, Field
+
+from bicameral_agent.ab_test import MetricSummary, compute_summary, welch_t_test
+from bicameral_agent.baseline_benchmark import (
+    ControllerFactory,
+    EpisodeCallback,
+    TaskMetrics,
+    run_condition,
+)
+from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
+from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.eval_report import TaskResult
+from bicameral_agent.no_subconscious_controller import NoSubconsciousController
+from bicameral_agent.random_controller import RandomController
+from bicameral_agent.schema import Episode
+
+logger = logging.getLogger(__name__)
+
+CONDITION_NAMES: tuple[str, ...] = (
+    "no_subconscious",
+    "random",
+    "heuristic",
+    "learned_no_search",
+    "learned_with_search",
+)
+
+METRIC_NAMES: tuple[str, ...] = (
+    "task_quality",
+    "task_completed",
+    "token_efficiency",
+    "user_stops",
+    "time_to_completion_ms",
+    "tool_precision",
+    "interrupt_rate",
+    "queue_expiry_rate",
+    "latency_mape",
+)
+
+_LOWER_IS_BETTER: frozenset[str] = frozenset(
+    {
+        "token_efficiency",
+        "user_stops",
+        "time_to_completion_ms",
+        "interrupt_rate",
+        "queue_expiry_rate",
+        "latency_mape",
+    }
+)
+
+_DIFFICULTY_ORDER: tuple[TaskDifficulty, ...] = (
+    TaskDifficulty.TYPICAL,
+    TaskDifficulty.HARD,
+    TaskDifficulty.TRICKY,
+)
+
+
+def condition_seed(base_seed: int, condition: str) -> int:
+    """Disjoint per-condition seed block: ``base_seed + 10_000 * index``.
+
+    Task ``idx`` within a condition then uses ``condition_seed(...) + idx``,
+    so no two (condition, task) pairs share a seed for up to 10k tasks.
+    """
+    return base_seed + 10_000 * CONDITION_NAMES.index(condition)
+
+
+# ---------------------------------------------------------------------------
+# Task selection
+# ---------------------------------------------------------------------------
+
+
+def parse_task_mix(spec: str) -> dict[TaskDifficulty, int]:
+    """Parse a ``--tasks`` spec into per-difficulty counts.
+
+    A plain integer ``N`` is split 50/25/25 across typical/hard/tricky
+    (matching the issue's 100-task layout); explicit counts use
+    ``typical=50,hard=25,tricky=25`` (omitted tiers default to 0).
+    """
+    spec = spec.strip()
+    if spec.isdigit():
+        total = int(spec)
+        typical = total // 2
+        hard = total // 4
+        return {
+            TaskDifficulty.TYPICAL: typical,
+            TaskDifficulty.HARD: hard,
+            TaskDifficulty.TRICKY: total - typical - hard,
+        }
+    mix = dict.fromkeys(_DIFFICULTY_ORDER, 0)
+    for part in spec.split(","):
+        key, _, value = part.partition("=")
+        try:
+            difficulty = TaskDifficulty(key.strip())
+            count = int(value)
+        except ValueError:
+            raise ValueError(
+                f"Invalid task mix component {part!r}; expected e.g. "
+                "'typical=50,hard=25,tricky=25' or a plain integer"
+            ) from None
+        mix[difficulty] = count
+    return mix
+
+
+def select_tasks(
+    dataset: ResearchQADataset, mix: dict[TaskDifficulty, int]
+) -> list[ResearchQATask]:
+    """Deterministic stratified pick of eval tasks per the difficulty mix.
+
+    Takes the first N eval tasks of each tier in dataset order and
+    concatenates tiers in typical/hard/tricky order — no RNG, so the
+    same dataset + mix always yields the same task list (the pairing
+    order shared by every condition). Raises ``ValueError`` if any tier
+    is short rather than silently substituting tasks from other tiers.
+    """
+    eval_tasks = dataset.eval_tasks()
+    selected: list[ResearchQATask] = []
+    shortfalls: list[str] = []
+    for difficulty in _DIFFICULTY_ORDER:
+        want = mix.get(difficulty, 0)
+        if want <= 0:
+            continue
+        available = [t for t in eval_tasks if t.difficulty == difficulty]
+        if len(available) < want:
+            shortfalls.append(f"{difficulty.value}: want {want}, have {len(available)}")
+            continue
+        selected.extend(available[:want])
+    if shortfalls:
+        raise ValueError(
+            "Dataset cannot satisfy the requested task mix ("
+            + "; ".join(shortfalls)
+            + ")"
+        )
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Condition factories
+# ---------------------------------------------------------------------------
+
+
+def baseline_condition_factories(
+    heuristic_factory: Callable[[], object],
+    *,
+    random_probability: float = 0.2,
+    base_seed: int = 42,
+) -> dict[str, ControllerFactory]:
+    """Factories for the three non-learned conditions.
+
+    ``heuristic_factory`` is a zero-arg constructor for the heuristic
+    controller (e.g. ``hyper.to_heuristic_controller``).
+    """
+    random_base = condition_seed(base_seed, "random")
+    return {
+        "no_subconscious": lambda _idx: NoSubconsciousController(),
+        "random": lambda idx: RandomController(
+            action_probability=random_probability, seed=random_base + idx
+        ),
+        "heuristic": lambda _idx: heuristic_factory(),
+    }
+
+
+def learned_condition_factories(
+    policy_checkpoint: str,
+    transition_checkpoint: str,
+    *,
+    num_simulations: int = 50,
+    max_turns: int = 25,
+    policy_hidden_dim: int = 160,
+    transition_hidden_dim: int = 128,
+    base_seed: int = 42,
+) -> dict[str, ControllerFactory]:
+    """Factories for the two learned conditions, loaded from checkpoints.
+
+    Both conditions share one loaded policy network and (for search) one
+    transition model; evaluation settings are deterministic (temperature
+    0, no root noise). Requires the ``torch`` extra — imports are lazy so
+    the rest of this module works without it.
+    """
+    from bicameral_agent.learned_controller import LearnedPolicyController
+    from bicameral_agent.mcts import MCTSEngine
+    from bicameral_agent.policy_value_net import PolicyValueNetwork
+    from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
+    from bicameral_agent.transition_model import TransitionModel
+
+    policy = PolicyValueNetwork.load(
+        policy_checkpoint, input_dim=STATE_DIM, hidden_dim=policy_hidden_dim
+    )
+    transition = TransitionModel.load(
+        transition_checkpoint, hidden_dim=transition_hidden_dim
+    )
+    pipeline = TrainingDataPipeline(max_turns=max_turns)
+    no_search_base = condition_seed(base_seed, "learned_no_search")
+    with_search_base = condition_seed(base_seed, "learned_with_search")
+
+    def no_search(idx: int) -> LearnedPolicyController:
+        return LearnedPolicyController(
+            policy, pipeline=pipeline, seed=no_search_base + idx
+        )
+
+    def with_search(idx: int) -> LearnedPolicyController:
+        seed = with_search_base + idx
+        return LearnedPolicyController(
+            policy,
+            mcts_engine=MCTSEngine(policy, transition, seed=seed),
+            num_simulations=num_simulations,
+            pipeline=pipeline,
+            seed=seed,
+        )
+
+    return {"learned_no_search": no_search, "learned_with_search": with_search}
+
+
+# ---------------------------------------------------------------------------
+# Evaluator
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ComparativeResult:
+    """Paired episodes + extracted metrics for every condition.
+
+    ``episodes[c][i]`` and ``metrics[c][i]`` correspond to ``tasks[i]``
+    for every condition ``c`` (the paired design).
+    """
+
+    tasks: list[ResearchQATask]
+    episodes: dict[str, list[Episode]] = dataclasses.field(default_factory=dict)
+    metrics: dict[str, list[TaskMetrics]] = dataclasses.field(default_factory=dict)
+
+    @property
+    def task_ids(self) -> list[str]:
+        """Shared task order (identical across conditions)."""
+        return [t.task_id for t in self.tasks]
+
+
+class ComparativeEvaluator:
+    """Runs every condition over the same task list in the same order."""
+
+    def __init__(
+        self, runner: EpisodeRunner, *, on_episode: EpisodeCallback | None = None
+    ) -> None:
+        self._runner = runner
+        self._on_episode = on_episode
+
+    def run(
+        self,
+        tasks: Sequence[ResearchQATask],
+        conditions: dict[str, ControllerFactory],
+    ) -> ComparativeResult:
+        """Run all conditions paired over ``tasks``.
+
+        ``conditions`` maps condition name to a per-task controller
+        factory (called with the task index). Conditions run in dict
+        order; within a condition, tasks run in list order — the same
+        list for every condition, which is what makes the comparison
+        paired.
+        """
+        result = ComparativeResult(tasks=list(tasks))
+        for condition, factory in conditions.items():
+            logger.info(
+                "Running %d episodes for condition %r", len(result.tasks), condition
+            )
+            episodes, metrics = run_condition(
+                self._runner,
+                result.tasks,
+                factory,
+                condition=condition,
+                on_episode=self._on_episode,
+            )
+            result.episodes[condition] = episodes
+            result.metrics[condition] = metrics
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def metric_values(metrics: Sequence[TaskMetrics], name: str) -> list[float]:
+    """Per-episode values for one comparison metric.
+
+    Episodes where the metric is undefined (see module docstring) are
+    skipped, so summary ``n`` reflects defined observations only.
+    """
+    values: list[float] = []
+    for m in metrics:
+        v = _metric_value(m, name)
+        if v is not None:
+            values.append(v)
+    return values
+
+
+def _metric_value(m: TaskMetrics, name: str) -> float | None:
+    if name == "task_quality":
+        return m.quality_score
+    if name == "task_completed":
+        return float(m.task_completed)
+    if name == "token_efficiency":
+        return float(m.total_tokens)
+    if name == "user_stops":
+        return float(m.user_stops)
+    if name == "time_to_completion_ms":
+        return float(m.wall_clock_ms)
+    if name == "tool_precision":
+        if m.tool_invocation_count == 0:
+            return None
+        return m.drain_count / m.tool_invocation_count
+    if name == "interrupt_rate":
+        if m.total_turns == 0:
+            return None
+        return m.interrupt_count / m.total_turns
+    if name == "queue_expiry_rate":
+        resolved = m.drain_count + m.expired_count
+        if resolved == 0:
+            return None
+        return m.expired_count / resolved
+    if name == "latency_mape":
+        if not m.latency_pairs:
+            return None
+        errors = [abs(p - a) / a for p, a in m.latency_pairs]
+        return 100.0 * sum(errors) / len(errors)
+    raise ValueError(f"Unknown metric {name!r}")
+
+
+def condition_summaries(metrics: Sequence[TaskMetrics]) -> dict[str, MetricSummary]:
+    """Mean / std / 95% CI for every comparison metric."""
+    return {name: compute_summary(metric_values(metrics, name)) for name in METRIC_NAMES}
+
+
+# ---------------------------------------------------------------------------
+# Statistics: Welch p-values (no scipy)
+# ---------------------------------------------------------------------------
+
+
+def _beta_continued_fraction(a: float, b: float, x: float) -> float:
+    """Continued fraction for the incomplete beta (Lentz's method)."""
+    tiny = 1e-30
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    h = d
+    for m in range(1, 200):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 1e-12:
+            break
+    return h
+
+
+def _regularized_incomplete_beta(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta function I_x(a, b)."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    ln_front = (
+        math.lgamma(a + b)
+        - math.lgamma(a)
+        - math.lgamma(b)
+        + a * math.log(x)
+        + b * math.log(1.0 - x)
+    )
+    front = math.exp(ln_front)
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _beta_continued_fraction(a, b, x) / a
+    return 1.0 - front * _beta_continued_fraction(b, a, 1.0 - x) / b
+
+
+def student_t_two_tailed_p(t_stat: float, df: float) -> float:
+    """Two-tailed p-value for a t statistic with ``df`` degrees of freedom."""
+    if df <= 0:
+        return 1.0
+    x = df / (df + t_stat * t_stat)
+    return _regularized_incomplete_beta(df / 2.0, 0.5, x)
+
+
+def _welch_df(a: Sequence[float], b: Sequence[float]) -> float:
+    """Welch-Satterthwaite degrees of freedom (fractional)."""
+    na, nb = len(a), len(b)
+    mean_a = sum(a) / na
+    mean_b = sum(b) / nb
+    se_a = sum((x - mean_a) ** 2 for x in a) / (na - 1) / na
+    se_b = sum((x - mean_b) ** 2 for x in b) / (nb - 1) / nb
+    se_sum = se_a + se_b
+    if se_sum == 0.0:
+        return 0.0
+    return se_sum**2 / (se_a**2 / (na - 1) + se_b**2 / (nb - 1))
+
+
+def welch_test_with_p(
+    a: Sequence[float], b: Sequence[float]
+) -> tuple[float, float, bool]:
+    """Welch's t-test with a two-tailed p-value.
+
+    Returns ``(t_stat, p_value, significant)``; ``t_stat`` and the
+    significance flag come from :func:`bicameral_agent.ab_test.welch_t_test`
+    (95% confidence), the p-value from the exact Welch-Satterthwaite df.
+    Degenerate inputs (< 2 samples on a side, or zero variance on both)
+    return ``(0.0, 1.0, False)``.
+    """
+    t_stat, significant = welch_t_test(list(a), list(b))
+    if len(a) < 2 or len(b) < 2:
+        return 0.0, 1.0, False
+    df = _welch_df(a, b)
+    if df <= 0:
+        return t_stat, 1.0, significant
+    return t_stat, student_t_two_tailed_p(t_stat, df), significant
+
+
+class PairwiseTestResult(BaseModel):
+    """One Welch t-test between two conditions on one metric."""
+
+    metric: str
+    condition_a: str
+    condition_b: str
+    mean_a: float
+    mean_b: float
+    n_a: int
+    n_b: int
+    t_stat: float
+    p_value: float
+    significant: bool
+
+
+def pairwise_tests(
+    metrics_by_condition: dict[str, list[TaskMetrics]],
+) -> list[PairwiseTestResult]:
+    """All pairwise Welch t-tests, per metric, in condition dict order."""
+    conditions = list(metrics_by_condition)
+    tests: list[PairwiseTestResult] = []
+    for name in METRIC_NAMES:
+        values = {c: metric_values(metrics_by_condition[c], name) for c in conditions}
+        for i, cond_a in enumerate(conditions):
+            for cond_b in conditions[i + 1 :]:
+                a, b = values[cond_a], values[cond_b]
+                t_stat, p_value, significant = welch_test_with_p(a, b)
+                tests.append(
+                    PairwiseTestResult(
+                        metric=name,
+                        condition_a=cond_a,
+                        condition_b=cond_b,
+                        mean_a=sum(a) / len(a) if a else 0.0,
+                        mean_b=sum(b) / len(b) if b else 0.0,
+                        n_a=len(a),
+                        n_b=len(b),
+                        t_stat=t_stat,
+                        p_value=p_value,
+                        significant=significant,
+                    )
+                )
+    return tests
+
+
+def difficulty_breakdown(
+    tasks: Sequence[ResearchQATask],
+    metrics_by_condition: dict[str, list[TaskMetrics]],
+) -> dict[str, dict[str, dict[str, MetricSummary]]]:
+    """Per-difficulty, per-condition metric summaries.
+
+    Relies on the paired design: ``metrics_by_condition[c][i]`` belongs
+    to ``tasks[i]``, so grouping indices by task difficulty slices every
+    condition identically.
+    """
+    breakdown: dict[str, dict[str, dict[str, MetricSummary]]] = {}
+    for difficulty in _DIFFICULTY_ORDER:
+        indices = [i for i, t in enumerate(tasks) if t.difficulty == difficulty]
+        if not indices:
+            continue
+        breakdown[difficulty.value] = {
+            condition: condition_summaries([metrics[i] for i in indices])
+            for condition, metrics in metrics_by_condition.items()
+        }
+    return breakdown
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+class ComparativeTaskResult(TaskResult):
+    """Per-episode result with the task's difficulty tier."""
+
+    difficulty: str = ""
+
+
+class ComparativeReport(BaseModel):
+    """Machine-readable report for one comparative evaluation run.
+
+    Extends the :class:`~bicameral_agent.eval_report.EvalReport` shape
+    (dataset/metric/provenance/conditions/results) with pairwise tests,
+    the difficulty breakdown, and the run's seed/task-mix identity.
+    """
+
+    dataset: str
+    metric: str
+    answerer: dict[str, str]
+    measurement: dict[str, str]
+    tasks_per_condition: int
+    max_turns: int
+    base_seed: int
+    task_mix: dict[str, int]
+    task_ids: list[str]
+    conditions: dict[str, dict]
+    """Per-condition ``{"n_episodes", "summaries": {metric: {...}}}``."""
+    pairwise: list[PairwiseTestResult]
+    by_difficulty: dict[str, dict[str, dict[str, dict]]]
+    results: list[ComparativeTaskResult] = Field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Serialize to the report.json payload."""
+        return self.model_dump_json(indent=2)
+
+    def to_markdown(self) -> str:
+        """Render the human-readable markdown report."""
+        return _render_markdown(self)
+
+
+def build_report(
+    result: ComparativeResult,
+    *,
+    dataset: str,
+    metric: str,
+    answerer: dict[str, str],
+    measurement: dict[str, str],
+    max_turns: int,
+    base_seed: int,
+) -> ComparativeReport:
+    """Aggregate a :class:`ComparativeResult` into a report.
+
+    Pure function of the collected episodes/metrics: identical inputs
+    produce byte-identical JSON and markdown (the deterministic side of
+    the boundary documented in the module docstring).
+    """
+    conditions = {
+        condition: {
+            "n_episodes": len(metrics),
+            "summaries": {
+                name: dataclasses.asdict(summary)
+                for name, summary in condition_summaries(metrics).items()
+            },
+        }
+        for condition, metrics in result.metrics.items()
+    }
+    difficulty = {
+        tier: {
+            condition: {
+                name: dataclasses.asdict(summary) for name, summary in summaries.items()
+            }
+            for condition, summaries in per_condition.items()
+        }
+        for tier, per_condition in difficulty_breakdown(
+            result.tasks, result.metrics
+        ).items()
+    }
+    results = [
+        ComparativeTaskResult(
+            task_id=task.task_id,
+            condition=condition,
+            score=episode.outcome.quality_score,
+            detail=(episode.metadata.get("verification") or {}).get("detail"),
+            difficulty=task.difficulty.value,
+        )
+        for condition, episodes in result.episodes.items()
+        for task, episode in zip(result.tasks, episodes)
+    ]
+    task_mix = Counter(t.difficulty.value for t in result.tasks)
+    return ComparativeReport(
+        dataset=dataset,
+        metric=metric,
+        answerer=answerer,
+        measurement=measurement,
+        tasks_per_condition=len(result.tasks),
+        max_turns=max_turns,
+        base_seed=base_seed,
+        task_mix=dict(task_mix),
+        task_ids=result.task_ids,
+        conditions=conditions,
+        pairwise=pairwise_tests(result.metrics),
+        by_difficulty=difficulty,
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+_PRIMARY_METRIC = "task_quality"
+
+
+def _fmt(value: float) -> str:
+    return f"{value:.4g}"
+
+
+def _summary_cell(summary: dict) -> str:
+    if summary["n"] == 0:
+        return "-"
+    return (
+        f"{_fmt(summary['mean'])} "
+        f"[{_fmt(summary['ci_lower'])}, {_fmt(summary['ci_upper'])}] "
+        f"(n={summary['n']})"
+    )
+
+
+def _summary_table(
+    conditions: Sequence[str], summaries: Callable[[str], dict[str, dict]]
+) -> list[str]:
+    lines = [
+        "| Metric | " + " | ".join(conditions) + " |",
+        "|---" * (len(conditions) + 1) + "|",
+    ]
+    for name in METRIC_NAMES:
+        direction = " (lower=better)" if name in _LOWER_IS_BETTER else ""
+        cells = [_summary_cell(summaries(c)[name]) for c in conditions]
+        lines.append(f"| {name}{direction} | " + " | ".join(cells) + " |")
+    return lines
+
+
+def _render_markdown(report: ComparativeReport) -> str:
+    conditions = list(report.conditions)
+    lines: list[str] = [
+        "# Comparative Evaluation Report",
+        "",
+        f"- Dataset: `{report.dataset}` (metric: `{report.metric}`)",
+        f"- Answerer: `{report.answerer.get('provider')}/{report.answerer.get('model')}`",
+        (
+            f"- Measurement: `{report.measurement.get('provider')}"
+            f"/{report.measurement.get('model')}`"
+        ),
+        f"- Tasks per condition: {report.tasks_per_condition} "
+        f"(mix: {report.task_mix})",
+        f"- Max turns: {report.max_turns}; base seed: {report.base_seed}",
+        "",
+        "Cells are `mean [95% CI] (n)`; n counts episodes where the metric",
+        "is defined (see module docs for the undefined cases).",
+        "",
+        "## Summary",
+        "",
+    ]
+    lines.extend(
+        _summary_table(conditions, lambda c: report.conditions[c]["summaries"])
+    )
+
+    lines.extend(["", f"## Pairwise Welch t-tests: {_PRIMARY_METRIC}", ""])
+    lines.append("| A | B | mean A | mean B | t | p | significant |")
+    lines.append("|---|---|---|---|---|---|---|")
+    other_significant: list[PairwiseTestResult] = []
+    for test in report.pairwise:
+        if test.metric == _PRIMARY_METRIC:
+            lines.append(
+                f"| {test.condition_a} | {test.condition_b} "
+                f"| {_fmt(test.mean_a)} | {_fmt(test.mean_b)} "
+                f"| {_fmt(test.t_stat)} | {_fmt(test.p_value)} "
+                f"| {'yes' if test.significant else 'no'} |"
+            )
+        elif test.significant:
+            other_significant.append(test)
+
+    lines.extend(["", "## Significant differences on other metrics (Welch 95%)", ""])
+    if other_significant:
+        for test in other_significant:
+            lines.append(
+                f"- {test.metric}: {test.condition_a} vs {test.condition_b} "
+                f"(means {_fmt(test.mean_a)} vs {_fmt(test.mean_b)}, "
+                f"t={_fmt(test.t_stat)}, p={_fmt(test.p_value)})"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Breakdown by difficulty"])
+    for tier, per_condition in report.by_difficulty.items():
+        tier_conditions = [c for c in conditions if c in per_condition]
+        lines.extend(["", f"### {tier}", ""])
+        lines.extend(
+            _summary_table(tier_conditions, lambda c, _pc=per_condition: _pc[c])
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Reproducibility",
+            "",
+            "Episode collection is LLM-stochastic; task selection/pairing,",
+            "controller seeds, and everything downstream of the collected",
+            "episodes (metrics, CIs, tests, this report) are deterministic",
+            "for the recorded base seed.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/bicameral_agent/comparative_eval.py
+++ b/src/bicameral_agent/comparative_eval.py
@@ -52,6 +52,19 @@ What IS deterministic for a fixed seed and fixed inputs:
 - everything downstream of collected episodes: metric extraction,
   summaries, CIs, Welch t-tests / p-values, difficulty breakdown, and
   both report serializations are pure functions of the episodes.
+
+Evaluation integrity: judge blinding
+------------------------------------
+The issue's "human eval blinded" item is N/A here: this framework has no
+human-eval pathway — scoring is LLM-judged by design, with the judge
+model pinned independently of the answerer (issue #53). The concern
+behind blinding — the judge must not know which condition produced an
+answer — holds structurally: verifiers score ``(task, agent_answer)``
+only, so the judge prompt is built from the task's question / gold
+answer / rubric plus the answer text, and the condition name never
+reaches the runner (``run_condition`` passes it only to the persistence
+callback, not to ``run_episode``). Asserted in tests: the captured
+judge prompt contains no condition identity.
 """
 
 from __future__ import annotations
@@ -73,7 +86,7 @@ from bicameral_agent.baseline_benchmark import (
 )
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
-from bicameral_agent.eval_report import TaskResult
+from bicameral_agent.eval_report import EvalReport, TaskResult
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.schema import Episode
@@ -569,32 +582,40 @@ class ComparativeTaskResult(TaskResult):
     difficulty: str = ""
 
 
-class ComparativeReport(BaseModel):
+class ComparativeReport(EvalReport):
     """Machine-readable report for one comparative evaluation run.
 
-    Extends the :class:`~bicameral_agent.eval_report.EvalReport` shape
-    (dataset/metric/provenance/conditions/results) with pairwise tests,
-    the difficulty breakdown, and the run's seed/task-mix identity.
+    Extends :class:`~bicameral_agent.eval_report.EvalReport` (inheriting
+    the dataset/metric/provenance/conditions/results shape and
+    ``to_json``) with pairwise tests, the difficulty breakdown, and the
+    run's seed/task-mix identity; ``results`` rows are narrowed to
+    :class:`ComparativeTaskResult` so each carries its difficulty tier.
+    Here ``conditions`` holds the ``{"n_episodes", "summaries"}`` dicts
+    built by :func:`build_report` (over the nine comparison metrics)
+    rather than baseline ``ConditionReport`` dicts.
     """
 
-    dataset: str
-    metric: str
-    answerer: dict[str, str]
-    measurement: dict[str, str]
-    tasks_per_condition: int
-    max_turns: int
     base_seed: int
     task_mix: dict[str, int]
     task_ids: list[str]
-    conditions: dict[str, dict]
-    """Per-condition ``{"n_episodes", "summaries": {metric: {...}}}``."""
     pairwise: list[PairwiseTestResult]
     by_difficulty: dict[str, dict[str, dict[str, dict]]]
     results: list[ComparativeTaskResult] = Field(default_factory=list)
 
-    def to_json(self) -> str:
-        """Serialize to the report.json payload."""
-        return self.model_dump_json(indent=2)
+    @classmethod
+    def from_benchmark(cls, *args: object, **kwargs: object) -> ComparativeReport:
+        """Unsupported: a comparative report needs the paired analysis.
+
+        The inherited constructor takes an unpaired ``BenchmarkResult``
+        and cannot supply the comparative-only fields (pairwise tests,
+        difficulty breakdown, seed/mix identity); use
+        :func:`build_report` on a :class:`ComparativeResult` instead.
+        """
+        msg = (
+            "ComparativeReport cannot be built from a BenchmarkResult; use "
+            "comparative_eval.build_report(ComparativeResult, ...) instead"
+        )
+        raise NotImplementedError(msg)
 
     def to_markdown(self) -> str:
         """Render the human-readable markdown report."""

--- a/tests/test_comparative_eval.py
+++ b/tests/test_comparative_eval.py
@@ -1,0 +1,506 @@
+"""Tests for comparative_eval — Issue #30.
+
+All tests are mock-LLM: episodes are synthetic and the runner is a
+MagicMock. The learned-condition wiring tests require torch and are
+skipped when it is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from bicameral_agent.ab_test import compute_summary
+from bicameral_agent.baseline_benchmark import TaskMetrics
+from bicameral_agent.comparative_eval import (
+    CONDITION_NAMES,
+    METRIC_NAMES,
+    ComparativeEvaluator,
+    ComparativeResult,
+    baseline_condition_factories,
+    build_report,
+    condition_seed,
+    difficulty_breakdown,
+    metric_values,
+    pairwise_tests,
+    parse_task_mix,
+    select_tasks,
+    student_t_two_tailed_p,
+    welch_test_with_p,
+)
+from bicameral_agent.dataset import (
+    ResearchQADataset,
+    ResearchQATask,
+    TaskDifficulty,
+    TaskSplit,
+)
+from bicameral_agent.episode_runner import EpisodeRunner
+from bicameral_agent.heuristic_controller import HeuristicController
+from bicameral_agent.no_subconscious_controller import NoSubconsciousController
+from bicameral_agent.random_controller import RandomController
+from bicameral_agent.schema import Episode, EpisodeOutcome
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    task_id: str = "t1",
+    difficulty: TaskDifficulty = TaskDifficulty.TYPICAL,
+    split: TaskSplit = TaskSplit.EVAL,
+) -> ResearchQATask:
+    return ResearchQATask(
+        task_id=task_id,
+        difficulty=difficulty,
+        split=split,
+        question="q",
+        gold_answer="a",
+        scoring_rubric="rubric",
+        known_assumptions=(
+            ["assume"] if difficulty == TaskDifficulty.TRICKY else None
+        ),
+    )
+
+
+def _metrics(
+    *,
+    quality_score: float | None = 0.7,
+    total_tokens: int = 100,
+    total_turns: int = 4,
+    user_stops: int = 0,
+    task_completed: int = 1,
+    wall_clock_ms: int = 5000,
+    tool_invocation_count: int = 2,
+    avg_queue_depth: float = 0.5,
+    interrupt_count: int = 1,
+    drain_count: int = 1,
+    expired_count: int = 1,
+    latency_pairs: tuple[tuple[float, float], ...] = ((100.0, 200.0),),
+) -> TaskMetrics:
+    return TaskMetrics(
+        quality_score=quality_score,
+        total_tokens=total_tokens,
+        total_turns=total_turns,
+        user_stops=user_stops,
+        task_completed=task_completed,
+        wall_clock_ms=wall_clock_ms,
+        tool_invocation_count=tool_invocation_count,
+        tool_cost_usd=0.01,
+        avg_queue_depth=avg_queue_depth,
+        interrupt_count=interrupt_count,
+        drain_count=drain_count,
+        expired_count=expired_count,
+        latency_pairs=latency_pairs,
+    )
+
+
+def _episode(quality_score: float | None = 0.7, task_id: str = "t1") -> Episode:
+    return Episode(
+        outcome=EpisodeOutcome(
+            quality_score=quality_score,
+            total_tokens=100,
+            total_turns=3,
+            wall_clock_ms=5000,
+        ),
+        metadata={"task_id": task_id},
+    )
+
+
+def _synthetic_result(
+    conditions: tuple[str, ...] = ("no_subconscious", "heuristic"),
+    qualities: dict[str, list[float]] | None = None,
+) -> ComparativeResult:
+    tasks = [
+        _task("t1", TaskDifficulty.TYPICAL),
+        _task("t2", TaskDifficulty.TYPICAL),
+        _task("t3", TaskDifficulty.HARD),
+        _task("t4", TaskDifficulty.TRICKY),
+    ]
+    qualities = qualities or {
+        c: [0.1 + 0.05 * i + 0.2 * j for i in range(len(tasks))]
+        for j, c in enumerate(conditions)
+    }
+    result = ComparativeResult(tasks=tasks)
+    for condition in conditions:
+        qs = qualities[condition]
+        result.episodes[condition] = [
+            _episode(q, task_id=t.task_id) for q, t in zip(qs, tasks)
+        ]
+        result.metrics[condition] = [_metrics(quality_score=q) for q in qs]
+    return result
+
+
+def _report(result: ComparativeResult | None = None):
+    return build_report(
+        result or _synthetic_result(),
+        dataset="builtin",
+        metric="llm_judge",
+        answerer={"provider": "gemini", "model": "m"},
+        measurement={"provider": "gemini", "model": "m"},
+        max_turns=10,
+        base_seed=42,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Condition wiring
+# ---------------------------------------------------------------------------
+
+
+class TestConditionFactories:
+    def test_baseline_factories_construct_expected_types(self):
+        factories = baseline_condition_factories(HeuristicController, base_seed=7)
+        assert isinstance(factories["no_subconscious"](0), NoSubconsciousController)
+        assert isinstance(factories["random"](0), RandomController)
+        assert isinstance(factories["heuristic"](0), HeuristicController)
+
+    def test_random_seeds_are_per_condition_and_per_task(self):
+        factories = baseline_condition_factories(
+            HeuristicController, random_probability=1.0, base_seed=7
+        )
+        # Same idx -> same decision stream; different idx -> distinct rng seed.
+        a = factories["random"](3)
+        b = factories["random"](3)
+        assert a._rng.random() == b._rng.random()
+
+    def test_condition_seeds_disjoint(self):
+        seeds = {condition_seed(42, c) for c in CONDITION_NAMES}
+        assert len(seeds) == len(CONDITION_NAMES)
+
+    def test_learned_factories_load_checkpoints(self, tmp_path):
+        pytest.importorskip("torch")
+        from bicameral_agent.comparative_eval import learned_condition_factories
+        from bicameral_agent.learned_controller import LearnedPolicyController
+        from bicameral_agent.policy_value_net import PolicyValueNetwork
+        from bicameral_agent.training_pipeline import STATE_DIM
+        from bicameral_agent.transition_model import TransitionModel
+
+        PolicyValueNetwork(input_dim=STATE_DIM).save(tmp_path / "policy.pt")
+        TransitionModel().save(tmp_path / "transition.pt")
+
+        factories = learned_condition_factories(
+            str(tmp_path / "policy.pt"),
+            str(tmp_path / "transition.pt"),
+            num_simulations=5,
+        )
+        assert set(factories) == {"learned_no_search", "learned_with_search"}
+        no_search = factories["learned_no_search"](0)
+        with_search = factories["learned_with_search"](0)
+        assert isinstance(no_search, LearnedPolicyController)
+        assert isinstance(with_search, LearnedPolicyController)
+        assert no_search._engine is None
+        assert with_search._engine is not None
+
+    def test_all_five_conditions_wired(self, tmp_path):
+        pytest.importorskip("torch")
+        from bicameral_agent.comparative_eval import learned_condition_factories
+        from bicameral_agent.policy_value_net import PolicyValueNetwork
+        from bicameral_agent.training_pipeline import STATE_DIM
+        from bicameral_agent.transition_model import TransitionModel
+
+        PolicyValueNetwork(input_dim=STATE_DIM).save(tmp_path / "policy.pt")
+        TransitionModel().save(tmp_path / "transition.pt")
+        conditions = {
+            **baseline_condition_factories(HeuristicController),
+            **learned_condition_factories(
+                str(tmp_path / "policy.pt"), str(tmp_path / "transition.pt")
+            ),
+        }
+        assert tuple(conditions) == CONDITION_NAMES
+
+
+# ---------------------------------------------------------------------------
+# Paired execution
+# ---------------------------------------------------------------------------
+
+
+class TestComparativeEvaluator:
+    def _mock_runner(self, seen: list[tuple[str, str]]) -> MagicMock:
+        runner = MagicMock(spec=EpisodeRunner)
+
+        def run_episode(task, controller):
+            seen.append((type(controller).__name__, task.task_id))
+            return _episode(task_id=task.task_id)
+
+        runner.run_episode.side_effect = run_episode
+        return runner
+
+    def test_task_order_identical_across_conditions(self):
+        seen: list[tuple[str, str]] = []
+        runner = self._mock_runner(seen)
+        tasks = [_task(f"t{i}") for i in range(3)]
+        conditions = {
+            "no_subconscious": lambda _idx: NoSubconsciousController(),
+            "random": lambda idx: RandomController(seed=idx),
+        }
+        result = ComparativeEvaluator(runner).run(tasks, conditions)
+
+        orders = {
+            condition: [tid for controller_name, tid in seen
+                        if controller_name == cls_name]
+            for condition, cls_name in [
+                ("no_subconscious", "NoSubconsciousController"),
+                ("random", "RandomController"),
+            ]
+        }
+        assert orders["no_subconscious"] == orders["random"] == result.task_ids
+        assert result.task_ids == ["t0", "t1", "t2"]
+
+    def test_episodes_and_metrics_collected_per_condition(self):
+        runner = self._mock_runner([])
+        tasks = [_task("t1"), _task("t2")]
+        result = ComparativeEvaluator(runner).run(
+            tasks, {"no_subconscious": lambda _idx: NoSubconsciousController()}
+        )
+        assert len(result.episodes["no_subconscious"]) == 2
+        assert len(result.metrics["no_subconscious"]) == 2
+
+    def test_on_episode_callback_fires_incrementally(self):
+        calls: list[tuple[str, int, str]] = []
+        runner = self._mock_runner([])
+        evaluator = ComparativeEvaluator(
+            runner,
+            on_episode=lambda cond, idx, ep: calls.append(
+                (cond, idx, ep.metadata["task_id"])
+            ),
+        )
+        evaluator.run(
+            [_task("t1"), _task("t2")],
+            {"no_subconscious": lambda _idx: NoSubconsciousController()},
+        )
+        assert calls == [("no_subconscious", 0, "t1"), ("no_subconscious", 1, "t2")]
+
+
+# ---------------------------------------------------------------------------
+# Metric extraction
+# ---------------------------------------------------------------------------
+
+
+class TestMetricValues:
+    def test_derived_rates(self):
+        m = _metrics(
+            total_turns=4,
+            interrupt_count=2,
+            tool_invocation_count=4,
+            drain_count=3,
+            expired_count=1,
+            latency_pairs=((100.0, 200.0), (300.0, 200.0)),
+        )
+        assert metric_values([m], "tool_precision") == [pytest.approx(0.75)]
+        assert metric_values([m], "interrupt_rate") == [pytest.approx(0.5)]
+        assert metric_values([m], "queue_expiry_rate") == [pytest.approx(0.25)]
+        # MAPE: mean(|100-200|/200, |300-200|/200) * 100 = mean(0.5, 0.5)*100
+        assert metric_values([m], "latency_mape") == [pytest.approx(50.0)]
+
+    def test_undefined_metrics_are_skipped(self):
+        m = _metrics(
+            quality_score=None,
+            tool_invocation_count=0,
+            drain_count=0,
+            expired_count=0,
+            latency_pairs=(),
+        )
+        for name in ("task_quality", "tool_precision", "queue_expiry_rate",
+                     "latency_mape"):
+            assert metric_values([m], name) == []
+        # Defined ones still present.
+        assert metric_values([m], "token_efficiency") == [100.0]
+        assert metric_values([m], "time_to_completion_ms") == [5000.0]
+
+    def test_unknown_metric_raises(self):
+        with pytest.raises(ValueError, match="Unknown metric"):
+            metric_values([_metrics()], "nope")
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+class TestStatistics:
+    def test_t_p_value_matches_table(self):
+        # t-table: two-tailed critical value at df=10, alpha=0.05 is 2.228.
+        assert student_t_two_tailed_p(2.228, 10) == pytest.approx(0.05, abs=1e-3)
+        assert student_t_two_tailed_p(0.0, 10) == pytest.approx(1.0)
+        # Large |t| -> tiny p.
+        assert student_t_two_tailed_p(10.0, 30) < 1e-6
+
+    def test_welch_clear_difference_is_significant(self):
+        a = [0.9, 0.85, 0.95, 0.9, 0.88]
+        b = [0.1, 0.15, 0.05, 0.1, 0.12]
+        t_stat, p_value, significant = welch_test_with_p(a, b)
+        assert significant
+        assert p_value < 0.001
+        assert t_stat > 0
+
+    def test_welch_identical_samples_not_significant(self):
+        a = [0.5, 0.5, 0.5]
+        t_stat, p_value, significant = welch_test_with_p(a, list(a))
+        assert not significant
+        assert t_stat == 0.0
+        assert p_value == 1.0
+
+    def test_welch_degenerate_inputs(self):
+        assert welch_test_with_p([0.5], [0.4, 0.6]) == (0.0, 1.0, False)
+
+    def test_pairwise_covers_all_metric_pairs(self):
+        result = _synthetic_result(conditions=("a", "b", "c"))
+        tests = pairwise_tests(result.metrics)
+        assert len(tests) == len(METRIC_NAMES) * 3  # 3 pairs per metric
+        quality = [t for t in tests if t.metric == "task_quality"]
+        assert [(t.condition_a, t.condition_b) for t in quality] == [
+            ("a", "b"), ("a", "c"), ("b", "c"),
+        ]
+
+    def test_pairwise_detects_planted_difference(self):
+        low = [_metrics(quality_score=0.1 + 0.01 * i) for i in range(10)]
+        high = [_metrics(quality_score=0.9 - 0.01 * i) for i in range(10)]
+        tests = pairwise_tests({"low": low, "high": high})
+        quality = next(t for t in tests if t.metric == "task_quality")
+        assert quality.significant
+        assert quality.p_value < 0.05
+        # Identical distributions elsewhere are not flagged.
+        tokens = next(t for t in tests if t.metric == "token_efficiency")
+        assert not tokens.significant
+
+
+# ---------------------------------------------------------------------------
+# Difficulty breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestDifficultyBreakdown:
+    def test_groups_by_task_difficulty(self):
+        result = _synthetic_result()
+        breakdown = difficulty_breakdown(result.tasks, result.metrics)
+        assert list(breakdown) == ["typical", "hard", "tricky"]
+        for condition in result.metrics:
+            assert breakdown["typical"][condition]["task_quality"].n == 2
+            assert breakdown["hard"][condition]["task_quality"].n == 1
+            assert breakdown["tricky"][condition]["task_quality"].n == 1
+
+    def test_per_tier_means_use_paired_indices(self):
+        result = _synthetic_result(
+            conditions=("a",), qualities={"a": [0.2, 0.4, 0.6, 0.8]}
+        )
+        breakdown = difficulty_breakdown(result.tasks, result.metrics)
+        assert breakdown["typical"]["a"]["task_quality"].mean == pytest.approx(0.3)
+        assert breakdown["hard"]["a"]["task_quality"].mean == pytest.approx(0.6)
+        assert breakdown["tricky"]["a"]["task_quality"].mean == pytest.approx(0.8)
+
+    def test_absent_tier_omitted(self):
+        tasks = [_task("t1"), _task("t2")]
+        metrics = {"a": [_metrics(), _metrics()]}
+        assert list(difficulty_breakdown(tasks, metrics)) == ["typical"]
+
+
+# ---------------------------------------------------------------------------
+# Report outputs
+# ---------------------------------------------------------------------------
+
+
+class TestReport:
+    def test_json_schema(self):
+        payload = json.loads(_report().to_json())
+        assert payload["dataset"] == "builtin"
+        assert payload["tasks_per_condition"] == 4
+        assert payload["base_seed"] == 42
+        assert payload["task_mix"] == {"typical": 2, "hard": 1, "tricky": 1}
+        assert payload["task_ids"] == ["t1", "t2", "t3", "t4"]
+        for condition in ("no_subconscious", "heuristic"):
+            summaries = payload["conditions"][condition]["summaries"]
+            assert set(summaries) == set(METRIC_NAMES)
+            for summary in summaries.values():
+                assert set(summary) == {"mean", "std", "ci_lower", "ci_upper", "n"}
+        assert {t["metric"] for t in payload["pairwise"]} == set(METRIC_NAMES)
+        first = payload["pairwise"][0]
+        assert {"condition_a", "condition_b", "t_stat", "p_value",
+                "significant"} <= set(first)
+        assert set(payload["by_difficulty"]) == {"typical", "hard", "tricky"}
+        assert len(payload["results"]) == 8  # 2 conditions x 4 tasks
+        assert payload["results"][0]["difficulty"] == "typical"
+
+    def test_summary_values_match_compute_summary(self):
+        result = _synthetic_result(conditions=("a",))
+        report = _report(result)
+        values = metric_values(result.metrics["a"], "task_quality")
+        expected = compute_summary(values)
+        got = report.conditions["a"]["summaries"]["task_quality"]
+        assert got["mean"] == pytest.approx(expected.mean)
+        assert got["ci_lower"] == pytest.approx(expected.ci_lower)
+        assert got["n"] == expected.n
+
+    def test_markdown_structure(self):
+        md = _report().to_markdown()
+        assert "# Comparative Evaluation Report" in md
+        assert "## Summary" in md
+        assert "## Pairwise Welch t-tests: task_quality" in md
+        assert "## Breakdown by difficulty" in md
+        assert "### typical" in md and "### hard" in md and "### tricky" in md
+        for name in METRIC_NAMES:
+            assert name in md
+        for condition in ("no_subconscious", "heuristic"):
+            assert condition in md
+
+    def test_downstream_determinism(self):
+        result = _synthetic_result()
+        first = _report(result)
+        second = _report(result)
+        assert first.to_json() == second.to_json()
+        assert first.to_markdown() == second.to_markdown()
+
+
+# ---------------------------------------------------------------------------
+# Task mix / selection
+# ---------------------------------------------------------------------------
+
+
+class TestTaskSelection:
+    def _dataset(self, typical=3, hard=2, tricky=2, non_eval_typical=1):
+        tasks = (
+            [_task(f"ty{i}", TaskDifficulty.TYPICAL) for i in range(typical)]
+            + [_task(f"h{i}", TaskDifficulty.HARD) for i in range(hard)]
+            + [_task(f"tr{i}", TaskDifficulty.TRICKY) for i in range(tricky)]
+            + [
+                _task(f"tt{i}", TaskDifficulty.TYPICAL, split=TaskSplit.TOOL_TEST)
+                for i in range(non_eval_typical)
+            ]
+        )
+        return ResearchQADataset(tasks)
+
+    def test_parse_plain_integer(self):
+        assert parse_task_mix("100") == {
+            TaskDifficulty.TYPICAL: 50,
+            TaskDifficulty.HARD: 25,
+            TaskDifficulty.TRICKY: 25,
+        }
+
+    def test_parse_explicit_mix(self):
+        assert parse_task_mix("typical=2, hard=1") == {
+            TaskDifficulty.TYPICAL: 2,
+            TaskDifficulty.HARD: 1,
+            TaskDifficulty.TRICKY: 0,
+        }
+
+    def test_parse_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid task mix"):
+            parse_task_mix("weird=3")
+
+    def test_select_is_deterministic_and_ordered(self):
+        dataset = self._dataset()
+        mix = parse_task_mix("typical=2,hard=1,tricky=1")
+        tasks = select_tasks(dataset, mix)
+        assert [t.task_id for t in tasks] == ["ty0", "ty1", "h0", "tr0"]
+        assert tasks == select_tasks(dataset, mix)
+
+    def test_select_uses_eval_split_only(self):
+        tasks = select_tasks(self._dataset(), {TaskDifficulty.TYPICAL: 3})
+        assert all(t.split == TaskSplit.EVAL for t in tasks)
+
+    def test_select_raises_on_shortfall(self):
+        with pytest.raises(ValueError, match="hard: want 5, have 2"):
+            select_tasks(self._dataset(), {TaskDifficulty.HARD: 5})

--- a/tests/test_comparative_eval.py
+++ b/tests/test_comparative_eval.py
@@ -453,6 +453,67 @@ class TestReport:
         assert first.to_json() == second.to_json()
         assert first.to_markdown() == second.to_markdown()
 
+    def test_extends_eval_report(self):
+        from bicameral_agent.comparative_eval import ComparativeReport
+        from bicameral_agent.eval_report import EvalReport
+
+        assert issubclass(ComparativeReport, EvalReport)
+
+    def test_from_benchmark_is_unsupported(self):
+        from bicameral_agent.comparative_eval import ComparativeReport
+
+        with pytest.raises(NotImplementedError, match="build_report"):
+            ComparativeReport.from_benchmark(MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Evaluation integrity: judge blinding
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeBlinding:
+    """Scoring is LLM-judged by design (no human-eval pathway; issue #53
+    pins the judge model), so "human eval blinded" reduces to: the judge
+    must not see which condition produced an answer.
+    """
+
+    def test_judge_prompt_contains_no_condition_identity(self):
+        from bicameral_agent.scorer import TaskScorer
+
+        client = MagicMock()
+        response = MagicMock()
+        response.content = json.dumps(
+            {"quality": 4, "completeness": 3, "accuracy": 5}
+        )
+        client.generate.return_value = response
+
+        task = _task("t1").model_copy(
+            update={"question": "What is the melting point of gallium?"}
+        )
+        TaskScorer(client=client).score(task, "the agent answer text")
+
+        call = client.generate.call_args
+        prompt_text = f"{call.args} {call.kwargs}".lower()
+        for condition in CONDITION_NAMES:
+            assert condition not in prompt_text
+        assert "controller" not in prompt_text
+        # The judge sees only task-derived fields and the answer.
+        assert task.question.lower() in prompt_text
+        assert "the agent answer text" in prompt_text
+
+    def test_runner_and_verifier_have_no_condition_channel(self):
+        import inspect
+
+        from bicameral_agent.verifiers import Verifier
+
+        # run_condition passes the condition name only to the persistence
+        # callback; run_episode has no parameter that could carry it.
+        run_params = inspect.signature(EpisodeRunner.run_episode).parameters
+        assert set(run_params) == {"self", "task", "controller"}
+        # Verifiers score (task, agent_answer) only.
+        score_params = inspect.signature(Verifier.score).parameters
+        assert set(score_params) == {"self", "task", "agent_answer"}
+
 
 # ---------------------------------------------------------------------------
 # Task mix / selection


### PR DESCRIPTION
## Summary
Implements the issue #30 comparative evaluation harness: `ComparativeEvaluator` runs {no_subconscious, random, heuristic, learned_no_search, learned_with_search} paired over the same evaluation task list (same tasks, same order, disjoint per-condition seed blocks), aggregates 9 comparison metrics with mean ± 95% CI, runs pairwise Welch t-tests with p-values, breaks results down by difficulty tier, and exports JSON + markdown reports.

## Work performed
- `src/bicameral_agent/comparative_eval.py`
  - `ComparativeEvaluator` + `ComparativeResult`: paired 5-condition runs reusing `baseline_benchmark.run_condition` / `TaskMetrics`, with an `on_episode` hook for incremental persistence.
  - `baseline_condition_factories` / `learned_condition_factories`: the learned conditions load `PolicyValueNetwork` / `TransitionModel` checkpoints (lazy torch imports so the module works without the torch extra); `learned_with_search` wraps an `MCTSEngine`; evaluation settings are deterministic (temperature 0, no root noise). `condition_seed` gives each condition a disjoint 10k seed block.
  - Metric mapping (documented in the module docstring): task_quality → verifier `quality_score`; task_completed (the 9th metric — the issue says "9" but names eight); token_efficiency → `total_tokens` (consumption proxy; no per-token quality attribution exists); user_stops → STOP events; time_to_completion_ms → `wall_clock_ms`; tool_precision → consumed injections / tool invocations (proxy: "useful" is not judged, consumed-by-the-loop is the recorded stand-in); interrupt_rate → interrupts/turn; queue_expiry_rate → expired / (drained + expired) resolved queue items (still-pending items are not attributable from episode records); latency_mape → per-episode MAPE from decision-log predicted latencies vs `ToolInvocation` durations.
  - Statistics: reuses `ab_test.compute_summary` / `welch_t_test`; adds two-tailed p-values via the regularized incomplete beta (Lentz continued fraction, no scipy) with exact Welch–Satterthwaite df.
  - `build_report` → `ComparativeReport` (extends the `EvalReport` shape with `pairwise`, `by_difficulty`, `base_seed`, `task_mix`, `task_ids`; per-task results carry difficulty), `to_json()` + `to_markdown()`.
  - Determinism boundary documented honestly: episode collection is LLM-stochastic; task selection/pairing, controller seeds, and everything downstream of collected episodes are deterministic for a fixed seed.
- `scripts/run_comparative_eval.py`: reuses `runner_setup.add_model_args` / `resolve_runner_clients`; `--tasks` accepts a total (50/25/25 split) or an explicit `typical=50,hard=25,tricky=25` mix; `--policy-checkpoint` / `--transition-checkpoint` (+ hidden-dim flags matching `train_mcts.py`); incremental per-condition parquet persistence like the baseline script; writes `report.json` + `report.md`.
- `tests/test_comparative_eval.py` (30 tests, all mock-LLM): 5-condition wiring incl. checkpoint loading (torch tests skip when unavailable), paired task order identical across conditions, metric/rate/MAPE extraction incl. undefined-value skipping, p-value math against the t-table, planted-difference significance, difficulty breakdown, JSON/markdown schema, downstream determinism, task-mix parsing/selection (deterministic, eval-split-only, shortfall errors).

## Test plan
- [x] `uv run --extra dev --extra torch pytest -q` — 1354 passed, 35 skipped
- [x] `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- [x] CLI arg parsing + synthetic-report rendering smoke-checked
- [ ] Pending (live, LLM/data-dependent): 5 × 100 episodes (50 typical + 25 hard + 25 tricky via `--dataset hard_benchmark --tasks typical=50,hard=25,tricky=25`) with real checkpoints from #29 live training; re-run reproducibility of the downstream metrics on the collected episodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy

Refs #30.