### PR TITLE
Ground Ollama structured output and count parse degradations

### DIFF
--- a/src/bicameral_agent/context_refresher.py
+++ b/src/bicameral_agent/context_refresher.py
@@ -9,8 +9,8 @@ no drift is detected.
 from __future__ import annotations
 
 import enum
-import json
 
+from bicameral_agent.llm_output import safe_parse_json
 from bicameral_agent.queue import Priority, QueueItem
 from bicameral_agent.schema import Message, estimate_text_tokens
 from bicameral_agent.tool_primitive import (
@@ -143,7 +143,14 @@ class ContextRefresher(ToolPrimitive):
                 ),
             )
 
-        parsed = _parse_json(response.content)
+        # Malformed output degrades to "no drift" (the pre-#82 local parser's
+        # fallback), now via safe_parse_json so the degradation is warned and
+        # counted like every other structured-output site.
+        parsed = safe_parse_json(
+            response,
+            context="ContextRefresher",
+            default={"drift_detected": False, "drifts": [], "reminder": None},
+        )
 
         if not parsed.get("drift_detected", False):
             return ToolResult(
@@ -210,24 +217,6 @@ class ContextRefresher(ToolPrimitive):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _parse_json(text: str) -> dict:
-    """Extract and parse JSON from LLM response, handling preamble text."""
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        # Try to find JSON object in the response
-        # Find the first top-level JSON object by matching balanced braces
-        start = text.find("{")
-        if start != -1:
-            decoder = json.JSONDecoder()
-            try:
-                obj, _ = decoder.raw_decode(text, start)
-                return obj
-            except json.JSONDecodeError:
-                pass
-        return {"drift_detected": False, "drifts": [], "reminder": None}
 
 
 def _extract_first_user_message(history: list[Message]) -> Message | None:

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -20,6 +20,7 @@ from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.encoder import StateEncoder
 from bicameral_agent.gap_scanner import ResearchGapScanner
 from bicameral_agent.heuristic_controller import Action, DecisionLog, FullState, TOOL_IDS
+from bicameral_agent.llm_output import DegradationCounter, count_degradations
 from bicameral_agent.logger import ConversationLogger
 from bicameral_agent.model_client import ModelClient
 from bicameral_agent.queue import ContextQueue, InterruptConfig
@@ -158,6 +159,19 @@ class EpisodeRunner:
         Episode
             A validated Episode capturing the full conversation.
         """
+        # Episode-scoped degradation counting (issue #82): every
+        # structured-output site funnels through safe_parse_json, whose
+        # degradation warning this handler tallies -- no counter threading
+        # through the six components (sim-user, tools, scorer/verifiers).
+        with count_degradations() as degradations:
+            return self._run_episode(task, controller, degradations)
+
+    def _run_episode(
+        self,
+        task: ResearchQATask,
+        controller: Controller,
+        degradations: DegradationCounter,
+    ) -> Episode:
         cfg = self._config
 
         # Cost tracking: reset episode, wrap every role's client so judge and
@@ -477,5 +491,9 @@ class EpisodeRunner:
                 "total": episode_cost.total,
                 "call_count": episode_cost.call_count,
             })
+
+        # After scoring, so judge/verifier degradations are included. Always
+        # present (empty dict on a clean episode) so runs can report a rate.
+        log.set_metadata("parse_degradations", dict(degradations.counts))
 
         return log.finalize(quality_score)

--- a/src/bicameral_agent/llm_output.py
+++ b/src/bicameral_agent/llm_output.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from collections import Counter
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Iterator
 
 if TYPE_CHECKING:
     from bicameral_agent.schema import Message
@@ -61,8 +63,46 @@ def safe_parse_json(response: Any, *, context: str, default: dict | None = None)
         context,
         getattr(response, "finish_reason", "unknown"),
         len(text),
+        extra={"degradation_component": context},
     )
     return default
+
+
+class DegradationCounter(logging.Handler):
+    """Tallies ``safe_parse_json`` degradations per component (issue #82).
+
+    ``safe_parse_json`` tags its degradation warning with the caller's
+    *context* string; this handler counts those tags, ignoring any other
+    records. Attach via ``count_degradations`` so counts are scoped to one
+    episode -- a module-level counter would bleed across episodes.
+    ``logging`` serializes ``emit`` per handler, so counting is safe under
+    the scorers' worker threads.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.counts: Counter[str] = Counter()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        component = getattr(record, "degradation_component", None)
+        if component is not None:
+            self.counts[component] += 1
+
+
+@contextmanager
+def count_degradations() -> Iterator[DegradationCounter]:
+    """Count safe-parse degradations occurring inside the ``with`` block.
+
+    Yields a ``DegradationCounter`` whose ``counts`` maps component context
+    strings (e.g. ``"TaskScorer"``) to degradation counts. The handler is
+    detached on exit, so counters never observe each other's blocks.
+    """
+    counter = DegradationCounter()
+    logger.addHandler(counter)
+    try:
+        yield counter
+    finally:
+        logger.removeHandler(counter)
 
 
 def clamp(value: Any, low: float, high: float, default: float) -> float:

--- a/src/bicameral_agent/llm_output.py
+++ b/src/bicameral_agent/llm_output.py
@@ -77,6 +77,12 @@ class DegradationCounter(logging.Handler):
     episode -- a module-level counter would bleed across episodes.
     ``logging`` serializes ``emit`` per handler, so counting is safe under
     the scorers' worker threads.
+
+    Assumes NON-OVERLAPPING EPISODES: the handler attaches to this module's
+    global logger, so concurrently running episodes (e.g. ``run_episode`` on
+    a ThreadPool) would count each other's degradations. A ContextVar-based
+    counter would lift that restriction if episode-level parallelism is ever
+    introduced.
     """
 
     def __init__(self) -> None:

--- a/src/bicameral_agent/ollama_cloud.py
+++ b/src/bicameral_agent/ollama_cloud.py
@@ -35,6 +35,19 @@ _MODEL = default_model("ollama")
 _DEFAULT_HOST = "https://ollama.com"
 _TIMEOUT_S = 120.0
 
+# Ollama Cloud does not yet honour the ``format`` schema for grammar-level
+# constrained decoding (verified 2026-07-07: gemma4:31b-cloud and the other
+# -cloud tags return markdown prose even with ``format`` set). The Ollama docs
+# recommend grounding the model by also stating the schema in the prompt; doing
+# so makes gemma return clean parseable JSON. We send both: ``format`` (correct
+# per the API spec, effective for local Ollama and forward-compatible if Cloud
+# adds decoder support) and this prompt grounding (what actually fixes the
+# pilot's 100% judge degradation, issue #82).
+_GROUNDING_TEMPLATE = (
+    "\n\nRespond with a single JSON object matching this schema exactly, and "
+    "nothing else -- no markdown, no code fences, no prose:\n{schema}"
+)
+
 
 class OllamaCloudClient(RetryingClientBase):
     """Thin wrapper around the Ollama Cloud chat API with retry, timing, callbacks.
@@ -89,7 +102,9 @@ class OllamaCloudClient(RetryingClientBase):
             max_output_tokens: Maps to Ollama ``options.num_predict``.
             tools: Function declarations (dicts with 'name', 'description',
                 'parameters_json_schema' keys), translated to Ollama tool format.
-            response_schema: JSON schema dict; passed through to Ollama ``format``.
+            response_schema: JSON schema dict. Sent as Ollama ``format`` and,
+                because Ollama Cloud ignores ``format``, also injected into the
+                system prompt to ground the model (issue #82).
 
         Returns:
             ModelResponse with content, token counts, timing, and finish reason.
@@ -117,7 +132,10 @@ class OllamaCloudClient(RetryingClientBase):
         response_schema: dict | None,
     ) -> dict[str, Any]:
         api_messages: list[dict[str, str]] = []
-        if system_prompt is not None:
+        if response_schema is not None:
+            grounding = _GROUNDING_TEMPLATE.format(schema=json.dumps(response_schema))
+            system_prompt = (system_prompt or "") + grounding
+        if system_prompt:
             api_messages.append({"role": "system", "content": system_prompt})
         for msg in messages:
             if isinstance(msg, ChatMessage):

--- a/tests/test_assumption_auditor.py
+++ b/tests/test_assumption_auditor.py
@@ -523,3 +523,34 @@ class TestMalformedOutput:
         result = auditor.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
 
         assert result.metadata.items_found == 1
+
+
+class TestResponseSchemas:
+    """Schema-constrained generation at both auditor call sites (issue #82)."""
+
+    def test_both_llm_calls_pass_their_schemas(self):
+        auditor = AssumptionAuditor()
+        client = _mock_client([_assumption_response(), _evidence_response()])
+        auditor.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        calls = client.generate.call_args_list
+        assert len(calls) == 2
+
+        extraction_schema = calls[0].kwargs["response_schema"]
+        assert extraction_schema["required"] == ["assumptions"]
+        item_props = extraction_schema["properties"]["assumptions"]["items"]["properties"]
+        assert set(item_props["risk_level"]["enum"]) == {"safe", "moderate", "high"}
+
+        evidence_schema = calls[1].kwargs["response_schema"]
+        assert evidence_schema["required"] == ["assessments"]
+        assessment = evidence_schema["properties"]["assessments"]["items"]["properties"]
+        assert set(assessment["verdict"]["enum"]) == {
+            "supporting",
+            "contradicting",
+            "inconclusive",
+        }
+        assert set(assessment["suggested_action"]["enum"]) == {
+            "validate",
+            "hedge",
+            "revise",
+        }

--- a/tests/test_coherence_judge.py
+++ b/tests/test_coherence_judge.py
@@ -197,3 +197,19 @@ class TestMalformedJudgeOutput:
         assert score.logical_flow == 1.0
         assert score.consistency == 0.5
         assert score.overall == 0.5
+
+
+class TestResponseSchema:
+    """Schema-constrained generation at the judge call site (issue #82)."""
+
+    def test_score_passes_response_schema(self):
+        client = MagicMock(spec=GeminiClient)
+        client.generate.return_value = _mock_judge_response()
+        judge = CoherenceJudge(client=client)
+        judge.score(_make_messages(("user", "q"), ("assistant", "a")))
+
+        schema = client.generate.call_args.kwargs["response_schema"]
+        assert schema["type"] == "object"
+        assert set(schema["required"]) == {"logical_flow", "consistency", "overall"}
+        for field in ("logical_flow", "consistency", "overall"):
+            assert schema["properties"][field]["type"] == "integer"

--- a/tests/test_context_refresher.py
+++ b/tests/test_context_refresher.py
@@ -617,3 +617,32 @@ class TestNullReminderDrift:
         result = refresher.execute(_make_history(), _make_state(), _DEFAULT_BUDGET, client)
 
         assert result.queue_deposit is None
+
+
+class TestResponseSchema:
+    """Schema-constrained generation at the refresher call site (issue #82)."""
+
+    def test_execute_passes_response_schema(self):
+        client = _mock_client(_no_drift_response())
+        refresher = ContextRefresher()
+        refresher.execute(_make_history(), _make_state(), _DEFAULT_BUDGET, client)
+
+        schema = client.generate.call_args.kwargs["response_schema"]
+        assert set(schema["required"]) == {"drift_detected", "drifts", "reminder"}
+        categories = schema["properties"]["drifts"]["items"]["properties"]["category"]
+        assert set(categories["enum"]) == {
+            "constraint_violation",
+            "scope_creep",
+            "requirement_ignored",
+        }
+
+    def test_malformed_output_degrades_to_no_drift_and_warns(self, caplog):
+        client = _mock_client(_fake_response("I could not produce JSON."))
+        refresher = ContextRefresher()
+        with caplog.at_level("WARNING"):
+            result = refresher.execute(
+                _make_history(), _make_state(), _DEFAULT_BUDGET, client
+            )
+
+        assert result.queue_deposit is None
+        assert "ContextRefresher" in caplog.text

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -1328,3 +1328,52 @@ class TestCostBudgetHandling:
         assert isinstance(episode, Episode)
         assert episode.outcome.total_turns == 1
         assert mock_sim.respond.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TestParseDegradationMetadata
+# ---------------------------------------------------------------------------
+
+
+class TestParseDegradationMetadata:
+    """Per-episode structured-output degradation counts (issue #82)."""
+
+    @staticmethod
+    def _run(client) -> Episode:
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+        runner = EpisodeRunner(client, EpisodeConfig(max_turns=1))
+        return runner.run_episode(_make_task(), ctrl)
+
+    def test_clean_episode_reports_empty_counts(self):
+        client = _scripted_client(
+            [{"action_type": "task_complete", "response_delay_ms": 100, "confidence": 0.9}]
+        )
+        episode = self._run(client)
+        assert episode.metadata["parse_degradations"] == {}
+
+    def test_sim_user_degradation_counted(self):
+        # _make_mock_client returns non-JSON prose for every call, so the
+        # real SimulatedUser's safe-parse degrades on its one call.
+        episode = self._run(_make_mock_client())
+        assert episode.metadata["parse_degradations"] == {"SimulatedUser.respond": 1}
+
+    def test_counts_do_not_cross_episodes(self):
+        client = _make_mock_client()
+        self._run(client)
+        second = self._run(client)
+        assert second.metadata["parse_degradations"] == {"SimulatedUser.respond": 1}
+
+    def test_scorer_degradation_counted(self):
+        client = _make_mock_client()
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+        runner = EpisodeRunner(
+            client, EpisodeConfig(max_turns=1, score_episode=True, metric="llm_judge")
+        )
+        episode = runner.run_episode(_make_task(), ctrl)
+        counts = episode.metadata["parse_degradations"]
+        assert counts["TaskScorer"] == 1
+        assert counts["SimulatedUser.respond"] == 1

--- a/tests/test_gap_scanner.py
+++ b/tests/test_gap_scanner.py
@@ -533,3 +533,25 @@ class TestMalformedOutput:
         # Non-numeric score coerces to 0.0 -> filtered out -> gaps-only deposit
         assert result.queue_deposit is not None
         assert "Research gaps identified" in result.queue_deposit.content
+
+
+class TestResponseSchemas:
+    """Schema-constrained generation at both scanner call sites (issue #82)."""
+
+    def test_both_llm_calls_pass_their_schemas(self):
+        scanner = ResearchGapScanner()
+        client = _mock_client([_gap_response(), _ranking_response()])
+        scanner.execute(_make_messages(), _make_state(), _DEFAULT_BUDGET, client)
+
+        calls = client.generate.call_args_list
+        assert len(calls) == 2
+
+        gap_schema = calls[0].kwargs["response_schema"]
+        assert set(gap_schema["required"]) == {"has_gaps", "gaps"}
+        category = gap_schema["properties"]["gaps"]["items"]["properties"]["category"]
+        assert set(category["enum"]) == {"core_claim", "supplementary", "nice_to_have"}
+
+        rank_schema = calls[1].kwargs["response_schema"]
+        assert set(rank_schema["required"]) == {"overall_confidence", "ranked_results"}
+        item_props = rank_schema["properties"]["ranked_results"]["items"]["properties"]
+        assert "relevance_score" in item_props

--- a/tests/test_llm_output.py
+++ b/tests/test_llm_output.py
@@ -7,7 +7,12 @@ import json
 import pytest
 
 from bicameral_agent.gemini import GeminiResponse
-from bicameral_agent.llm_output import clamp, coerce_int, safe_parse_json
+from bicameral_agent.llm_output import (
+    clamp,
+    coerce_int,
+    count_degradations,
+    safe_parse_json,
+)
 
 
 def _response(content: str, finish_reason: str = "STOP") -> GeminiResponse:
@@ -79,3 +84,40 @@ class TestCoerceInt:
     @pytest.mark.parametrize("value", [None, "good", [], float("nan")])
     def test_non_numeric_returns_default(self, value):
         assert coerce_int(value, 3) == 3
+
+
+class TestCountDegradations:
+    """Episode-scoped degradation counting (issue #82)."""
+
+    def test_counts_per_component(self):
+        with count_degradations() as counter:
+            safe_parse_json(_response("not json"), context="TaskScorer")
+            safe_parse_json(_response("also bad"), context="TaskScorer")
+            safe_parse_json(_response("nope"), context="SimulatedUser.respond")
+        assert counter.counts == {"TaskScorer": 2, "SimulatedUser.respond": 1}
+
+    def test_successful_parse_not_counted(self):
+        with count_degradations() as counter:
+            safe_parse_json(_response('{"a": 1}'), context="TaskScorer")
+        assert counter.counts == {}
+
+    def test_detached_after_exit(self):
+        with count_degradations() as counter:
+            pass
+        safe_parse_json(_response("bad"), context="TaskScorer")
+        assert counter.counts == {}
+
+    def test_ignores_untagged_warnings(self):
+        import logging
+
+        with count_degradations() as counter:
+            logging.getLogger("bicameral_agent.llm_output").warning("unrelated")
+        assert counter.counts == {}
+
+    def test_nested_counters_are_independent(self):
+        with count_degradations() as outer:
+            safe_parse_json(_response("bad"), context="A")
+            with count_degradations() as inner:
+                safe_parse_json(_response("bad"), context="B")
+        assert inner.counts == {"B": 1}
+        assert outer.counts == {"A": 1, "B": 1}

--- a/tests/test_ollama_cloud.py
+++ b/tests/test_ollama_cloud.py
@@ -182,6 +182,44 @@ class TestRequestBuilding:
             )
         assert _sent_payload(captured)["format"] == schema
 
+    def test_response_schema_grounds_system_prompt(self):
+        # Ollama Cloud ignores ``format``; the schema is also injected into the
+        # system prompt so the model returns parseable JSON (issue #82).
+        import json
+
+        schema = {"type": "object", "properties": {"q": {"type": "integer"}}}
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}],
+                system_prompt="be terse",
+                response_schema=schema,
+            )
+        system_msg = _sent_payload(captured)["messages"][0]
+        assert system_msg["role"] == "system"
+        assert system_msg["content"].startswith("be terse")
+        assert json.dumps(schema) in system_msg["content"]
+
+    def test_response_schema_grounds_without_system_prompt(self):
+        import json
+
+        schema = {"type": "object", "properties": {"q": {"type": "integer"}}}
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate(
+                [{"role": "user", "content": "x"}], response_schema=schema
+            )
+        messages = _sent_payload(captured)["messages"]
+        assert messages[0]["role"] == "system"
+        assert json.dumps(schema) in messages[0]["content"]
+
+    def test_no_system_message_without_schema_or_prompt(self):
+        fake, captured = _urlopen_returning(_make_response_body())
+        with patch("urllib.request.urlopen", fake):
+            OllamaCloudClient(api_key="k").generate([{"role": "user", "content": "x"}])
+        roles = [m["role"] for m in _sent_payload(captured)["messages"]]
+        assert "system" not in roles
+
     def test_tools_translated_to_ollama_format(self):
         tools = [{
             "name": "get_weather",


### PR DESCRIPTION
## Problem

The 2026-07-07 all-Ollama pilot (#46, gemma4:31b-cloud for answerer + judge + sim-user) degraded structured-output parsing catastrophically despite the #47 safe-parse fallback:

- **TaskScorer: 19/19 episodes (100%)** — every quality score collapsed to the neutral 0.5 fallback (zero variance, zero signal).
- **SimulatedUser: 107/19 (~5.6/episode)** — follow-ups collapsed to the default probe.

`finish_reason=stop`, not truncation: gemma wrapped/malformed the JSON.

## Key finding

The clients already threaded `response_schema` to Ollama's `format` field and Gemini's `response_json_schema`. But **Ollama Cloud does not honour `format`** for constrained decoding — verified against `docs.ollama.com/capabilities/structured-outputs` ("Ollama's Cloud currently does not support structured outputs") and live: every `-cloud` tag (gemma4, gpt-oss, qwen3-coder, deepseek-v3.1) returns markdown prose even with `format` set.

## Fix

Per the Ollama docs' recommended workaround, `OllamaCloudClient` now **also injects the schema into the system prompt** to ground the model when `response_schema` is set. Live gemma4:31b-cloud then returns clean parseable JSON. `format` is still sent — correct per the API spec, effective for local Ollama, forward-compatible if Cloud adds decoder support. Gemini is unchanged (already maps to `response_mime_type` + `response_json_schema`).

## Degradation measurement

Safe-parse degradations are now counted per component into episode metadata (`parse_degradations`). An episode-scoped logging handler tallies the WARNING `safe_parse_json` already emits (now tagged with the caller's context), wired via `with count_degradations()` around the episode — no counter threaded through the six components, and no module-level counter that would bleed across episodes. `ContextRefresher`'s own silent JSON parser was routed through `safe_parse_json` so it warns and counts like the rest.

## Test plan

- `uv run --extra dev --extra torch pytest -q` → **1341 passed, 35 skipped**
- `uv run --extra dev ruff check src/ tests/ scripts/` → **All checks passed**
- New tests: Ollama `format` payload + system-prompt grounding assertions; Gemini schema mapping (pre-existing); every call site passes its schema; safe-parse fallback still covered; degradation counting appears in episode metadata and does not cross episodes.
- **Live validation** (gemma4:31b-cloud via TaskScorer schema): raw call returned parseable JSON; `TaskScorer.score()` returned overall **1.0** (a real discriminative score, not the 0.5 neutral fallback), confirming grounding fixes the pilot's degradation on the only runnable backend.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy