### PR TITLE
Attribute tool actions to turns via explicit turn linkage

### DIFF
--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -333,7 +333,7 @@ class EpisodeRunner:
                     max_turns=cfg.max_turns,
                 )
 
-                inv_idx = log.log_tool_invocation(tool_id, 0)
+                inv_idx = log.log_tool_invocation(tool_id, 0, turn=turn)
                 try:
                     result = tool.execute(
                         conversation_history=temp_messages,

--- a/src/bicameral_agent/logger.py
+++ b/src/bicameral_agent/logger.py
@@ -39,7 +39,7 @@ class ConversationLogger:
         self._context_injections: list[ContextInjection] = []
         self._tool_invocations: list[tuple[int, ToolInvocation]] = []  # (index, invocation)
 
-        self._pending_tools: dict[int, tuple[str, int, int]] = {}
+        self._pending_tools: dict[int, tuple[str, int, int, int | None]] = {}
         self._next_tool_index = 0
         self._next_injection_index = 0
         self._wasted_tokens = 0
@@ -150,12 +150,17 @@ class ConversationLogger:
                 )
             )
 
-    def log_tool_invocation(self, tool_id: str, input_tokens: int) -> int:
+    def log_tool_invocation(
+        self, tool_id: str, input_tokens: int, turn: int | None = None
+    ) -> int:
         """Record the start of a tool invocation.
 
         Args:
             tool_id: Identifier of the tool being invoked.
             input_tokens: Number of tokens in the tool's input.
+            turn: 1-based conversational turn making the invocation, if known.
+                Recorded on the ToolInvocation so consumers can attribute the
+                invocation to its turn without timestamp heuristics.
 
         Returns:
             An opaque invocation index to pass to log_tool_completion().
@@ -165,7 +170,7 @@ class ConversationLogger:
             ts = self._now_ms()
             idx = self._next_tool_index
             self._next_tool_index += 1
-            self._pending_tools[idx] = (tool_id, input_tokens, ts)
+            self._pending_tools[idx] = (tool_id, input_tokens, ts, turn)
             return idx
 
     def log_tool_completion(
@@ -194,7 +199,7 @@ class ConversationLogger:
                 raise ValueError(
                     f"Unknown invocation index: {invocation_index}"
                 )
-            tool_id, input_tokens, invoked_at_ms = pending
+            tool_id, input_tokens, invoked_at_ms, turn = pending
             self._tool_invocations.append((
                 invocation_index,
                 ToolInvocation(
@@ -205,6 +210,7 @@ class ConversationLogger:
                     output_tokens=output_tokens,
                     result_deposited=result_deposited,
                     budget_exceeded=budget_exceeded,
+                    turn=turn,
                 ),
             ))
 

--- a/src/bicameral_agent/schema.py
+++ b/src/bicameral_agent/schema.py
@@ -152,6 +152,11 @@ class ToolInvocation(BaseModel):
     Budget-exceeded invocations have partial durations and must be excluded
     from latency-prediction accuracy metrics."""
 
+    turn: int | None = Field(default=None, ge=1)
+    """1-based conversational turn during which this tool was invoked.
+    None for episodes logged before this field existed; consumers must
+    fall back to timestamp-based attribution in that case."""
+
     @model_validator(mode="after")
     def check_temporal_order(self) -> ToolInvocation:
         """Ensure completed_at_ms >= invoked_at_ms."""

--- a/src/bicameral_agent/training_pipeline.py
+++ b/src/bicameral_agent/training_pipeline.py
@@ -485,40 +485,52 @@ class TrainingDataPipeline:
 
         Returns a dict ``{turn_number: action_index}``. Missing turns
         default to DO_NOTHING.
+
+        Invocations carrying an explicit ``turn`` (logged by the live
+        runner since issue #80) are attributed directly. Legacy invocations
+        without one fall back to the timestamp window
+        ``[user_ts, next_user_ts)``, which is order-agnostic: it covers both
+        the pre-#50 logging order (tool events before the assistant message)
+        and the current order (assistant message logged at generation time,
+        before tool events). The final turn's window is open-ended.
+
+        This stays aligned with EpisodeReplayer's strict decision-point
+        cutoffs (#51): the invocation labeled as turn N's action is invoked
+        at/after that turn's assistant message, so it is excluded from turn
+        N's decision-point state and only appears in later states.
         """
         # Reverse mapping: tool_id -> Action
         tool_to_action: dict[str, Action] = {v: k for k, v in TOOL_IDS.items()}
 
-        # Pair each user message with the next assistant message; any tool
-        # invocation falling in that window is the action for that turn.
+        user_ts_list = [m.timestamp_ms for m in episode.messages if m.role == "user"]
+        n_turns = len(user_ts_list)
+
         actions: dict[int, int] = {}
-        turn_no = 0
-        i = 0
-        msgs = episode.messages
-        while i < len(msgs):
-            if msgs[i].role != "user":
-                i += 1
+
+        def record(turn_no: int, tool_id: str) -> None:
+            # First invocation per turn wins (invocations are sorted by
+            # invoked_at_ms), matching the previous semantics.
+            if turn_no in actions:
+                return
+            action = tool_to_action.get(tool_id, Action.DO_NOTHING)
+            actions[turn_no] = _ACTION_INDEX[action]
+
+        for inv in episode.tool_invocations:
+            if inv.turn is not None:
+                if 1 <= inv.turn <= n_turns:
+                    record(inv.turn, inv.tool_id)
                 continue
-            turn_no += 1
-            user_ts = msgs[i].timestamp_ms
-
-            # Find next assistant message
-            j = i + 1
-            while j < len(msgs) and msgs[j].role != "assistant":
-                j += 1
-            if j >= len(msgs):
-                break
-            assistant_ts = msgs[j].timestamp_ms
-
-            # Find a tool invocation in (user_ts, assistant_ts]
-            found_action = Action.DO_NOTHING
-            for inv in episode.tool_invocations:
-                if user_ts < inv.invoked_at_ms <= assistant_ts:
-                    action = tool_to_action.get(inv.tool_id, Action.DO_NOTHING)
-                    found_action = action
+            # Legacy fallback: attribute to the turn whose window
+            # [user_ts, next_user_ts) contains the invocation.
+            for turn_no in range(1, n_turns + 1):
+                lo = user_ts_list[turn_no - 1]
+                hi = user_ts_list[turn_no] if turn_no < n_turns else None
+                if lo <= inv.invoked_at_ms and (hi is None or inv.invoked_at_ms < hi):
+                    record(turn_no, inv.tool_id)
                     break
-            actions[turn_no] = _ACTION_INDEX[found_action]
-            i = j + 1
+
+        for turn_no in range(1, n_turns + 1):
+            actions.setdefault(turn_no, _ACTION_INDEX[Action.DO_NOTHING])
         return actions
 
     # ------------------------------------------------------------------

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -550,6 +550,67 @@ class TestEpisodeRunner:
         assistant_msg = next(m for m in episode.messages if m.role == "assistant")
         assert assistant_msg.timestamp_ms <= episode.tool_invocations[0].invoked_at_ms
 
+    def test_live_logged_tool_action_round_trips_through_pipeline(self):
+        """Regression (#80): a live-logged tool action is not mislabeled DO_NOTHING.
+
+        Runs an episode through the real runner/logger (assistant message
+        logged before tool events, per #50) and asserts the pipeline
+        attributes the tool action to the turn that took it.
+        """
+        from bicameral_agent.replay import EpisodeReplayer
+        from bicameral_agent.training_pipeline import (
+            TrainingDataPipeline,
+            _ACTION_INDEX,
+        )
+
+        client = _make_mock_client()
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.SCANNER
+
+        runner = EpisodeRunner(client, EpisodeConfig(max_turns=1))
+
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.return_value = UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+            MockSimUser.return_value = mock_sim
+
+            with patch("bicameral_agent.episode_runner.ResearchGapScanner") as MockScanner:
+                from bicameral_agent.tool_primitive import ToolMetadata, ToolResult
+
+                mock_tool = MagicMock()
+                mock_tool.execute.return_value = ToolResult(
+                    queue_deposit=None,
+                    metadata=ToolMetadata(
+                        tool_id="research_gap_scanner",
+                        action_taken="scanned",
+                        confidence=0.8,
+                        items_found=0,
+                        estimated_relevance=0.0,
+                        tokens_consumed=50,
+                    ),
+                )
+                MockScanner.return_value = mock_tool
+
+                episode = runner.run_episode(_make_task(), ctrl)
+
+        inv = episode.tool_invocations[0]
+        assert inv.turn == 1
+
+        examples = TrainingDataPipeline().process_episode(episode)
+        assert examples[0].action == _ACTION_INDEX[Action.SCANNER]
+
+        # Alignment with replay's strict decision-point cutoff (#51): the
+        # invocation labeled as this turn's action happened at/after the
+        # assistant message, so it must not leak into the decision state.
+        dp = next(EpisodeReplayer(episode).iter_decision_points())
+        assert inv not in dp.state.active_tool_invocations
+        assert inv not in dp.state.completed_tool_invocations
+
     def test_sim_user_receives_runner_turn(self):
         """The runner passes its own turn to the sim-user (no off-by-one).
 

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -44,6 +44,7 @@ def _build_episode(
     assistant_msg_tokens: int = 20,
     user_events: list[tuple[UserEventType, int]] | None = None,
     tool_invocations_per_turn: dict[int, str] | None = None,
+    tool_invoked_offset_ms: int = 100,
     context_injections: list[ContextInjection] | None = None,
     user_messages: list[str] | None = None,
     metadata: dict | None = None,
@@ -56,8 +57,12 @@ def _build_episode(
         List of ``(event_type, turn_number)`` pairs. The event timestamp
         is placed just after the assistant message of the given turn.
     tool_invocations_per_turn:
-        Map from turn_number to tool_id. The tool is invoked between the
-        user and assistant messages of that turn.
+        Map from turn_number to tool_id. The tool is invoked at
+        ``user_ts + tool_invoked_offset_ms`` of that turn.
+    tool_invoked_offset_ms:
+        Offset of the invocation from the turn's user message. The default
+        (100) places it before the assistant message (pre-#50 logging
+        order); values above 500 place it after (current runner order).
     context_injections:
         Already-built ContextInjection records to attach.
     user_messages:
@@ -89,8 +94,8 @@ def _build_episode(
             tools.append(
                 ToolInvocation(
                     tool_id=tool_id,
-                    invoked_at_ms=user_ts + 100,
-                    completed_at_ms=user_ts + 300,
+                    invoked_at_ms=user_ts + tool_invoked_offset_ms,
+                    completed_at_ms=user_ts + tool_invoked_offset_ms + 200,
                     input_tokens=50,
                     output_tokens=80,
                     result_deposited=False,
@@ -604,6 +609,50 @@ def test_all_action_indices_in_valid_range(
     examples = pipeline.process_episode(episode)
     for ex in examples:
         assert 0 <= ex.action <= 3
+
+
+def test_action_inference_with_live_runner_ordering(
+    pipeline: TrainingDataPipeline,
+) -> None:
+    """Regression (#80): tools logged after the assistant message are attributed.
+
+    Since #50 the runner logs the assistant message at generation time,
+    before tool events, so invocations fall after assistant_ts. The old
+    (user_ts, assistant_ts] window mislabeled these turns DO_NOTHING.
+    """
+    episode = _build_episode(
+        num_turns=3,
+        tool_invocations_per_turn={
+            1: TOOL_IDS[Action.SCANNER],
+            3: TOOL_IDS[Action.REFRESHER],
+        },
+        tool_invoked_offset_ms=600,  # after the assistant message (+500)
+    )
+    examples = pipeline.process_episode(episode)
+    assert examples[0].action == _ACTION_INDEX[Action.SCANNER]
+    assert examples[1].action == _ACTION_INDEX[Action.DO_NOTHING]
+    assert examples[2].action == _ACTION_INDEX[Action.REFRESHER]
+
+
+def test_action_inference_prefers_turn_linkage_over_timestamps(
+    pipeline: TrainingDataPipeline,
+) -> None:
+    """An invocation carrying ``turn`` is attributed to it regardless of timestamps."""
+    episode = _build_episode(num_turns=3)
+    inv = ToolInvocation(
+        tool_id=TOOL_IDS[Action.AUDITOR],
+        # Timestamps fall inside turn 3's window; the turn field must win.
+        invoked_at_ms=episode.messages[-1].timestamp_ms + 100,
+        completed_at_ms=episode.messages[-1].timestamp_ms + 200,
+        input_tokens=50,
+        output_tokens=80,
+        turn=2,
+    )
+    episode = episode.model_copy(update={"tool_invocations": [inv]})
+    examples = pipeline.process_episode(episode)
+    assert examples[0].action == _ACTION_INDEX[Action.DO_NOTHING]
+    assert examples[1].action == _ACTION_INDEX[Action.AUDITOR]
+    assert examples[2].action == _ACTION_INDEX[Action.DO_NOTHING]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`TrainingDataPipeline._infer_actions` attributed a tool invocation to a turn only when its timestamp fell in `(user_ts, assistant_ts]`. Since #50 the live runner logs the assistant message at generation time, **before** tool events, so every live-logged invocation falls after `assistant_ts` and the turn was mislabeled `DO_NOTHING` — corrupting transition-model action one-hots and action-accuracy diagnostics on all episodes collected by the current runner.

## Fix

- **Primary mechanism: explicit turn linkage.** `ToolInvocation` gains an optional `turn` field (1-based); `ConversationLogger.log_tool_invocation` accepts it and the runner passes the current turn. `_infer_actions` uses it directly when present. Chosen over a wider timestamp window because the bug class is precisely "timestamp-ordering assumptions break when logging order changes" — an explicit link is immune to future ordering changes and same-millisecond collisions.
- **Legacy fallback:** invocations without `turn` (all historical episodes) are attributed via the order-agnostic window `[user_ts, next_user_ts)` (open-ended on the final turn), correct under both pre-#50 and current logging orders.

## Verification

- Round-trip regression test: a mocked-client `EpisodeRunner` episode (real logger, real call order) goes through the pipeline and the tool action is attributed to its turn, not `DO_NOTHING`.
- Pipeline unit tests for live-runner ordering (fallback path) and for turn-linkage-over-timestamps precedence.
- Re-checked against `replay.py`'s strict decision-point cutoffs (#51): the invocation labeled as turn N's action is invoked at/after that turn's assistant message, so it stays out of turn N's decision-point state (asserted in the regression test). Labels and states remain causally aligned.
- Downstream consumers (`transition_model`, `pretrain`, `learned_controller`) contain no inference logic of their own; #26/#27 refits on newly collected episodes pick up corrected labels automatically.

Note: 3 pre-existing failures in `tests/test_comparative_eval.py` (unpack mismatch at `comparative_eval.py:339`) reproduce on the unmodified base and are unrelated.

Closes #80