### PR TITLE
Contain per-episode transport failures and add per-condition resume

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -21,7 +21,12 @@ import logging
 import sys
 from pathlib import Path
 
-from bicameral_agent.baseline_benchmark import format_report, run_benchmark
+from bicameral_agent.baseline_benchmark import (
+    CONDITION_NAMES,
+    format_report,
+    parse_conditions,
+    run_benchmark,
+)
 from bicameral_agent.config import HyperConfig
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
@@ -77,12 +82,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--metric", default=None,
                         help="Verification metric (defaults to the dataset's "
                              "default_metric; must be in its supported_metrics).")
+    parser.add_argument("--conditions", default=",".join(CONDITION_NAMES),
+                        help="Comma-separated subset of conditions to run "
+                             f"(of: {', '.join(CONDITION_NAMES)}; default all). "
+                             "Lets an aborted run be resumed per-condition.")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
     parser.add_argument("--random-probability", type=float, default=0.2)
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)
+
+    try:
+        selected_conditions = parse_conditions(args.conditions)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     logging.basicConfig(
         level=logging.WARNING if args.quiet else logging.INFO,
@@ -123,7 +137,7 @@ def main(argv: list[str] | None = None) -> int:
         sim_user_client=judge_client,
     )
 
-    conditions = {
+    factories = {
         "no_subconscious": lambda _idx: NoSubconsciousController(),
         "random": lambda idx: RandomController(
             action_probability=args.random_probability,
@@ -131,6 +145,7 @@ def main(argv: list[str] | None = None) -> int:
         ),
         "heuristic": lambda _idx: hyper.to_heuristic_controller(),
     }
+    conditions = {name: factories[name] for name in selected_conditions}
 
     # Persist episodes incrementally: rewrite the condition's parquet after
     # every completed episode so a late crash keeps all prior results.

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -20,6 +20,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Callable
 
 from bicameral_agent.baseline_benchmark import (
     CONDITION_NAMES,
@@ -69,6 +70,33 @@ def select_tasks(dataset: ResearchQADataset, total: int) -> list[ResearchQATask]
                 if len(selected) == total:
                     break
     return selected[:total]
+
+
+def build_conditions(
+    args: argparse.Namespace, hyper: HyperConfig, selected: tuple[str, ...]
+) -> dict[str, Callable]:
+    """Map the selected condition names to their controller factories.
+
+    Raises:
+        RuntimeError: If the factories here drift out of sync with
+            ``CONDITION_NAMES`` (which ``--conditions`` is validated
+            against), so a mismatch fails loudly at startup instead of
+            KeyError-ing mid-run or silently dropping a condition.
+    """
+    factories = {
+        "no_subconscious": lambda _idx: NoSubconsciousController(),
+        "random": lambda idx: RandomController(
+            action_probability=args.random_probability,
+            seed=args.random_seed + idx,
+        ),
+        "heuristic": lambda _idx: hyper.to_heuristic_controller(),
+    }
+    if set(factories) != set(CONDITION_NAMES):
+        raise RuntimeError(
+            f"Controller factories {sorted(factories)} are out of sync with "
+            f"CONDITION_NAMES {sorted(CONDITION_NAMES)}; update both together."
+        )
+    return {name: factories[name] for name in selected}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -137,15 +165,7 @@ def main(argv: list[str] | None = None) -> int:
         sim_user_client=judge_client,
     )
 
-    factories = {
-        "no_subconscious": lambda _idx: NoSubconsciousController(),
-        "random": lambda idx: RandomController(
-            action_probability=args.random_probability,
-            seed=args.random_seed + idx,
-        ),
-        "heuristic": lambda _idx: hyper.to_heuristic_controller(),
-    }
-    conditions = {name: factories[name] for name in selected_conditions}
+    conditions = build_conditions(args, hyper, selected_conditions)
 
     # Persist episodes incrementally: rewrite the condition's parquet after
     # every completed episode so a late crash keeps all prior results.

--- a/src/bicameral_agent/baseline_benchmark.py
+++ b/src/bicameral_agent/baseline_benchmark.py
@@ -18,9 +18,66 @@ from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.episode_runner import Controller, EpisodeRunner
 from bicameral_agent.gemini import GeminiClient
 from bicameral_agent.heuristic_controller import Action, DecisionLog, TOOL_IDS
+from bicameral_agent.model_client import TransportExhausted
 from bicameral_agent.schema import Episode, UserEventType, episode_completed
 
 logger = logging.getLogger(__name__)
+
+CONDITION_NAMES: tuple[str, ...] = ("no_subconscious", "random", "heuristic")
+
+FAILURE_THRESHOLD = 0.3
+"""Abort a condition once transport failures exceed this fraction of its episodes."""
+
+
+def parse_conditions(spec: str) -> tuple[str, ...]:
+    """Parse a comma-separated ``--conditions`` value into canonical order.
+
+    Duplicates collapse and the result follows ``CONDITION_NAMES`` order
+    regardless of input order, so a resumed run's report sections line up
+    with a full run's.
+
+    Raises:
+        ValueError: On an empty spec or unknown condition names.
+    """
+    names = {n.strip() for n in spec.split(",") if n.strip()}
+    unknown = sorted(names - set(CONDITION_NAMES))
+    if unknown:
+        raise ValueError(
+            f"Unknown condition(s) {unknown}; valid: {list(CONDITION_NAMES)}"
+        )
+    if not names:
+        raise ValueError(f"No conditions given; valid: {list(CONDITION_NAMES)}")
+    return tuple(c for c in CONDITION_NAMES if c in names)
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeFailure:
+    """A per-episode transport failure contained by :func:`run_condition`."""
+
+    condition: str
+    episode_index: int
+    task_id: str
+    error: str
+
+
+class ConditionAbortedError(RuntimeError):
+    """Transport failures exceeded the threshold for one condition.
+
+    Raised instead of silently finishing a near-empty condition when the
+    network/provider is effectively down (issue #81). Resume the aborted
+    conditions with ``--conditions`` once the transport recovers.
+    """
+
+    def __init__(self, condition: str, n_failures: int, n_tasks: int, threshold: float) -> None:
+        self.condition = condition
+        self.n_failures = n_failures
+        self.n_tasks = n_tasks
+        super().__init__(
+            f"Aborting condition {condition!r}: {n_failures}/{n_tasks} episodes "
+            f"({n_failures / n_tasks:.0%}) failed on transport errors, exceeding "
+            f"the {threshold:.0%} threshold; check the network/provider and "
+            f"resume with --conditions {condition}."
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -176,6 +233,8 @@ class BenchmarkResult:
     episodes: dict[str, list[Episode]] = field(default_factory=dict)
     metrics: dict[str, list[TaskMetrics]] = field(default_factory=dict)
     reports: dict[str, ConditionReport] = field(default_factory=dict)
+    failures: dict[str, list[EpisodeFailure]] = field(default_factory=dict)
+    """Per-condition transport failures contained during the run."""
 
 
 ControllerFactory = Callable[[int], Controller]
@@ -190,24 +249,52 @@ def run_condition(
     controller_factory: ControllerFactory,
     condition: str = "",
     on_episode: EpisodeCallback | None = None,
-) -> tuple[list[Episode], list[TaskMetrics]]:
+    failure_threshold: float = FAILURE_THRESHOLD,
+) -> tuple[list[Episode], list[TaskMetrics], list[EpisodeFailure]]:
     """Run one controller condition over the task pool.
 
     A fresh controller is constructed per episode (via ``controller_factory(idx)``)
     so that decision logs are scoped to a single episode. ``on_episode`` (if
     given) fires after each completed episode, letting callers persist results
     incrementally so a late crash keeps prior episodes.
+
+    A :class:`~bicameral_agent.model_client.TransportExhausted` error (a
+    transport failure that outlived the client's retry budget) fails only its
+    episode: the failure is recorded and the run continues with the next task.
+    Once failures exceed ``failure_threshold`` of the condition's episodes,
+    :class:`ConditionAbortedError` is raised instead — a dead network must not
+    produce a near-empty "successful" run.
     """
     episodes: list[Episode] = []
     metrics: list[TaskMetrics] = []
+    failures: list[EpisodeFailure] = []
     for idx, task in enumerate(tasks):
         controller = controller_factory(idx)
-        episode = runner.run_episode(task, controller)
+        try:
+            episode = runner.run_episode(task, controller)
+        except TransportExhausted as exc:
+            failures.append(
+                EpisodeFailure(
+                    condition=condition,
+                    episode_index=idx,
+                    task_id=task.task_id,
+                    error=str(exc),
+                )
+            )
+            logger.warning(
+                "Episode %d (task %s) in condition %r failed on transport: %s",
+                idx, task.task_id, condition, exc,
+            )
+            if len(failures) / len(tasks) > failure_threshold:
+                raise ConditionAbortedError(
+                    condition, len(failures), len(tasks), failure_threshold
+                ) from exc
+            continue
         episodes.append(episode)
         metrics.append(extract_task_metrics(episode, list(controller.decisions)))
         if on_episode is not None:
             on_episode(condition, idx, episode)
-    return episodes, metrics
+    return episodes, metrics, failures
 
 
 def _format_summary(summary: MetricSummary, fmt: str) -> str:
@@ -223,22 +310,26 @@ def run_benchmark(
     conditions: dict[str, ControllerFactory],
     runner: EpisodeRunner | None = None,
     on_episode: EpisodeCallback | None = None,
+    failure_threshold: float = FAILURE_THRESHOLD,
 ) -> BenchmarkResult:
     """Run all conditions over the task pool and aggregate.
 
     ``on_episode`` is forwarded to :func:`run_condition` for incremental
-    persistence of completed episodes.
+    persistence of completed episodes, ``failure_threshold`` for the
+    per-condition transport-failure abort.
     """
     runner = runner or EpisodeRunner(client)
     result = BenchmarkResult()
     for condition, factory in conditions.items():
         logger.info("Running %d episodes for condition %r", len(tasks), condition)
-        episodes, metrics = run_condition(
-            runner, tasks, factory, condition=condition, on_episode=on_episode
+        episodes, metrics, failures = run_condition(
+            runner, tasks, factory, condition=condition, on_episode=on_episode,
+            failure_threshold=failure_threshold,
         )
         result.episodes[condition] = episodes
         result.metrics[condition] = metrics
         result.reports[condition] = aggregate(condition, metrics)
+        result.failures[condition] = failures
     return result
 
 
@@ -279,6 +370,12 @@ def format_report(result: BenchmarkResult) -> str:
             f"  latency_prediction       MAPE={report.latency_mape_percent:.2f}% "
             f"n_pairs={report.latency_n_pairs}"
         )
+        failures = result.failures.get(condition, [])
+        if failures:
+            failed_ids = ", ".join(f.task_id for f in failures)
+            lines.append(
+                f"  transport_failures       n={len(failures)} (tasks: {failed_ids})"
+            )
         lines.append("")
 
     lines.append("## Comparisons")

--- a/src/bicameral_agent/eval_report.py
+++ b/src/bicameral_agent/eval_report.py
@@ -32,6 +32,14 @@ class TaskResult(BaseModel):
     """Verifier-specific report (from episode.metadata["verification"])."""
 
 
+class TaskFailure(BaseModel):
+    """One episode that failed on a contained transport error (issue #81)."""
+
+    task_id: str
+    condition: str
+    error: str
+
+
 class EvalReport(BaseModel):
     """Machine-readable report for one benchmark run."""
 
@@ -44,6 +52,8 @@ class EvalReport(BaseModel):
     conditions: dict[str, dict]
     """Per-condition ConditionReport dicts (summaries with mean/std/CI)."""
     results: list[TaskResult] = Field(default_factory=list)
+    failures: list[TaskFailure] = Field(default_factory=list)
+    """Episodes skipped after transport retries were exhausted."""
 
     @classmethod
     def from_benchmark(
@@ -68,6 +78,13 @@ class EvalReport(BaseModel):
             for condition, episodes in result.episodes.items()
             for episode in episodes
         ]
+        failures = [
+            TaskFailure(
+                task_id=failure.task_id, condition=condition, error=failure.error
+            )
+            for condition, condition_failures in result.failures.items()
+            for failure in condition_failures
+        ]
         return cls(
             dataset=dataset,
             metric=metric,
@@ -80,6 +97,7 @@ class EvalReport(BaseModel):
                 for condition, report in result.reports.items()
             },
             results=results,
+            failures=failures,
         )
 
     def to_json(self) -> str:

--- a/src/bicameral_agent/model_client.py
+++ b/src/bicameral_agent/model_client.py
@@ -89,18 +89,37 @@ def validate_thinking_level(thinking_level: str) -> str:
     return lowered
 
 
+class TransportExhausted(RuntimeError):
+    """A retryable transport error survived the whole client retry budget.
+
+    Raised by ``RetryingClientBase._execute_with_retry`` in place of the
+    final provider exception (preserved as ``__cause__``) so callers can
+    contain exhausted-retry transport failures narrowly, without also
+    catching non-transient errors such as bad requests or parsing bugs
+    (issue #81).
+    """
+
+    def __init__(self, attempts: int, last_error: Exception) -> None:
+        self.attempts = attempts
+        self.last_error = last_error
+        super().__init__(
+            f"transport error persisted after {attempts} attempts: "
+            f"{type(last_error).__name__}: {last_error}"
+        )
+
+
 class RetryingClientBase:
     """Shared retry/backoff scaffold for concrete model clients.
 
     Subclasses implement ``_is_retryable`` (their typed, provider-specific
     transient-error check) and route each API call through
     ``_execute_with_retry`` with a zero-arg attempt callable that performs
-    one timed request/parse round trip.
+    one timed request/parse round trip. A retryable error that survives
+    the whole budget is raised as ``TransportExhausted``; non-retryable
+    errors propagate unchanged.
     """
 
     def _execute_with_retry(self, attempt: Callable[[], ModelResponse]) -> ModelResponse:
-        last_exc: Exception | None = None
-
         for attempt_idx in range(_MAX_RETRIES + 1):
             if attempt_idx > 0:
                 delay = _BASE_DELAY * (_BACKOFF_FACTOR ** (attempt_idx - 1))
@@ -110,12 +129,12 @@ class RetryingClientBase:
             try:
                 return attempt()
             except Exception as exc:
-                if self._is_retryable(exc) and attempt_idx < _MAX_RETRIES:
-                    last_exc = exc
-                    continue
-                raise
+                if not self._is_retryable(exc):
+                    raise
+                if attempt_idx == _MAX_RETRIES:
+                    raise TransportExhausted(_MAX_RETRIES + 1, exc) from exc
 
-        raise last_exc  # type: ignore[misc]
+        raise AssertionError("unreachable: retry loop always returns or raises")
 
     @staticmethod
     def _is_retryable(exc: Exception) -> bool:

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -616,3 +618,28 @@ class TestTransportFailureContainment:
         assert result.failures["random"] == []
         assert result.reports["heuristic"].n_episodes == 3
         assert result.reports["random"].n_episodes == 4
+
+
+def _load_benchmark_script():
+    """Import scripts/run_baseline_benchmark.py (not a package) by path."""
+    path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "run_baseline_benchmark.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_baseline_benchmark", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBuildConditions:
+    """The script's factories must stay in sync with CONDITION_NAMES."""
+
+    def test_factories_cover_all_condition_names(self):
+        script = _load_benchmark_script()
+        conditions = script.build_conditions(MagicMock(), MagicMock(), CONDITION_NAMES)
+        assert tuple(conditions) == CONDITION_NAMES
+
+    def test_subset_builds_only_selected(self):
+        script = _load_benchmark_script()
+        conditions = script.build_conditions(MagicMock(), MagicMock(), ("heuristic",))
+        assert list(conditions) == ["heuristic"]

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -8,10 +8,15 @@ import pytest
 
 from bicameral_agent.baseline_benchmark import (
     aggregate,
+    BenchmarkResult,
+    ConditionAbortedError,
+    CONDITION_NAMES,
+    EpisodeFailure,
     extract_task_metrics,
     format_report,
     heuristic_outperforms,
     latency_mape,
+    parse_conditions,
     run_benchmark,
     run_condition,
     TaskMetrics,
@@ -25,6 +30,7 @@ from bicameral_agent.heuristic_controller import (
     FullState,
     TOOL_IDS,
 )
+from bicameral_agent.model_client import TransportExhausted
 from bicameral_agent.schema import (
     ContextInjection,
     Episode,
@@ -81,9 +87,9 @@ def _make_episode(
     )
 
 
-def _task() -> ResearchQATask:
+def _task(task_id: str = "t1") -> ResearchQATask:
     return ResearchQATask(
-        task_id="t1",
+        task_id=task_id,
         difficulty=TaskDifficulty.TYPICAL,
         split=TaskSplit.EVAL,
         question="q",
@@ -310,8 +316,6 @@ class TestComparisons:
 
 class TestFormatReport:
     def test_includes_all_conditions(self):
-        from bicameral_agent.baseline_benchmark import BenchmarkResult
-
         def _report(name: str, qualities: list[float]):
             return aggregate(name, [_metrics(quality_score=q) for q in qualities])
 
@@ -329,6 +333,66 @@ class TestFormatReport:
         assert "quality_score" in text
         assert "heuristic > random on quality_score (Welch 95%): YES" in text
         assert "heuristic > no_subconscious on quality_score (Welch 95%): YES" in text
+
+    def test_subset_compares_only_present_conditions(self):
+        """A --conditions subset run reports comparisons among present conditions only."""
+        result = BenchmarkResult()
+        result.reports = {
+            "heuristic": aggregate(
+                "heuristic", [_metrics(quality_score=q) for q in (0.6, 0.62, 0.58)]
+            ),
+            "random": aggregate(
+                "random", [_metrics(quality_score=q) for q in (0.4, 0.42, 0.38)]
+            ),
+        }
+        text = format_report(result)
+        assert "heuristic > random on quality_score" in text
+        assert "no_subconscious" not in text
+
+    def test_single_condition_report_has_no_comparisons(self):
+        result = BenchmarkResult()
+        result.reports = {
+            "no_subconscious": aggregate("no_subconscious", [_metrics(), _metrics()])
+        }
+        text = format_report(result)
+        assert "no_subconscious" in text
+        assert "heuristic >" not in text
+
+    def test_lists_transport_failures(self):
+        result = BenchmarkResult()
+        result.reports = {"random": aggregate("random", [_metrics()])}
+        result.failures = {
+            "random": [
+                EpisodeFailure(
+                    condition="random", episode_index=1, task_id="t7",
+                    error="transport error persisted after 4 attempts",
+                )
+            ]
+        }
+        text = format_report(result)
+        assert "transport_failures       n=1 (tasks: t7)" in text
+
+
+class TestParseConditions:
+    def test_default_spec_returns_all(self):
+        assert parse_conditions(",".join(CONDITION_NAMES)) == CONDITION_NAMES
+
+    def test_single_condition(self):
+        assert parse_conditions("heuristic") == ("heuristic",)
+
+    def test_canonical_order_and_dedup(self):
+        assert parse_conditions("heuristic, random,heuristic") == (
+            "random",
+            "heuristic",
+        )
+
+    def test_unknown_condition_raises(self):
+        with pytest.raises(ValueError, match="Unknown condition"):
+            parse_conditions("heuristic,bogus")
+
+    def test_empty_spec_raises(self):
+        with pytest.raises(ValueError, match="No conditions"):
+            parse_conditions(" , ")
 
 
 class _StubController:
@@ -355,11 +419,12 @@ class TestRunCondition:
             return _StubController()
 
         tasks = [_task(), _task(), _task()]
-        episodes, metrics = run_condition(runner, tasks, factory)
+        episodes, metrics, failures = run_condition(runner, tasks, factory)
 
         assert factory_calls == [0, 1, 2]
         assert len(episodes) == 3
         assert len(metrics) == 3
+        assert failures == []
         assert runner.run_episode.call_count == 3
 
     def test_run_benchmark_aggregates_each_condition(self):
@@ -432,3 +497,122 @@ class TestIncrementalPersistence:
             on_episode=lambda cond, idx, ep: seen.append(cond),
         )
         assert seen == ["heuristic", "random"]
+
+
+def _transport_exhausted() -> TransportExhausted:
+    return TransportExhausted(4, TimeoutError("read timed out"))
+
+
+class TestTransportFailureContainment:
+    """Issue #81: a transport failure that outlives client retries fails only
+    its episode; the condition continues unless failures exceed the threshold."""
+
+    def test_failed_episode_recorded_and_run_continues(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        episode = _make_episode()
+        runner.run_episode.side_effect = [
+            episode, _transport_exhausted(), episode, episode
+        ]
+        tasks = [_task(f"t{i}") for i in range(4)]
+
+        episodes, metrics, failures = run_condition(
+            runner, tasks, lambda _idx: _StubController(), condition="random"
+        )
+
+        assert runner.run_episode.call_count == 4
+        assert len(episodes) == 3
+        assert len(metrics) == 3
+        (failure,) = failures
+        assert failure.condition == "random"
+        assert failure.episode_index == 1
+        assert failure.task_id == "t1"
+        assert "read timed out" in failure.error
+
+    def test_on_episode_skips_failed_episode(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        episode = _make_episode()
+        runner.run_episode.side_effect = [
+            episode, _transport_exhausted(), episode, episode
+        ]
+
+        seen: list[int] = []
+        run_condition(
+            runner,
+            [_task(f"t{i}") for i in range(4)],
+            lambda _idx: _StubController(),
+            condition="random",
+            on_episode=lambda cond, idx, ep: seen.append(idx),
+        )
+        assert seen == [0, 2, 3]
+
+    def test_threshold_abort_names_failure_rate(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = _transport_exhausted()
+        tasks = [_task(f"t{i}") for i in range(3)]
+
+        # 1 failure out of 3 tasks (33%) already exceeds the 30% default.
+        with pytest.raises(ConditionAbortedError, match=r"1/3 episodes \(33%\)"):
+            run_condition(
+                runner, tasks, lambda _idx: _StubController(), condition="random"
+            )
+        assert runner.run_episode.call_count == 1
+
+    def test_failures_below_threshold_do_not_abort(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        episode = _make_episode()
+        # 3 failures out of 10 tasks = 30%, not strictly above the threshold.
+        effects: list = [_transport_exhausted()] * 3 + [episode] * 7
+        runner.run_episode.side_effect = effects
+
+        episodes, _, failures = run_condition(
+            runner,
+            [_task(f"t{i}") for i in range(10)],
+            lambda _idx: _StubController(),
+            condition="heuristic",
+        )
+        assert len(episodes) == 7
+        assert len(failures) == 3
+
+    def test_abort_preserves_transport_error_as_cause(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = _transport_exhausted()
+
+        with pytest.raises(ConditionAbortedError) as exc_info:
+            run_condition(
+                runner,
+                [_task()],
+                lambda _idx: _StubController(),
+                condition="random",
+            )
+        assert isinstance(exc_info.value.__cause__, TransportExhausted)
+
+    def test_non_transport_error_still_propagates(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = ValueError("programming bug")
+
+        with pytest.raises(ValueError, match="programming bug"):
+            run_condition(
+                runner, [_task()], lambda _idx: _StubController(), condition="random"
+            )
+
+    def test_run_benchmark_records_failures_per_condition(self):
+        runner = MagicMock(spec=EpisodeRunner)
+        episode = _make_episode()
+        runner.run_episode.side_effect = [
+            episode, _transport_exhausted(), episode, episode,  # heuristic
+            episode, episode, episode, episode,  # random
+        ]
+
+        result = run_benchmark(
+            client=MagicMock(),
+            tasks=[_task(f"t{i}") for i in range(4)],
+            conditions={
+                "heuristic": lambda _idx: _StubController(),
+                "random": lambda _idx: _StubController(),
+            },
+            runner=runner,
+        )
+        assert [f.task_id for f in result.failures["heuristic"]] == ["t1"]
+        assert result.failures["random"] == []
+        assert result.reports["heuristic"].n_episodes == 3
+        assert result.reports["random"].n_episodes == 4

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -3,7 +3,11 @@
 import json
 
 from bicameral_agent.ab_test import compute_summary
-from bicameral_agent.baseline_benchmark import BenchmarkResult, ConditionReport
+from bicameral_agent.baseline_benchmark import (
+    BenchmarkResult,
+    ConditionReport,
+    EpisodeFailure,
+)
 from bicameral_agent.eval_report import EvalReport
 
 # Metrics the ui/ Review screen reads from summary.json
@@ -88,3 +92,34 @@ class TestEvalReport:
         )
         (task_result,) = _make_report(result).results
         assert task_result.detail is None
+
+    def test_contained_transport_failures_serialized(self, make_episode):
+        """Issue #81: contained per-episode failures land in summary.json."""
+        result = BenchmarkResult(
+            episodes={"random": [make_episode(metadata={"task_id": "t1"})]},
+            reports={"random": _condition_report("random")},
+            failures={
+                "random": [
+                    EpisodeFailure(
+                        condition="random", episode_index=2, task_id="t3",
+                        error="transport error persisted after 4 attempts",
+                    )
+                ]
+            },
+        )
+        payload = json.loads(_make_report(result).to_json())
+        assert payload["failures"] == [
+            {
+                "task_id": "t3",
+                "condition": "random",
+                "error": "transport error persisted after 4 attempts",
+            }
+        ]
+
+    def test_failures_key_present_when_empty(self, make_episode):
+        result = BenchmarkResult(
+            episodes={"random": [make_episode()]},
+            reports={"random": _condition_report("random")},
+        )
+        payload = json.loads(_make_report(result).to_json())
+        assert payload["failures"] == []

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -17,6 +17,7 @@ from bicameral_agent.model_client import (
     _BASE_DELAY,
     _BACKOFF_FACTOR,
     _MAX_RETRIES,
+    TransportExhausted,
 )
 
 
@@ -252,9 +253,10 @@ class TestRetryLogic:
         exc_429 = Exception("429 Too Many Requests")
         sdk.models.generate_content.side_effect = exc_429
         with patch("bicameral_agent.model_client.time.sleep"):
-            with pytest.raises(Exception, match="429"):
+            with pytest.raises(TransportExhausted, match="429") as exc_info:
                 client.generate([{"role": "user", "content": "hi"}])
         assert sdk.models.generate_content.call_count == _MAX_RETRIES + 1
+        assert exc_info.value.__cause__ is exc_429
 
     def test_exponential_backoff_timing(self, mock_client):
         client, sdk = mock_client

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -10,13 +10,21 @@ adapter, and that the Ollama Gemma tag is a known (flat-rate) model for
 from __future__ import annotations
 
 import logging
+from unittest.mock import patch
 
 import pytest
 
 from bicameral_agent.config import HyperConfig, ModelConfig
 from bicameral_agent.cost_tracker import MODEL_PRICING, CostTracker, resolve_pricing
 from bicameral_agent.gemini import GeminiClient
-from bicameral_agent.model_client import build_client, default_model, provider_names
+from bicameral_agent.model_client import (
+    _MAX_RETRIES,
+    RetryingClientBase,
+    TransportExhausted,
+    build_client,
+    default_model,
+    provider_names,
+)
 from bicameral_agent.ollama_cloud import OllamaCloudClient
 
 
@@ -112,6 +120,58 @@ class TestModelConfigProvider:
         client = config.to_model_client()
         assert isinstance(client, OllamaCloudClient)
         assert client.model == "gemma4:31b-cloud"
+
+
+class _TimeoutRetryClient(RetryingClientBase):
+    """Retry-base test double: only TimeoutError is retryable."""
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        return isinstance(exc, TimeoutError)
+
+
+class TestTransportExhausted:
+    """Issue #81: exhausted retries surface as a typed error callers can catch."""
+
+    def test_exhausted_retries_raise_typed_error_with_cause(self):
+        client = _TimeoutRetryClient()
+        original = TimeoutError("read timed out")
+        calls = {"n": 0}
+
+        def _attempt():
+            calls["n"] += 1
+            raise original
+
+        with patch("bicameral_agent.model_client.time.sleep"):
+            with pytest.raises(TransportExhausted, match="read timed out") as exc_info:
+                client._execute_with_retry(_attempt)
+
+        assert calls["n"] == _MAX_RETRIES + 1
+        assert exc_info.value.__cause__ is original
+        assert exc_info.value.last_error is original
+        assert exc_info.value.attempts == _MAX_RETRIES + 1
+
+    def test_non_retryable_error_propagates_unwrapped(self):
+        client = _TimeoutRetryClient()
+
+        def _attempt():
+            raise ValueError("bad request")
+
+        with pytest.raises(ValueError, match="bad request"):
+            client._execute_with_retry(_attempt)
+
+    def test_success_after_transient_failures_is_not_wrapped(self):
+        client = _TimeoutRetryClient()
+        outcomes = [TimeoutError("t1"), TimeoutError("t2"), "ok"]
+
+        def _attempt():
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        with patch("bicameral_agent.model_client.time.sleep"):
+            assert client._execute_with_retry(_attempt) == "ok"
 
 
 class TestGemmaPricing:

--- a/tests/test_ollama_cloud.py
+++ b/tests/test_ollama_cloud.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bicameral_agent.gemini import ChatMessage, GeminiResponse
-from bicameral_agent.model_client import _MAX_RETRIES
+from bicameral_agent.model_client import _MAX_RETRIES, TransportExhausted
 from bicameral_agent.ollama_cloud import OllamaCloudClient
 
 
@@ -318,9 +318,10 @@ class TestRetry:
 
         with patch("urllib.request.urlopen", _fake), \
                 patch("bicameral_agent.model_client.time.sleep") as sleep:
-            with pytest.raises(urllib.error.HTTPError):
+            with pytest.raises(TransportExhausted) as exc_info:
                 OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
         assert sleep.call_count == _MAX_RETRIES
+        assert isinstance(exc_info.value.__cause__, urllib.error.HTTPError)
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +404,9 @@ class TestReadPhaseRetry:
 
         with patch("urllib.request.urlopen", _fake), \
                 patch("bicameral_agent.model_client.time.sleep") as sleep:
-            with pytest.raises(TimeoutError):
+            with pytest.raises(TransportExhausted) as exc_info:
                 OllamaCloudClient(api_key="k").generate(
                     [{"role": "user", "content": "x"}]
                 )
         assert sleep.call_count == _MAX_RETRIES
+        assert isinstance(exc_info.value.__cause__, TimeoutError)


### PR DESCRIPTION
## Summary
- Add a typed `TransportExhausted` error to the shared retry base (`model_client.RetryingClientBase`): when a retryable error survives the full retry budget it is raised in place of the raw provider exception, with the original preserved as `__cause__`. Non-retryable errors still propagate unchanged. Both clients (`GeminiClient`, `OllamaCloudClient`) inherit this via `_execute_with_retry`; no `generate()` signature changes.
- `run_condition` now contains transport failures per episode: the failure (condition, episode index, task id, error string) is recorded on `BenchmarkResult.failures` and the run continues with the next task. Once failures exceed 30% of the condition's episodes it raises `ConditionAbortedError` naming the failure rate, so a dead network cannot produce a near-empty "successful" run.
- Contained failures are reported: a `transport_failures` line per condition in `report.txt` and an additive `failures` key in `summary.json` (`EvalReport`).
- `scripts/run_baseline_benchmark.py` gains `--conditions` (comma-separated subset of no_subconscious, random, heuristic; default all; validated before any client build) so an aborted run can be resumed per-condition. Report/summary generation compares only among present conditions.

## Motivation
The 2026-07-07 pilot run (#46) died after 19/30 episodes when an Ollama read timeout exhausted the client retries and propagated to `main`, killing the heuristic condition entirely. This is the same all-or-nothing failure mode #47 targeted, one layer down.

## Testing
- `uv run --extra dev --extra torch pytest -q` — 1344 passed, 35 skipped
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- New tests: retry-base `TransportExhausted` typing (wrapped with cause, non-retryable unwrapped, success unaffected); mid-condition transport failure continues and records the failure while `on_episode` skips it; threshold abort at >30% with the rate in the message; sub-threshold failures do not abort; non-transport errors still propagate; `parse_conditions` (subset, canonical order, dedupe, unknown/empty rejection); subset reports omit absent-condition comparisons; failures serialized in `summary.json`.
- Manual: `--conditions bogus` exits 2 with a clear error before any client is built; `--help` documents the flag.

Closes #81