### PR TITLE
Fix comparative harness for run_condition's 3-tuple failure containment

### DIFF
--- a/scripts/run_comparative_eval.py
+++ b/scripts/run_comparative_eval.py
@@ -32,6 +32,7 @@ import logging
 import sys
 from pathlib import Path
 
+from bicameral_agent.baseline_benchmark import FAILURE_THRESHOLD
 from bicameral_agent.comparative_eval import (
     ComparativeEvaluator,
     baseline_condition_factories,
@@ -83,6 +84,9 @@ def main(argv: list[str] | None = None) -> int:
                         help="Base seed; per-condition seeds are derived "
                              "deterministically from it.")
     parser.add_argument("--random-probability", type=float, default=0.2)
+    parser.add_argument("--failure-threshold", type=float, default=FAILURE_THRESHOLD,
+                        help="Abort a condition once contained transport "
+                             "failures exceed this fraction of its episodes.")
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)
 
@@ -155,7 +159,11 @@ def main(argv: list[str] | None = None) -> int:
             completed[condition], str(output_dir / f"{condition}.parquet")
         )
 
-    evaluator = ComparativeEvaluator(runner, on_episode=persist_episode)
+    evaluator = ComparativeEvaluator(
+        runner,
+        on_episode=persist_episode,
+        failure_threshold=args.failure_threshold,
+    )
     result = evaluator.run(tasks, conditions)
 
     report = build_report(

--- a/src/bicameral_agent/comparative_eval.py
+++ b/src/bicameral_agent/comparative_eval.py
@@ -53,6 +53,21 @@ What IS deterministic for a fixed seed and fixed inputs:
   summaries, CIs, Welch t-tests / p-values, difficulty breakdown, and
   both report serializations are pure functions of the episodes.
 
+Transport failures and pairing
+------------------------------
+:func:`~bicameral_agent.baseline_benchmark.run_condition` contains
+per-episode ``TransportExhausted`` failures (issue #81): a failed
+episode is recorded, not fatal, until ``failure_threshold`` aborts the
+condition. A failure breaks the pair for its task, so *all* statistics
+(summary table, pairwise tests, difficulty breakdown) are computed over
+the tasks that completed in every condition — dropping the broken pair
+for all conditions is the smallest change that keeps the comparison
+paired and unbiased (keeping asymmetric samples would let one
+condition's failures shift another's means). The dropped task ids are
+recorded in the report (``excluded_task_ids``) next to the raw
+``failures``; per-task ``results`` rows still include every completed
+episode.
+
 Evaluation integrity: judge blinding
 ------------------------------------
 The issue's "human eval blinded" item is N/A here: this framework has no
@@ -79,14 +94,16 @@ from pydantic import BaseModel, Field
 
 from bicameral_agent.ab_test import MetricSummary, compute_summary, welch_t_test
 from bicameral_agent.baseline_benchmark import (
+    FAILURE_THRESHOLD,
     ControllerFactory,
     EpisodeCallback,
+    EpisodeFailure,
     TaskMetrics,
     run_condition,
 )
 from bicameral_agent.dataset import ResearchQADataset, ResearchQATask, TaskDifficulty
 from bicameral_agent.episode_runner import EpisodeRunner
-from bicameral_agent.eval_report import EvalReport, TaskResult
+from bicameral_agent.eval_report import EvalReport, TaskFailure, TaskResult
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.schema import Episode
@@ -295,28 +312,72 @@ def learned_condition_factories(
 class ComparativeResult:
     """Paired episodes + extracted metrics for every condition.
 
-    ``episodes[c][i]`` and ``metrics[c][i]`` correspond to ``tasks[i]``
-    for every condition ``c`` (the paired design).
+    ``episodes[c]`` / ``metrics[c]`` hold only the *completed* episodes
+    of condition ``c`` in task order; contained transport failures (issue
+    #81) are recorded in ``failures[c]`` with their task index. Use
+    :meth:`completed_indices` to map an episode position back to its
+    task, and :meth:`paired_metrics` / :attr:`paired_tasks` for the
+    subset of tasks completed in *every* condition (the paired design).
     """
 
     tasks: list[ResearchQATask]
     episodes: dict[str, list[Episode]] = dataclasses.field(default_factory=dict)
     metrics: dict[str, list[TaskMetrics]] = dataclasses.field(default_factory=dict)
+    failures: dict[str, list[EpisodeFailure]] = dataclasses.field(default_factory=dict)
 
     @property
     def task_ids(self) -> list[str]:
         """Shared task order (identical across conditions)."""
         return [t.task_id for t in self.tasks]
 
+    def completed_indices(self, condition: str) -> list[int]:
+        """Task indices the condition completed, aligned with its episodes."""
+        failed = {f.episode_index for f in self.failures.get(condition, ())}
+        return [i for i in range(len(self.tasks)) if i not in failed]
+
+    @property
+    def paired_indices(self) -> list[int]:
+        """Task indices completed by every condition."""
+        failed = {f.episode_index for fs in self.failures.values() for f in fs}
+        return [i for i in range(len(self.tasks)) if i not in failed]
+
+    @property
+    def paired_tasks(self) -> list[ResearchQATask]:
+        """Tasks completed by every condition, in task order."""
+        return [self.tasks[i] for i in self.paired_indices]
+
+    @property
+    def excluded_task_ids(self) -> list[str]:
+        """Tasks dropped from paired analyses (failed in >= 1 condition)."""
+        paired = set(self.paired_indices)
+        return [t.task_id for i, t in enumerate(self.tasks) if i not in paired]
+
+    def paired_metrics(self) -> dict[str, list[TaskMetrics]]:
+        """Per-condition metrics restricted to the paired task subset."""
+        paired = set(self.paired_indices)
+        return {
+            condition: [
+                m
+                for i, m in zip(self.completed_indices(condition), metrics)
+                if i in paired
+            ]
+            for condition, metrics in self.metrics.items()
+        }
+
 
 class ComparativeEvaluator:
     """Runs every condition over the same task list in the same order."""
 
     def __init__(
-        self, runner: EpisodeRunner, *, on_episode: EpisodeCallback | None = None
+        self,
+        runner: EpisodeRunner,
+        *,
+        on_episode: EpisodeCallback | None = None,
+        failure_threshold: float = FAILURE_THRESHOLD,
     ) -> None:
         self._runner = runner
         self._on_episode = on_episode
+        self._failure_threshold = failure_threshold
 
     def run(
         self,
@@ -329,22 +390,27 @@ class ComparativeEvaluator:
         factory (called with the task index). Conditions run in dict
         order; within a condition, tasks run in list order — the same
         list for every condition, which is what makes the comparison
-        paired.
+        paired. Per-episode transport failures are contained by
+        :func:`~bicameral_agent.baseline_benchmark.run_condition` (which
+        raises ``ConditionAbortedError`` past ``failure_threshold``) and
+        recorded on the result.
         """
         result = ComparativeResult(tasks=list(tasks))
         for condition, factory in conditions.items():
             logger.info(
                 "Running %d episodes for condition %r", len(result.tasks), condition
             )
-            episodes, metrics = run_condition(
+            episodes, metrics, failures = run_condition(
                 self._runner,
                 result.tasks,
                 factory,
                 condition=condition,
                 on_episode=self._on_episode,
+                failure_threshold=self._failure_threshold,
             )
             result.episodes[condition] = episodes
             result.metrics[condition] = metrics
+            result.failures[condition] = failures
         return result
 
 
@@ -601,6 +667,10 @@ class ComparativeReport(EvalReport):
     pairwise: list[PairwiseTestResult]
     by_difficulty: dict[str, dict[str, dict[str, dict]]]
     results: list[ComparativeTaskResult] = Field(default_factory=list)
+    excluded_task_ids: list[str] = Field(default_factory=list)
+    """Tasks dropped from all paired analyses: they failed on transport
+    in at least one condition, so keeping them would break the pairing.
+    The raw failures are in the inherited ``failures`` field."""
 
     @classmethod
     def from_benchmark(cls, *args: object, **kwargs: object) -> ComparativeReport:
@@ -637,16 +707,25 @@ def build_report(
     Pure function of the collected episodes/metrics: identical inputs
     produce byte-identical JSON and markdown (the deterministic side of
     the boundary documented in the module docstring).
+
+    All statistics (summary table, pairwise tests, difficulty breakdown)
+    are computed over the *paired* subset — tasks completed in every
+    condition — so a transport failure in one condition cannot bias the
+    comparison in either direction; the dropped tasks are recorded in
+    ``excluded_task_ids`` and the raw failures in ``failures``. The
+    per-task ``results`` rows keep every completed episode, mapped back
+    to its task via each condition's completed indices.
     """
+    paired_metrics = result.paired_metrics()
     conditions = {
         condition: {
-            "n_episodes": len(metrics),
+            "n_episodes": len(result.metrics[condition]),
             "summaries": {
                 name: dataclasses.asdict(summary)
                 for name, summary in condition_summaries(metrics).items()
             },
         }
-        for condition, metrics in result.metrics.items()
+        for condition, metrics in paired_metrics.items()
     }
     difficulty = {
         tier: {
@@ -656,19 +735,24 @@ def build_report(
             for condition, summaries in per_condition.items()
         }
         for tier, per_condition in difficulty_breakdown(
-            result.tasks, result.metrics
+            result.paired_tasks, paired_metrics
         ).items()
     }
     results = [
         ComparativeTaskResult(
-            task_id=task.task_id,
+            task_id=result.tasks[i].task_id,
             condition=condition,
             score=episode.outcome.quality_score,
             detail=(episode.metadata.get("verification") or {}).get("detail"),
-            difficulty=task.difficulty.value,
+            difficulty=result.tasks[i].difficulty.value,
         )
         for condition, episodes in result.episodes.items()
-        for task, episode in zip(result.tasks, episodes)
+        for i, episode in zip(result.completed_indices(condition), episodes)
+    ]
+    failures = [
+        TaskFailure(task_id=f.task_id, condition=condition, error=f.error)
+        for condition, condition_failures in result.failures.items()
+        for f in condition_failures
     ]
     task_mix = Counter(t.difficulty.value for t in result.tasks)
     return ComparativeReport(
@@ -682,9 +766,11 @@ def build_report(
         task_mix=dict(task_mix),
         task_ids=result.task_ids,
         conditions=conditions,
-        pairwise=pairwise_tests(result.metrics),
+        pairwise=pairwise_tests(paired_metrics),
         by_difficulty=difficulty,
         results=results,
+        failures=failures,
+        excluded_task_ids=result.excluded_task_ids,
     )
 
 
@@ -781,6 +867,20 @@ def _render_markdown(report: ComparativeReport) -> str:
         lines.extend(
             _summary_table(tier_conditions, lambda c, _pc=per_condition: _pc[c])
         )
+
+    lines.extend(["", "## Transport failures", ""])
+    if report.failures or report.excluded_task_ids:
+        for failure in report.failures:
+            lines.append(
+                f"- {failure.condition} / {failure.task_id}: {failure.error}"
+            )
+        lines.append(
+            f"- Paired analyses cover {len(report.task_ids) - len(report.excluded_task_ids)}"
+            f"/{len(report.task_ids)} tasks; excluded (failed in >= 1 "
+            f"condition): {', '.join(report.excluded_task_ids)}"
+        )
+    else:
+        lines.append("- none")
 
     lines.extend(
         [

--- a/tests/test_comparative_eval.py
+++ b/tests/test_comparative_eval.py
@@ -440,6 +440,7 @@ class TestReport:
         assert "## Summary" in md
         assert "## Pairwise Welch t-tests: task_quality" in md
         assert "## Breakdown by difficulty" in md
+        assert "## Transport failures\n\n- none" in md
         assert "### typical" in md and "### hard" in md and "### tricky" in md
         for name in METRIC_NAMES:
             assert name in md
@@ -464,6 +465,94 @@ class TestReport:
 
         with pytest.raises(NotImplementedError, match="build_report"):
             ComparativeReport.from_benchmark(MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Transport failures and pairing (issue #81 containment)
+# ---------------------------------------------------------------------------
+
+
+class TestTransportFailures:
+    """run_condition contains TransportExhausted per episode; a failed task
+    is dropped from paired analyses for all conditions and recorded.
+    """
+
+    def _failing_runner(self, fail_on: tuple[str, str]) -> MagicMock:
+        """Runner that fails one (controller class name, task_id) episode."""
+        from bicameral_agent.model_client import TransportExhausted
+
+        runner = MagicMock(spec=EpisodeRunner)
+
+        def run_episode(task, controller):
+            if (type(controller).__name__, task.task_id) == fail_on:
+                raise TransportExhausted(4, RuntimeError("boom"))
+            return _episode(task_id=task.task_id)
+
+        runner.run_episode.side_effect = run_episode
+        return runner
+
+    def _run(self):
+        # 4 tasks: one failure is 25%, under the default 30% abort threshold.
+        runner = self._failing_runner(("RandomController", "t1"))
+        tasks = [_task(f"t{i}") for i in range(4)]
+        conditions = {
+            "no_subconscious": lambda _idx: NoSubconsciousController(),
+            "random": lambda idx: RandomController(seed=idx),
+        }
+        return ComparativeEvaluator(runner).run(tasks, conditions)
+
+    def test_failure_recorded_and_run_continues(self):
+        result = self._run()
+        assert [f.task_id for f in result.failures["random"]] == ["t1"]
+        assert result.failures["random"][0].episode_index == 1
+        assert "boom" in result.failures["random"][0].error
+        assert result.failures["no_subconscious"] == []
+        assert len(result.episodes["random"]) == 3
+        assert len(result.episodes["no_subconscious"]) == 4
+
+    def test_failed_task_dropped_from_paired_analyses_for_all_conditions(self):
+        result = self._run()
+        assert result.paired_indices == [0, 2, 3]
+        assert result.excluded_task_ids == ["t1"]
+        paired = result.paired_metrics()
+        assert len(paired["no_subconscious"]) == 3
+        assert len(paired["random"]) == 3
+        assert result.completed_indices("random") == [0, 2, 3]
+        assert result.completed_indices("no_subconscious") == [0, 1, 2, 3]
+
+    def test_report_records_failures_and_exclusions(self):
+        report = _report(self._run())
+        assert [f.task_id for f in report.failures] == ["t1"]
+        assert report.failures[0].condition == "random"
+        assert report.excluded_task_ids == ["t1"]
+        # Statistics are computed over the paired subset only...
+        for condition in ("no_subconscious", "random"):
+            summaries = report.conditions[condition]["summaries"]
+            assert summaries["task_quality"]["n"] == 3
+        # ...while n_episodes and per-task rows keep every completed episode,
+        # mapped back to the right task despite the skipped index.
+        assert report.conditions["no_subconscious"]["n_episodes"] == 4
+        assert report.conditions["random"]["n_episodes"] == 3
+        random_rows = [r for r in report.results if r.condition == "random"]
+        assert [r.task_id for r in random_rows] == ["t0", "t2", "t3"]
+
+    def test_markdown_lists_failures_and_paired_coverage(self):
+        md = _report(self._run()).to_markdown()
+        assert "## Transport failures" in md
+        assert "random / t1: " in md
+        assert "Paired analyses cover 3/4 tasks" in md
+        assert "excluded (failed in >= 1 condition): t1" in md
+
+    def test_failure_threshold_forwarded_to_run_condition(self):
+        from bicameral_agent.baseline_benchmark import ConditionAbortedError
+
+        runner = self._failing_runner(("NoSubconsciousController", "t0"))
+        evaluator = ComparativeEvaluator(runner, failure_threshold=0.0)
+        with pytest.raises(ConditionAbortedError):
+            evaluator.run(
+                [_task("t0"), _task("t1")],
+                {"no_subconscious": lambda _idx: NoSubconsciousController()},
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes the 3 failing tests on main (`test_task_order_identical_across_conditions`, `test_episodes_and_metrics_collected_per_condition`, `test_on_episode_callback_fires_incrementally`). Cause: PR #84 (issue #81) changed `baseline_benchmark.run_condition` to return `(episodes, metrics, failures)` with per-episode `TransportExhausted` containment, and it merged right after PR #83 — `comparative_eval.py` still unpacked a 2-tuple. Beyond the unpack, containment quietly broke a deeper assumption: a skipped episode misaligns `metrics[c][i]` with `tasks[i]`, which the paired analyses relied on.

## Work performed
- Unpack the 3-tuple; `ComparativeResult` gains `failures: dict[str, list[EpisodeFailure]]` plus `completed_indices` / `paired_indices` / `paired_tasks` / `paired_metrics` / `excluded_task_ids` helpers.
- **Paired handling of failures** (the statistically defensible smaller change, documented in the module docstring): all statistics — summary table, pairwise Welch tests, difficulty breakdown — are computed over tasks completed in *every* condition. Dropping the broken pair for all conditions keeps the comparison paired and unbiased; keeping asymmetric samples would let one condition's failures shift another's means. Dropped task ids are recorded in a new `excluded_task_ids` report field beside the inherited `failures` field (`TaskFailure` rows from #84). Raw per-task `results` rows keep every completed episode, remapped to their tasks via each condition's completed indices; `n_episodes` still counts completed episodes while summary `n` reflects the paired subset.
- `ComparativeEvaluator` takes `failure_threshold` (default `FAILURE_THRESHOLD`) and forwards it to `run_condition`, so `ConditionAbortedError` semantics from #84 apply; exposed as `--failure-threshold` on `scripts/run_comparative_eval.py`.
- Markdown report gains a "Transport failures" section (failure list + paired-coverage line, or "none").
- Regression tests (`TestTransportFailures`, 5 tests): injected `TransportExhausted` in one condition → failure recorded with index/task id, run continues, failed task excluded from paired analyses for all conditions, report/markdown record failures + exclusions with correct task remapping, and threshold forwarding aborts via `ConditionAbortedError`.

## Test plan
- [x] `uv run --extra dev --extra torch pytest -q` — 1402 passed, 35 skipped (fully green, including the 3 failures on main)
- [x] `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- [ ] Live 5×100 comparative run remains pending (unchanged from #83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HwbXtgGy8LK9crkHzgyy

Refs #30