### PR TITLE
Recalibrate tool latency priors to the Ollama backend measurements

### DIFF
--- a/src/bicameral_agent/latency.py
+++ b/src/bicameral_agent/latency.py
@@ -3,8 +3,9 @@
 Models total API call latency as a linear function of input and output
 token counts, using incremental OLS with Welford's variance tracking
 for percentile estimation. Uses priors calibrated against measured
-baseline durations during cold start (< 20 observations) and smoothly
-transitions to learned parameters.
+baseline durations on the current (Ollama cloud) backend during cold
+start (< 20 observations) and smoothly transitions to learned
+parameters.
 """
 
 from __future__ import annotations
@@ -18,15 +19,19 @@ import numpy as np
 # Cold-start threshold: below this, blend priors with learned parameters
 _COLD_START_THRESHOLD = 20
 
-# Priors calibrated against the measured tool durations from the #23
-# baseline run (data/baseline/*.parquet): single API calls complete in
-# roughly 0.9-1.5s with recorded output token counts of ~1000-1500.
-# The old priors (alpha=1000, 25 tok/s) over-predicted 9-23x (#44).
+# Priors calibrated against the measured tool durations from the #46
+# baseline re-run on the Ollama cloud backend (gemma4:31b-cloud; 109
+# tool invocations across data/baseline_full + data/baseline_pilot_v2):
+# single API calls complete in roughly 2-5s, dominated by a large fixed
+# per-call cost (cloud queueing/prefill) that swamps the token terms —
+# measured durations are nearly uncorrelated with context size in this
+# regime. The previous Gemini-era calibration (#67: alpha=700) under-
+# predicted 2-4x on this backend (62-75% MAPE in the #46 report).
 # Note: recorded output token counts are approximate (len/4 estimates),
 # so _PRIOR_OUTPUT_RATE is an *effective* rate on that scale, not a true
 # model decode speed.
-_PRIOR_ALPHA = 700.0  # TTFT intercept (ms)
-_PRIOR_BETA = 0.02  # ms per input token
+_PRIOR_ALPHA = 3000.0  # per-call intercept (ms)
+_PRIOR_BETA = 0.05  # ms per input token
 _PRIOR_OUTPUT_RATE = 2500.0  # effective output tokens per second
 _PRIOR_OVERHEAD = 175.0  # fixed overhead (ms)
 _PRIOR_VARIANCE_FRAC = 0.5  # residual std as fraction of predicted mean
@@ -75,7 +80,8 @@ class APILatencyModel:
     and Welford's algorithm for residual variance tracking.
 
     With fewer than 20 observations, predictions are blended with
-    priors calibrated against the #23 baseline measurements (#44).
+    priors calibrated against the #46 baseline measurements on the
+    Ollama cloud backend (#44).
     """
 
     def __init__(self) -> None:

--- a/src/bicameral_agent/token_estimator.py
+++ b/src/bicameral_agent/token_estimator.py
@@ -45,16 +45,17 @@ class _ToolProfile:
 # run against a local provider), the auditor makes two (assumption
 # extraction + evidence assessment), and the refresher makes one.
 # Default output-per-call values are anchored to the median recorded
-# output token counts from the #23 baseline run (#44).
+# output token counts from the #46 baseline re-run on the Ollama cloud
+# backend (#44): scanner 1566/2, auditor 1856/2, refresher 1110/1.
 _TOOL_PROFILES: dict[str, _ToolProfile] = {
     TOOL_IDS[Action.SCANNER]: _ToolProfile(
         system_prompt_tokens=500,
-        default_output_per_call=670,
+        default_output_per_call=780,
         num_calls=2,
     ),
     TOOL_IDS[Action.AUDITOR]: _ToolProfile(
         system_prompt_tokens=400,
-        default_output_per_call=750,
+        default_output_per_call=930,
         num_calls=2,
     ),
     TOOL_IDS[Action.REFRESHER]: _ToolProfile(

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -63,15 +63,16 @@ class TestColdStart:
     """AC1: With 0 observations, predict() returns calibrated prior estimates.
 
     Priors are calibrated against the measured single-call latencies from
-    the #23 baseline run (~0.9-1.5s per call), see #44.
+    the #46 baseline re-run on the Ollama cloud backend (~2-5s per call,
+    dominated by a fixed per-call cost), see #44.
     """
 
     def test_zero_observations_in_calibrated_range(self):
         model = APILatencyModel()
         est = model.predict(1000, 500)
-        # A ~1k-input / 500-output call was measured at roughly a second;
-        # the cold-start prior must land in the same order of magnitude.
-        assert 500.0 <= est.mean_ms <= 2500.0
+        # Single calls on the Ollama cloud backend measure roughly 2-5s;
+        # the cold-start prior must land in the same range.
+        assert 2000.0 <= est.mean_ms <= 5000.0
 
     def test_zero_observations_has_wide_spread(self):
         model = APILatencyModel()

--- a/tests/test_token_estimator.py
+++ b/tests/test_token_estimator.py
@@ -187,7 +187,7 @@ class TestObserveUpdates:
         estimator = TokenEstimator()
         ctx = ContextFeatures(conversation_length_tokens=3000, conversation_turn_count=10)
 
-        # Default for auditor is 750 per call
+        # Default for auditor is 930 per call
         estimator.observe_tool("assumption_auditor", ctx, 1000)
         est = estimator.estimate("assumption_auditor", ctx)
 

--- a/tests/test_tool_latency.py
+++ b/tests/test_tool_latency.py
@@ -1,5 +1,6 @@
 """Tests for the composite tool latency model (Issue #9)."""
 
+import json
 import threading
 import time
 from pathlib import Path
@@ -129,15 +130,17 @@ class TestAuditorDecomposition:
 class TestCalibratedColdStart:
     """#44: cold-start predictions land in the measured latency range.
 
-    Ranges bracket the tool durations measured in the #23 baseline run
-    (data/baseline: scanner ~1.7-4.5s, auditor ~2.7-2.9s,
-    refresher ~0.9-1.3s) with headroom for larger conversations.
+    Ranges bracket the tool durations measured in the #46 baseline
+    re-run on the Ollama cloud backend (data/baseline_full +
+    data/baseline_pilot_v2 medians: scanner ~10.1s, auditor ~8.8s,
+    refresher ~2.3s with a heavy right tail) with headroom for larger
+    conversations.
     """
 
     _RANGES = {
-        "research_gap_scanner": (1500.0, 4500.0),
-        "assumption_auditor": (1500.0, 4500.0),
-        "context_refresher": (600.0, 2200.0),
+        "research_gap_scanner": (6500.0, 11000.0),
+        "assumption_auditor": (6500.0, 11000.0),
+        "context_refresher": (2000.0, 5500.0),
     }
 
     @pytest.mark.parametrize("tool_id", _TOOL_IDS)
@@ -165,18 +168,28 @@ class TestCalibratedColdStart:
 _BASELINE_DIR = Path(__file__).resolve().parents[1] / "data" / "baseline"
 
 
+def _baseline_run_provider() -> str | None:
+    """Answerer provider recorded in the committed baseline run's summary."""
+    summary = _BASELINE_DIR / "summary.json"
+    if not summary.exists():
+        return None
+    answerer = json.loads(summary.read_text()).get("answerer")
+    return answerer.get("provider") if isinstance(answerer, dict) else None
+
+
 @pytest.mark.skipif(
-    not _BASELINE_DIR.exists(), reason="baseline episode data not available"
+    _baseline_run_provider() != "ollama",
+    reason="committed baseline episodes missing or not from the Ollama "
+    "backend the cold-start priors are calibrated against (#44/#46)",
 )
 class TestBaselineMape:
-    """#44 AC: cold-start MAPE < 50% against measured baseline tool durations."""
+    """#44 AC: cold-start MAPE < 50% against measured baseline tool durations.
 
-    @pytest.mark.xfail(
-        reason="priors were fit on Gemini-era durations; the 2026-07 baseline "
-        "re-run uses the slower Ollama backend (MAPE 62-75%). Re-enable once "
-        "the #44 Ollama latency refit lands.",
-        strict=False,
-    )
+    Guarded on the run's recorded answerer provider: the priors are
+    calibrated to the Ollama cloud backend, so the regression is only
+    meaningful against episodes collected on that backend.
+    """
+
     def test_cold_start_mape_under_50_percent(self):
         from bicameral_agent.serialization import episodes_from_parquet
 


### PR DESCRIPTION
## Summary
Completes issue #44's remaining acceptance criterion — "re-running the latency-MAPE computation on fresh episodes yields the improved error" — by recalibrating the cold-start priors against the fresh #46 baseline re-run on the Ollama cloud backend (gemma4:31b-cloud). The #67 calibration encoded Gemini-era speeds (~1s/call); on the Ollama backend single calls measure ~2-5s, so cold-start predictions under-predicted 2-4x, producing the 62.5% (random) / 75.0% (heuristic) MAPE in the #46 report.

## Baseline reproduction
Recomputing cold-start predictions from the fresh parquet episodes reproduces the report exactly (predictions in the runner are pure cold start — the latency model receives no `observe` calls during episodes): heuristic 74.95% (n=53), random 62.48% (n=27) on `data/baseline_full`, 70.4% on `data/baseline_pilot_v2` (n=29); 70.6% over all 109 pairs.

## Design: single shared prior profile (refit), not per-provider profiles
Per-provider profiles were considered and rejected for train/serve consistency:
- The serving site (`episode_runner`) could select on `client.provider`, but the training site (`training_pipeline`) re-encodes recorded episodes, and episodes do **not** reliably record the resolved provider — the `hyperparameters` metadata shows the config default (`gemini`) even for the Ollama run — so per-episode profile selection would silently mismatch.
- All current and planned collection runs (epic #41) use the Ollama backend; the Gemini-era regime is retired (`data/baseline_v1_nosignal`).
- The priors only govern cold start; the online OLS supersedes them after 20 observations on whatever backend is live.

Cost: Gemini-era predictions regress from ~15-17% to ~213% MAPE (measured against the archived `data/baseline_v1_nosignal` durations). Accepted: that backend no longer collects episodes.

## Refit
Grid search over (intercept, input coefficient, effective output rate) on a stratified per-tool alternate-split train half (55 rows) of the 109 fresh pairs, mirroring the #67 methodology; token-estimator `default_output_per_call` re-anchored to the run's recorded medians (scanner 780, auditor 930, refresher 1100 per call). Result: `_PRIOR_ALPHA` 700 → 3000 ms, `_PRIOR_BETA` 0.02 → 0.05 ms/token; output rate (2500) and overhead (175) unchanged. A small positive input coefficient is kept for strict monotonicity even though measured durations in this regime are dominated by a fixed per-call cost (scanner conv~duration correlation ≈ 0).

## Results (cold-start MAPE on fresh Ollama measurements)
| | before | after |
|---|---|---|
| Held-out (54 pairs, stratified split) | — | **44.7%** |
| All 109 pairs | 70.6% | 44.7% |
| research_gap_scanner (held-out, n=40) | — | 36.8% |
| assumption_auditor (held-out, n=4) | — | 22.2% |
| context_refresher (held-out, n=10) | — | 85.0% |
| `data/baseline` (committed run, regression test) | 70.7% | 44.6% |

Known limitation: the refresher's measured distribution (cluster at 1.6-3.5s plus 5/21 heavy-tail rows of 11-73s) sits below what the shared per-call intercept can express — its per-call cost is tied to the scanner/auditor calls, whose output tokens are *smaller*, so the token-linear form cannot lower it independently. Fixing that would need per-tool intercepts (architecture change, out of scope here); the overall target (<50% held-out) is met.

## Tests / coordination with #88
- `TestBaselineMape` (asserts <50% against committed `data/baseline`) is **un-xfailed**: PR #88 swapped `data/baseline` to the Ollama run and xfailed the test pending this refit; this PR removes the xfail (now passes at ~44.6%) and adds a provenance guard that skips unless the run's recorded answerer provider in `summary.json` is `ollama`, so the regression stays meaningful (or skips loudly) if the committed data changes backend again.
- `TestCalibratedColdStart` ranges updated as ranges bracketing the measured Ollama durations (medians: scanner ~10.1s, auditor ~8.8s, refresher ~2.3s); monotonicity test unchanged and passing.
- `test_latency.py` cold-start range updated to the measured 2-5s per-call band.
- Save/load (`save_observations`/`load_observations`) untouched and passing.

## Test plan
- `uv run --extra dev --extra torch pytest -q` — 1405 passed, 35 skipped.
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean.
- Held-out validation: constants fitted on the 55-row train half only; reported MAPE from the untouched 54-row half.

Closes #44