### PR TITLE
Run episodes concurrently within a condition

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -115,6 +115,11 @@ def main(argv: list[str] | None = None) -> int:
                              f"(of: {', '.join(CONDITION_NAMES)}; default all). "
                              "Lets an aborted run be resumed per-condition.")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
+    parser.add_argument("--parallel-episodes", type=int, default=1,
+                        help="Episodes run concurrently within a condition "
+                             "(bounded thread pool; 1 = sequential). Match the "
+                             "provider's concurrent-request allowance "
+                             "(Ollama Cloud: 3).")
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
     parser.add_argument("--random-probability", type=float, default=0.2)
@@ -125,6 +130,8 @@ def main(argv: list[str] | None = None) -> int:
         selected_conditions = parse_conditions(args.conditions)
     except ValueError as exc:
         parser.error(str(exc))
+    if args.parallel_episodes < 1:
+        parser.error(f"--parallel-episodes must be >= 1, got {args.parallel_episodes}")
 
     logging.basicConfig(
         level=logging.WARNING if args.quiet else logging.INFO,
@@ -169,16 +176,22 @@ def main(argv: list[str] | None = None) -> int:
 
     # Persist episodes incrementally: rewrite the condition's parquet after
     # every completed episode so a late crash keeps all prior results.
-    completed: dict[str, list[Episode]] = {}
+    # Episodes are keyed by task index and written sorted, so the file stays
+    # in task order even when --parallel-episodes completes out of order
+    # (run_condition serializes these callbacks on its coordinating thread).
+    completed: dict[str, dict[int, Episode]] = {}
 
-    def persist_episode(condition: str, _idx: int, episode: Episode) -> None:
-        completed.setdefault(condition, []).append(episode)
+    def persist_episode(condition: str, idx: int, episode: Episode) -> None:
+        by_index = completed.setdefault(condition, {})
+        by_index[idx] = episode
         episodes_to_parquet(
-            completed[condition], str(output_dir / f"{condition}.parquet")
+            [by_index[i] for i in sorted(by_index)],
+            str(output_dir / f"{condition}.parquet"),
         )
 
     result = run_benchmark(
-        client, tasks, conditions, runner=runner, on_episode=persist_episode
+        client, tasks, conditions, runner=runner, on_episode=persist_episode,
+        parallel_episodes=args.parallel_episodes,
     )
 
     report_text = format_report(result)

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -127,6 +127,11 @@ def main(argv: list[str] | None = None) -> int:
                         help="Verification metric used to score episodes.")
     parser.add_argument("--iterations", type=int, default=10)
     parser.add_argument("--episodes-per-iteration", type=int, default=50)
+    parser.add_argument("--parallel-episodes", type=int, default=1,
+                        help="Collection episodes run concurrently (bounded "
+                             "thread pool; 1 = sequential). Match the "
+                             "provider's concurrent-request allowance "
+                             "(Ollama Cloud: 3).")
     parser.add_argument("--simulations", type=int, default=50,
                         help="MCTS budget per decision point.")
     parser.add_argument("--eval-tasks", type=int, default=20,
@@ -167,12 +172,16 @@ def main(argv: list[str] | None = None) -> int:
 
     policy, transition = load_models(args)
 
+    if args.parallel_episodes < 1:
+        parser.error(f"--parallel-episodes must be >= 1, got {args.parallel_episodes}")
+
     trainer_config = MCTSTrainerConfig(
         collect_with_search=not args.no_search,
         eval_with_search=not args.no_search,
         retrain_transition=args.retrain_transition,
         max_turns=args.max_turns,
         seed=args.seed,
+        parallel_episodes=args.parallel_episodes,
     )
     pipeline = TrainingDataPipeline(max_turns=args.max_turns)
 

--- a/src/bicameral_agent/baseline_benchmark.py
+++ b/src/bicameral_agent/baseline_benchmark.py
@@ -9,13 +9,13 @@ recorded in the episode.
 
 from __future__ import annotations
 
-import contextvars
 import logging
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from typing import Callable
 
 from bicameral_agent.ab_test import MetricSummary, compute_summary, welch_t_test_from_stats
+from bicameral_agent.concurrency import submit_in_context
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.episode_runner import Controller, EpisodeRunner
 from bicameral_agent.gemini import GeminiClient
@@ -308,10 +308,7 @@ def run_condition(
                 and abort_cause is None
                 and fatal is None
             ):
-                future = pool.submit(
-                    contextvars.copy_context().run, _run_one, next_idx
-                )
-                in_flight[future] = next_idx
+                in_flight[submit_in_context(pool, _run_one, next_idx)] = next_idx
                 next_idx += 1
             if not in_flight:
                 break

--- a/src/bicameral_agent/baseline_benchmark.py
+++ b/src/bicameral_agent/baseline_benchmark.py
@@ -9,7 +9,9 @@ recorded in the episode.
 
 from __future__ import annotations
 
+import contextvars
 import logging
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -250,51 +252,111 @@ def run_condition(
     condition: str = "",
     on_episode: EpisodeCallback | None = None,
     failure_threshold: float = FAILURE_THRESHOLD,
+    parallel_episodes: int = 1,
 ) -> tuple[list[Episode], list[TaskMetrics], list[EpisodeFailure]]:
     """Run one controller condition over the task pool.
 
     A fresh controller is constructed per episode (via ``controller_factory(idx)``)
     so that decision logs are scoped to a single episode. ``on_episode`` (if
     given) fires after each completed episode, letting callers persist results
-    incrementally so a late crash keeps prior episodes.
+    incrementally so a late crash keeps prior episodes. It is always invoked
+    from the coordinating thread (never concurrently), in completion order —
+    which is task order when ``parallel_episodes`` is 1.
+
+    ``parallel_episodes`` bounds how many episodes run concurrently on a
+    thread pool (issue #91; 1 = sequential, the default). Episodes launch in
+    task order and results are keyed by task index, so the returned episode,
+    metric, and failure lists are in task order regardless of completion
+    order. Each episode runs in a copy of the caller's ``contextvars``
+    context, so per-episode context-local state (degradation counters,
+    episode cost accumulators) never crosses episodes.
 
     A :class:`~bicameral_agent.model_client.TransportExhausted` error (a
     transport failure that outlived the client's retry budget) fails only its
     episode: the failure is recorded and the run continues with the next task.
     Once failures exceed ``failure_threshold`` of the condition's episodes,
     :class:`ConditionAbortedError` is raised instead — a dead network must not
-    produce a near-empty "successful" run.
+    produce a near-empty "successful" run. Under concurrency the abort waits
+    for in-flight episodes to settle (completed ones still reach
+    ``on_episode``) and launches nothing new.
     """
-    episodes: list[Episode] = []
-    metrics: list[TaskMetrics] = []
-    failures: list[EpisodeFailure] = []
-    for idx, task in enumerate(tasks):
+    if parallel_episodes < 1:
+        raise ValueError(f"parallel_episodes must be >= 1, got {parallel_episodes}")
+
+    def _run_one(idx: int) -> tuple[Episode, TaskMetrics]:
         controller = controller_factory(idx)
-        try:
-            episode = runner.run_episode(task, controller)
-        except TransportExhausted as exc:
-            failures.append(
-                EpisodeFailure(
-                    condition=condition,
-                    episode_index=idx,
-                    task_id=task.task_id,
-                    error=str(exc),
+        episode = runner.run_episode(tasks[idx], controller)
+        return episode, extract_task_metrics(episode, list(controller.decisions))
+
+    results: dict[int, tuple[Episode, TaskMetrics]] = {}
+    failures: dict[int, EpisodeFailure] = {}
+    abort_cause: TransportExhausted | None = None
+    fatal: Exception | None = None
+
+    with ThreadPoolExecutor(max_workers=parallel_episodes) as pool:
+        next_idx = 0
+        in_flight: dict[Future, int] = {}
+        while True:
+            # Keep at most parallel_episodes episodes in flight, launched in
+            # task order; stop launching once aborting or failing. Windowed
+            # submission (rather than submitting everything upfront) means a
+            # worker never races ahead of the threshold check — with
+            # parallel_episodes=1 this is exactly the old sequential loop.
+            while (
+                next_idx < len(tasks)
+                and len(in_flight) < parallel_episodes
+                and abort_cause is None
+                and fatal is None
+            ):
+                future = pool.submit(
+                    contextvars.copy_context().run, _run_one, next_idx
                 )
-            )
-            logger.warning(
-                "Episode %d (task %s) in condition %r failed on transport: %s",
-                idx, task.task_id, condition, exc,
-            )
-            if len(failures) / len(tasks) > failure_threshold:
-                raise ConditionAbortedError(
-                    condition, len(failures), len(tasks), failure_threshold
-                ) from exc
-            continue
-        episodes.append(episode)
-        metrics.append(extract_task_metrics(episode, list(controller.decisions)))
-        if on_episode is not None:
-            on_episode(condition, idx, episode)
-    return episodes, metrics, failures
+                in_flight[future] = next_idx
+                next_idx += 1
+            if not in_flight:
+                break
+            done, _ = wait(in_flight, return_when=FIRST_COMPLETED)
+            for future in sorted(done, key=in_flight.__getitem__):
+                idx = in_flight.pop(future)
+                try:
+                    episode, task_metrics = future.result()
+                except TransportExhausted as exc:
+                    failures[idx] = EpisodeFailure(
+                        condition=condition,
+                        episode_index=idx,
+                        task_id=tasks[idx].task_id,
+                        error=str(exc),
+                    )
+                    logger.warning(
+                        "Episode %d (task %s) in condition %r failed on transport: %s",
+                        idx, tasks[idx].task_id, condition, exc,
+                    )
+                    if (
+                        abort_cause is None
+                        and len(failures) / len(tasks) > failure_threshold
+                    ):
+                        abort_cause = exc
+                except Exception as exc:
+                    # Non-transport errors are programming bugs: stop
+                    # launching, let in-flight episodes settle, re-raise.
+                    if fatal is None:
+                        fatal = exc
+                else:
+                    results[idx] = (episode, task_metrics)
+                    if on_episode is not None:
+                        on_episode(condition, idx, episode)
+
+    if fatal is not None:
+        raise fatal
+    if abort_cause is not None:
+        raise ConditionAbortedError(
+            condition, len(failures), len(tasks), failure_threshold
+        ) from abort_cause
+    return (
+        [results[i][0] for i in sorted(results)],
+        [results[i][1] for i in sorted(results)],
+        [failures[i] for i in sorted(failures)],
+    )
 
 
 def _format_summary(summary: MetricSummary, fmt: str) -> str:
@@ -311,12 +373,14 @@ def run_benchmark(
     runner: EpisodeRunner | None = None,
     on_episode: EpisodeCallback | None = None,
     failure_threshold: float = FAILURE_THRESHOLD,
+    parallel_episodes: int = 1,
 ) -> BenchmarkResult:
     """Run all conditions over the task pool and aggregate.
 
     ``on_episode`` is forwarded to :func:`run_condition` for incremental
     persistence of completed episodes, ``failure_threshold`` for the
-    per-condition transport-failure abort.
+    per-condition transport-failure abort, and ``parallel_episodes`` for
+    within-condition episode concurrency.
     """
     runner = runner or EpisodeRunner(client)
     result = BenchmarkResult()
@@ -324,7 +388,7 @@ def run_benchmark(
         logger.info("Running %d episodes for condition %r", len(tasks), condition)
         episodes, metrics, failures = run_condition(
             runner, tasks, factory, condition=condition, on_episode=on_episode,
-            failure_threshold=failure_threshold,
+            failure_threshold=failure_threshold, parallel_episodes=parallel_episodes,
         )
         result.episodes[condition] = episodes
         result.metrics[condition] = metrics

--- a/src/bicameral_agent/concurrency.py
+++ b/src/bicameral_agent/concurrency.py
@@ -1,0 +1,35 @@
+"""Context-propagating thread-pool submission (issue #91).
+
+Per-episode state lives in ``contextvars`` ContextVars: the degradation
+counters in ``llm_output`` and the episode cost accumulators in
+``cost_tracker``. ``ThreadPoolExecutor`` worker threads do NOT inherit the
+submitter's context -- each thread runs in its own context, created empty at
+thread start -- so work submitted with a plain ``pool.submit(fn, ...)``
+silently escapes the submitting episode's counters and cost accounting.
+This module names and enforces that contract in one place.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from concurrent.futures import Executor, Future
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def submit_in_context(
+    pool: Executor, fn: Callable[..., T], /, *args, **kwargs
+) -> Future[T]:
+    """Submit ``fn(*args, **kwargs)`` to ``pool``, run in a copy of the
+    caller's ``contextvars`` context.
+
+    Use this for ALL episode-scoped pool work: it is what makes
+    context-local per-episode state (degradation counters, episode cost
+    accumulators) attribute worker-thread activity to the submitting
+    episode. A fresh ``copy_context()`` is captured per submission, so
+    concurrent tasks never share a Context object (``Context.run`` may not
+    be entered concurrently) and mutations of context variables inside the
+    worker never leak back to the submitter.
+    """
+    return pool.submit(contextvars.copy_context().run, fn, *args, **kwargs)

--- a/src/bicameral_agent/cost_tracker.py
+++ b/src/bicameral_agent/cost_tracker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from bicameral_agent.model_client import PROVIDERS, ModelClient, ModelResponse
@@ -90,11 +91,29 @@ class CostBudgetExceeded(Exception):
     """Raised when the accumulated cost exceeds the configured budget."""
 
 
+class _EpisodeCosts:
+    """Mutable per-episode accumulator; mutation is guarded by the tracker lock."""
+
+    __slots__ = ("input_cost", "output_cost", "call_count")
+
+    def __init__(self) -> None:
+        self.input_cost = 0.0
+        self.output_cost = 0.0
+        self.call_count = 0
+
+
 class CostTracker:
     """Thread-safe cost tracker with session and episode accumulators.
 
     Session accumulators persist for the lifetime of the tracker.
     Episode accumulators can be reset between episodes via ``reset_episode()``.
+
+    The episode accumulator is context-local (issue #91): concurrent
+    episodes each run in their own ``contextvars`` context, so one
+    episode's ``reset_episode``/``get_episode_cost`` never touches
+    another's accumulator, while threads an episode spawns with a copied
+    context (e.g. the scorer's worker pool) still attribute their calls to
+    that episode. Session accumulators remain shared across all contexts.
     """
 
     def __init__(self) -> None:
@@ -103,13 +122,22 @@ class CostTracker:
         self._session_input_cost: float = 0.0
         self._session_output_cost: float = 0.0
         self._session_call_count: int = 0
-        # Episode-level (reset via reset_episode)
-        self._episode_input_cost: float = 0.0
-        self._episode_output_cost: float = 0.0
-        self._episode_call_count: int = 0
+        # Episode-level (reset via reset_episode); context-local, one
+        # ContextVar per tracker so independent trackers stay isolated.
+        self._episode_costs: ContextVar[_EpisodeCosts | None] = ContextVar(
+            f"episode_costs_{id(self)}", default=None
+        )
         # Budget limits
         self._session_budget: float | None = None
         self._episode_budget: float | None = None
+
+    def _episode(self) -> _EpisodeCosts:
+        """The current context's episode accumulator, created on first use."""
+        costs = self._episode_costs.get()
+        if costs is None:
+            costs = _EpisodeCosts()
+            self._episode_costs.set(costs)
+        return costs
 
     def record_call(
         self,
@@ -139,9 +167,10 @@ class CostTracker:
             self._session_input_cost += input_cost
             self._session_output_cost += output_cost
             self._session_call_count += 1
-            self._episode_input_cost += input_cost
-            self._episode_output_cost += output_cost
-            self._episode_call_count += 1
+            episode = self._episode()
+            episode.input_cost += input_cost
+            episode.output_cost += output_cost
+            episode.call_count += 1
 
     def check_budget(self) -> None:
         """Raise ``CostBudgetExceeded`` if session or episode budget is exceeded."""
@@ -149,7 +178,10 @@ class CostTracker:
             return
         with self._lock:
             session_total = self._session_input_cost + self._session_output_cost
-            episode_total = self._episode_input_cost + self._episode_output_cost
+            episode = self._episode_costs.get()
+            episode_total = (
+                episode.input_cost + episode.output_cost if episode is not None else 0.0
+            )
 
         if self._session_budget is not None and session_total >= self._session_budget:
             raise CostBudgetExceeded(
@@ -171,14 +203,21 @@ class CostTracker:
             )
 
     def get_episode_cost(self) -> CostReport:
-        """Return episode-level cost report."""
+        """Return the current context's episode-level cost report."""
         with self._lock:
-            return CostReport(
-                input_cost=self._episode_input_cost,
-                output_cost=self._episode_output_cost,
-                total=self._episode_input_cost + self._episode_output_cost,
-                call_count=self._episode_call_count,
-            )
+            return self._episode_report()
+
+    def _episode_report(self) -> CostReport:
+        """Snapshot the current context's episode costs (call under the lock)."""
+        episode = self._episode_costs.get()
+        if episode is None:
+            return CostReport(input_cost=0.0, output_cost=0.0, total=0.0, call_count=0)
+        return CostReport(
+            input_cost=episode.input_cost,
+            output_cost=episode.output_cost,
+            total=episode.input_cost + episode.output_cost,
+            call_count=episode.call_count,
+        )
 
     def set_budget(self, max_dollars: float | None) -> None:
         """Set the session-level budget (``None`` to disable)."""
@@ -189,17 +228,10 @@ class CostTracker:
         self._episode_budget = max_dollars
 
     def reset_episode(self) -> CostReport:
-        """Return episode report and zero the episode accumulators."""
+        """Return the current context's episode report and start a fresh one."""
         with self._lock:
-            report = CostReport(
-                input_cost=self._episode_input_cost,
-                output_cost=self._episode_output_cost,
-                total=self._episode_input_cost + self._episode_output_cost,
-                call_count=self._episode_call_count,
-            )
-            self._episode_input_cost = 0.0
-            self._episode_output_cost = 0.0
-            self._episode_call_count = 0
+            report = self._episode_report()
+            self._episode_costs.set(_EpisodeCosts())
             return report
 
 

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -160,9 +160,11 @@ class EpisodeRunner:
             A validated Episode capturing the full conversation.
         """
         # Episode-scoped degradation counting (issue #82): every
-        # structured-output site funnels through safe_parse_json, whose
-        # degradation warning this handler tallies -- no counter threading
+        # structured-output site funnels through safe_parse_json, which
+        # reports to this context-local counter -- no counter threading
         # through the six components (sim-user, tools, scorer/verifiers).
+        # Context-local (issue #91) so concurrent episodes, each run in its
+        # own contextvars context, never count each other's degradations.
         with count_degradations() as degradations:
             return self._run_episode(task, controller, degradations)
 

--- a/src/bicameral_agent/llm_output.py
+++ b/src/bicameral_agent/llm_output.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import json
 import logging
 import re
+import threading
 from collections import Counter
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Iterator
 
 if TYPE_CHECKING:
@@ -63,36 +65,39 @@ def safe_parse_json(response: Any, *, context: str, default: dict | None = None)
         context,
         getattr(response, "finish_reason", "unknown"),
         len(text),
-        extra={"degradation_component": context},
     )
+    for counter in _active_counters.get():
+        counter.add(context)
     return default
 
 
-class DegradationCounter(logging.Handler):
+class DegradationCounter:
     """Tallies ``safe_parse_json`` degradations per component (issue #82).
 
-    ``safe_parse_json`` tags its degradation warning with the caller's
-    *context* string; this handler counts those tags, ignoring any other
-    records. Attach via ``count_degradations`` so counts are scoped to one
-    episode -- a module-level counter would bleed across episodes.
-    ``logging`` serializes ``emit`` per handler, so counting is safe under
-    the scorers' worker threads.
-
-    Assumes NON-OVERLAPPING EPISODES: the handler attaches to this module's
-    global logger, so concurrently running episodes (e.g. ``run_episode`` on
-    a ThreadPool) would count each other's degradations. A ContextVar-based
-    counter would lift that restriction if episode-level parallelism is ever
-    introduced.
+    ``safe_parse_json`` reports each degradation (tagged with the caller's
+    *context* string) to every counter active in the current ``contextvars``
+    context; attach one via ``count_degradations``. Counters live in a
+    ContextVar rather than on a module-level logger, so concurrently running
+    episodes (``run_episode`` on a ThreadPool, issue #91) never observe each
+    other's degradations -- each episode's worker task runs in its own
+    context. Increments are lock-guarded because a scorer's own worker
+    threads (which run in a *copy* of the episode's context) may report
+    concurrently.
     """
 
     def __init__(self) -> None:
-        super().__init__(level=logging.WARNING)
         self.counts: Counter[str] = Counter()
+        self._lock = threading.Lock()
 
-    def emit(self, record: logging.LogRecord) -> None:
-        component = getattr(record, "degradation_component", None)
-        if component is not None:
+    def add(self, component: str) -> None:
+        """Record one degradation attributed to *component*."""
+        with self._lock:
             self.counts[component] += 1
+
+
+_active_counters: ContextVar[tuple[DegradationCounter, ...]] = ContextVar(
+    "llm_output_degradation_counters", default=()
+)
 
 
 @contextmanager
@@ -100,15 +105,20 @@ def count_degradations() -> Iterator[DegradationCounter]:
     """Count safe-parse degradations occurring inside the ``with`` block.
 
     Yields a ``DegradationCounter`` whose ``counts`` maps component context
-    strings (e.g. ``"TaskScorer"``) to degradation counts. The handler is
-    detached on exit, so counters never observe each other's blocks.
+    strings (e.g. ``"TaskScorer"``) to degradation counts. Counters stack:
+    nested blocks count independently, with the outer counter still seeing
+    the inner block's degradations. The stack lives in a ContextVar that is
+    reset on exit, so counters are scoped to their own context -- concurrent
+    episodes each see only their own degradations, and threads spawned with
+    a copied context (``contextvars.copy_context``) inherit their episode's
+    counters.
     """
     counter = DegradationCounter()
-    logger.addHandler(counter)
+    token = _active_counters.set(_active_counters.get() + (counter,))
     try:
         yield counter
     finally:
-        logger.removeHandler(counter)
+        _active_counters.reset(token)
 
 
 def clamp(value: Any, low: float, high: float, default: float) -> float:

--- a/src/bicameral_agent/mcts_trainer.py
+++ b/src/bicameral_agent/mcts_trainer.py
@@ -34,7 +34,6 @@ and no torch RNG is consumed (the networks have no stochastic layers).
 
 from __future__ import annotations
 
-import contextvars
 import dataclasses
 import json
 import logging
@@ -47,6 +46,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from bicameral_agent.concurrency import submit_in_context
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.heuristic_controller import FullState, HeuristicController
@@ -426,8 +426,7 @@ class MCTSTrainer:
         episodes: dict[int, Episode] = {}
         with ThreadPoolExecutor(max_workers=parallel) as pool:
             futures = {
-                pool.submit(contextvars.copy_context().run, _run_one, i): i
-                for i in range(n_episodes)
+                submit_in_context(pool, _run_one, i): i for i in range(n_episodes)
             }
             try:
                 for future in as_completed(futures):

--- a/src/bicameral_agent/mcts_trainer.py
+++ b/src/bicameral_agent/mcts_trainer.py
@@ -34,10 +34,12 @@ and no torch RNG is consumed (the networks have no stochastic layers).
 
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import json
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Callable, Sequence
 
@@ -89,6 +91,11 @@ class MCTSTrainerConfig:
     ``max_turns`` must match the ``EpisodeConfig.max_turns`` used by the
     runner so the pipeline's completion-fraction features are consistent
     between collection and training.
+
+    ``parallel_episodes`` bounds how many collection episodes run
+    concurrently (issue #91; 1 = sequential). Per-episode seeds and the
+    returned episode order are index-based, so parallelism does not change
+    what is collected — only the wall clock.
     """
 
     epochs: int = 50
@@ -105,6 +112,7 @@ class MCTSTrainerConfig:
     train_ratio: float = 0.8
     max_turns: int = 25
     seed: int = 0
+    parallel_episodes: int = 1
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -389,17 +397,46 @@ class MCTSTrainer:
         if n_episodes < 1:
             msg = f"n_episodes must be >= 1, got {n_episodes}"
             raise ValueError(msg)
-        episodes: list[Episode] = []
-        for i in range(n_episodes):
+        parallel = self._config.parallel_episodes
+        if parallel < 1:
+            msg = f"parallel_episodes must be >= 1, got {parallel}"
+            raise ValueError(msg)
+
+        def _run_one(i: int) -> Episode:
             task = self._train_tasks[i % len(self._train_tasks)]
             controller = self._make_controller(
                 training=True, n_simulations=n_simulations, seed=base_seed + 10 + i
             )
-            episodes.append(self._runner.run_episode(task, controller))
+            episode = self._runner.run_episode(task, controller)
             logger.info(
                 "collected episode %d/%d (task %s)", i + 1, n_episodes, task.task_id
             )
-        return episodes
+            return episode
+
+        if parallel == 1:
+            return [_run_one(i) for i in range(n_episodes)]
+
+        # Issue #91: bounded episode concurrency. Results are keyed by
+        # episode index so the returned list is in collection order (and
+        # per-episode seeds stay index-based) regardless of completion
+        # order. Each episode runs in a copy of the caller's contextvars
+        # context so per-episode counters/cost never cross episodes. Any
+        # failure cancels unstarted episodes and propagates once in-flight
+        # ones settle.
+        episodes: dict[int, Episode] = {}
+        with ThreadPoolExecutor(max_workers=parallel) as pool:
+            futures = {
+                pool.submit(contextvars.copy_context().run, _run_one, i): i
+                for i in range(n_episodes)
+            }
+            try:
+                for future in as_completed(futures):
+                    episodes[futures[future]] = future.result()
+            except BaseException:
+                for f in futures:
+                    f.cancel()
+                raise
+        return [episodes[i] for i in range(n_episodes)]
 
     def _evaluate(
         self, n_simulations: int, seed: int

--- a/src/bicameral_agent/scorer.py
+++ b/src/bicameral_agent/scorer.py
@@ -6,6 +6,7 @@ for evaluating agent answers against research QA tasks with scoring rubrics.
 
 from __future__ import annotations
 
+import contextvars
 import hashlib
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -125,6 +126,11 @@ class CachedConcurrentScorer:
     ``_score_cached`` / ``_score_batch_cached`` with a hashable cache key
     per item. Thread-safe; batch scoring dispatches uncached items to a
     ThreadPoolExecutor. Shared by TaskScorer and CoherenceJudge (issue #54).
+
+    Each batch item runs in a copy of the submitting thread's contextvars
+    context (issue #91): pool threads do not inherit context by default, so
+    without the copy, context-scoped per-episode state (degradation
+    counters, episode cost accumulators) would miss work done here.
     """
 
     def __init__(self, max_workers: int = 10) -> None:
@@ -163,7 +169,11 @@ class CachedConcurrentScorer:
         if uncached_indices:
             with ThreadPoolExecutor(max_workers=self._max_workers) as pool:
                 future_to_idx = {
-                    pool.submit(self._score_uncached, items[i]): i
+                    pool.submit(
+                        contextvars.copy_context().run,
+                        self._score_uncached,
+                        items[i],
+                    ): i
                     for i in uncached_indices
                 }
                 for future in as_completed(future_to_idx):

--- a/src/bicameral_agent/scorer.py
+++ b/src/bicameral_agent/scorer.py
@@ -6,13 +6,13 @@ for evaluating agent answers against research QA tasks with scoring rubrics.
 
 from __future__ import annotations
 
-import contextvars
 import hashlib
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pydantic import BaseModel, Field
 
+from bicameral_agent.concurrency import submit_in_context
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.gemini import GeminiClient
 from bicameral_agent.llm_output import coerce_int, safe_parse_json, tokenize
@@ -169,11 +169,7 @@ class CachedConcurrentScorer:
         if uncached_indices:
             with ThreadPoolExecutor(max_workers=self._max_workers) as pool:
                 future_to_idx = {
-                    pool.submit(
-                        contextvars.copy_context().run,
-                        self._score_uncached,
-                        items[i],
-                    ): i
+                    submit_in_context(pool, self._score_uncached, items[i]): i
                     for i in uncached_indices
                 }
                 for future in as_completed(future_to_idx):

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -618,6 +621,208 @@ class TestTransportFailureContainment:
         assert result.failures["random"] == []
         assert result.reports["heuristic"].n_episodes == 3
         assert result.reports["random"].n_episodes == 4
+
+
+class _StubRunner:
+    """Thread-safe stand-in for EpisodeRunner with per-task delays/errors.
+
+    Returns an episode tagged with the task id; later tasks finish sooner
+    (reversed delays) so concurrent completion order inverts task order.
+    """
+
+    def __init__(
+        self,
+        n_tasks: int,
+        fail_task_ids: set[str] | None = None,
+        delay_step_s: float = 0.01,
+    ) -> None:
+        self._n_tasks = n_tasks
+        self._fail_task_ids = fail_task_ids or set()
+        self._delay_step_s = delay_step_s
+        self._lock = threading.Lock()
+        self.call_count = 0
+        self.started_task_ids: list[str] = []
+
+    def run_episode(self, task, controller):
+        with self._lock:
+            self.call_count += 1
+            self.started_task_ids.append(task.task_id)
+        idx = int(task.task_id[1:])
+        time.sleep((self._n_tasks - idx) * self._delay_step_s)
+        if task.task_id in self._fail_task_ids:
+            raise _transport_exhausted()
+        return _make_episode(metadata={"task_id": task.task_id})
+
+
+class TestParallelEpisodes:
+    """Issue #91: bounded episode concurrency within a condition."""
+
+    def test_parallel_output_matches_sequential(self):
+        tasks = [_task(f"t{i}") for i in range(6)]
+
+        def run(parallel):
+            runner = _StubRunner(len(tasks))
+            seen: list[int] = []
+            episodes, metrics, failures = run_condition(
+                runner, tasks, lambda _idx: _StubController(),
+                condition="random",
+                on_episode=lambda cond, idx, ep: seen.append(idx),
+                parallel_episodes=parallel,
+            )
+            return episodes, metrics, failures, seen, runner
+
+        seq_eps, seq_metrics, seq_fail, seq_seen, _ = run(1)
+        par_eps, par_metrics, par_fail, par_seen, par_runner = run(3)
+
+        # Same episodes in task order, regardless of completion order.
+        assert [e.metadata["task_id"] for e in seq_eps] == [t.task_id for t in tasks]
+        assert [e.metadata["task_id"] for e in par_eps] == [t.task_id for t in tasks]
+        assert par_metrics == seq_metrics
+        assert par_fail == seq_fail == []
+        # Sequential callbacks are in task order; parallel fires for every
+        # episode exactly once (completion order may differ).
+        assert seq_seen == list(range(6))
+        assert sorted(par_seen) == list(range(6))
+        assert par_runner.call_count == 6
+
+    def test_parallel_containment_keeps_task_order(self):
+        tasks = [_task(f"t{i}") for i in range(6)]
+        runner = _StubRunner(len(tasks), fail_task_ids={"t2"})
+        episodes, metrics, failures = run_condition(
+            runner, tasks, lambda _idx: _StubController(),
+            condition="random", parallel_episodes=3,
+        )
+        assert [e.metadata["task_id"] for e in episodes] == [
+            "t0", "t1", "t3", "t4", "t5"
+        ]
+        assert len(metrics) == 5
+        (failure,) = failures
+        assert failure.episode_index == 2
+        assert failure.task_id == "t2"
+
+    def test_parallel_threshold_abort_skips_unstarted(self):
+        tasks = [_task(f"t{i}") for i in range(12)]
+        runner = _StubRunner(
+            len(tasks), fail_task_ids={t.task_id for t in tasks}, delay_step_s=0.0
+        )
+        with pytest.raises(ConditionAbortedError) as exc_info:
+            run_condition(
+                runner, tasks, lambda _idx: _StubController(),
+                condition="random", parallel_episodes=3,
+            )
+        # Threshold trips at the 4th failure (4/12 > 30%); at most the
+        # in-flight window (3) can still have started beyond that point.
+        assert exc_info.value.n_failures >= 4
+        assert runner.call_count <= 4 + 3
+        assert isinstance(exc_info.value.__cause__, TransportExhausted)
+
+    def test_parallel_workers_must_be_positive(self):
+        with pytest.raises(ValueError, match="parallel_episodes"):
+            run_condition(
+                MagicMock(spec=EpisodeRunner), [_task()],
+                lambda _idx: _StubController(), parallel_episodes=0,
+            )
+
+    def test_run_benchmark_forwards_parallel_episodes(self):
+        tasks = [_task(f"t{i}") for i in range(3)]
+        runner = _StubRunner(len(tasks))
+        result = run_benchmark(
+            client=MagicMock(),
+            tasks=tasks,
+            conditions={"random": lambda _idx: _StubController()},
+            runner=runner,
+            parallel_episodes=3,
+        )
+        assert [e.metadata["task_id"] for e in result.episodes["random"]] == [
+            "t0", "t1", "t2"
+        ]
+
+
+class _DeterministicClient:
+    """Thread-safe mocked model client keyed purely on request content.
+
+    Sim-user calls (they carry a response_schema) get a clean task_complete
+    JSON, except when the conversation mentions the degradation marker, in
+    which case they get unparseable prose. Answerer calls get plain text.
+    A small sleep encourages episodes to actually overlap under N>1.
+    """
+
+    model = "gemini-3.1-flash-lite-preview"
+
+    DEGRADE_MARKER = "UNPARSEABLE-EPISODE"
+
+    def generate(self, messages, **kwargs):
+        from bicameral_agent.gemini import GeminiResponse
+
+        time.sleep(0.005)
+        text = " ".join(
+            m["content"] if isinstance(m, dict) else m.content for m in messages
+        )
+        if kwargs.get("response_schema") is not None:
+            if self.DEGRADE_MARKER in text:
+                content = "definitely not json"
+            else:
+                content = json.dumps(
+                    {
+                        "action_type": "task_complete",
+                        "response_delay_ms": 100,
+                        "confidence": 0.9,
+                    }
+                )
+        else:
+            content = "A deterministic answer."
+        return GeminiResponse(
+            content=content,
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=1.0,
+            finish_reason="STOP",
+        )
+
+
+class TestParallelEpisodeIsolation:
+    """Concurrent episodes through the real EpisodeRunner stay isolated."""
+
+    def _run(self, parallel: int) -> list[Episode]:
+        from bicameral_agent.episode_runner import EpisodeConfig
+
+        tasks = [
+            _task("t0"),
+            ResearchQATask(
+                task_id="t1",
+                difficulty=TaskDifficulty.TYPICAL,
+                split=TaskSplit.EVAL,
+                question=f"q {_DeterministicClient.DEGRADE_MARKER}",
+                gold_answer="a",
+                scoring_rubric="rubric",
+            ),
+            _task("t2"),
+        ]
+        runner = EpisodeRunner(
+            _DeterministicClient(), config=EpisodeConfig(max_turns=1)
+        )
+        episodes, _, failures = run_condition(
+            runner, tasks, lambda _idx: _StubController(),
+            condition="no_subconscious", parallel_episodes=parallel,
+        )
+        assert failures == []
+        return episodes
+
+    def test_parallel_run_identical_to_sequential(self):
+        seq = self._run(1)
+        par = self._run(3)
+        for a, b in zip(seq, par):
+            assert a.metadata["task_id"] == b.metadata["task_id"]
+            assert a.metadata["parse_degradations"] == b.metadata["parse_degradations"]
+            assert a.outcome.total_turns == b.outcome.total_turns
+            assert [m.content for m in a.messages] == [m.content for m in b.messages]
+
+    def test_degradation_counts_stay_per_episode(self):
+        episodes = self._run(3)
+        by_task = {e.metadata["task_id"]: e.metadata["parse_degradations"] for e in episodes}
+        assert by_task["t0"] == {}
+        assert by_task["t1"] == {"SimulatedUser.respond": 1}
+        assert by_task["t2"] == {}
 
 
 def _load_benchmark_script():

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,50 @@
+"""Tests for context-propagating pool submission (issue #91)."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
+
+from bicameral_agent.concurrency import submit_in_context
+
+_var: ContextVar[str] = ContextVar("test_concurrency_var", default="unset")
+
+
+class TestSubmitInContext:
+    def test_worker_sees_submitters_context(self):
+        token = _var.set("episode-A")
+        try:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                # Plain submit does not inherit the submitter's context...
+                assert pool.submit(_var.get).result() == "unset"
+                # ...submit_in_context does.
+                assert submit_in_context(pool, _var.get).result() == "episode-A"
+        finally:
+            _var.reset(token)
+
+    def test_context_captured_per_submission(self):
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            token = _var.set("first")
+            future_first = submit_in_context(pool, _var.get)
+            _var.reset(token)
+            token = _var.set("second")
+            future_second = submit_in_context(pool, _var.get)
+            _var.reset(token)
+            assert future_first.result() == "first"
+            assert future_second.result() == "second"
+
+    def test_worker_mutations_do_not_leak_back(self):
+        token = _var.set("outer")
+        try:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                submit_in_context(pool, _var.set, "inner").result()
+            assert _var.get() == "outer"
+        finally:
+            _var.reset(token)
+
+    def test_args_and_kwargs_forwarded(self):
+        def combine(a, b, *, sep):
+            return f"{a}{sep}{b}"
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            assert submit_in_context(pool, combine, "x", "y", sep="-").result() == "x-y"

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextvars
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -187,6 +189,53 @@ class TestThreadSafety:
         expected_output = expected_calls * 200 * _PRICING.output_cost_per_token
         assert report.input_cost == pytest.approx(expected_input)
         assert report.output_cost == pytest.approx(expected_output)
+
+
+class TestEpisodeContextIsolation:
+    """Issue #91: episode accumulators are context-local, session shared."""
+
+    def test_concurrent_episodes_have_isolated_episode_costs(self):
+        tracker = CostTracker()
+        barrier = threading.Barrier(2)
+        results: dict[str, int] = {}
+
+        def episode(name: str, n_calls: int) -> None:
+            tracker.reset_episode()
+            barrier.wait(timeout=5)
+            for _ in range(n_calls):
+                tracker.record_call(100, 200, _MODEL)
+            barrier.wait(timeout=5)
+            results[name] = tracker.get_episode_cost().call_count
+
+        threads = [
+            threading.Thread(target=episode, args=("A", 2)),
+            threading.Thread(target=episode, args=("B", 5)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Each episode sees only its own calls; the session sees all.
+        assert results == {"A": 2, "B": 5}
+        assert tracker.get_total().call_count == 7
+
+    def test_copied_context_worker_threads_attribute_to_episode(self):
+        """Scorer-pool style: threads submitted with a copied context record
+        into the submitting episode's accumulator."""
+        tracker = CostTracker()
+        tracker.reset_episode()
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(
+                    contextvars.copy_context().run,
+                    tracker.record_call, 100, 200, _MODEL,
+                )
+                for _ in range(3)
+            ]
+            for f in futures:
+                f.result()
+        assert tracker.get_episode_cost().call_count == 3
 
 
 class TestCostTrackedClient:

--- a/tests/test_llm_output.py
+++ b/tests/test_llm_output.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import contextvars
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -121,3 +124,49 @@ class TestCountDegradations:
                 safe_parse_json(_response("bad"), context="B")
         assert inner.counts == {"B": 1}
         assert outer.counts == {"A": 1, "B": 1}
+
+    def test_concurrent_episodes_do_not_cross_contaminate(self):
+        """Issue #91: overlapping episode counters each see only their own.
+
+        A barrier holds both threads inside their ``count_degradations``
+        blocks simultaneously, so a regression to a shared module-level
+        counter would deterministically leak counts across threads.
+        """
+        barrier = threading.Barrier(2)
+        results: dict[str, dict[str, int]] = {}
+
+        def episode(name: str, n: int) -> None:
+            with count_degradations() as counter:
+                barrier.wait(timeout=5)
+                for _ in range(n):
+                    safe_parse_json(_response("bad"), context=name)
+                barrier.wait(timeout=5)
+            results[name] = dict(counter.counts)
+
+        threads = [
+            threading.Thread(target=episode, args=("A", 2)),
+            threading.Thread(target=episode, args=("B", 3)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert results == {"A": {"A": 2}, "B": {"B": 3}}
+
+    def test_copied_context_worker_threads_report_to_counter(self):
+        """Threads submitted with a copied context (scorer-pool style, issue
+        #91) attribute their degradations to the submitting episode."""
+        with count_degradations() as counter:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(
+                        contextvars.copy_context().run,
+                        safe_parse_json,
+                        _response("bad"),
+                        context="TaskScorer",
+                    )
+                    for _ in range(3)
+                ]
+                for f in futures:
+                    f.result()
+        assert counter.counts == {"TaskScorer": 3}

--- a/tests/test_mcts_trainer.py
+++ b/tests/test_mcts_trainer.py
@@ -310,6 +310,54 @@ class TestOfflineIteration:
             trainer.run_iteration(2, 4)
 
 
+class TestParallelCollection:
+    """Issue #91: bounded concurrent collection preserves episode order."""
+
+    def _collect(self, tmp_path, parallel: int) -> list[Episode]:
+        import time
+
+        tasks = [_make_task(f"task-{i}") for i in range(4)]
+        runner = MagicMock(spec=EpisodeRunner)
+
+        def run_episode(task, controller):
+            # Later tasks finish sooner, inverting completion order at N>1.
+            idx = int(task.task_id.split("-")[1])
+            time.sleep((len(tasks) - idx) * 0.01)
+            episode = _build_episode(num_turns=2)
+            return episode.model_copy(update={"metadata": {"task_id": task.task_id}})
+
+        runner.run_episode.side_effect = run_episode
+        trainer = _make_trainer(
+            tmp_path,
+            config=MCTSTrainerConfig(
+                epochs=1, seed=0, parallel_episodes=parallel
+            ),
+            runner=runner,
+            train_tasks=tasks,
+        )
+        return trainer._collect(len(tasks), n_simulations=2, base_seed=0)
+
+    def test_parallel_collect_matches_sequential_order(self, tmp_path):
+        sequential = self._collect(tmp_path / "seq", 1)
+        parallel = self._collect(tmp_path / "par", 3)
+        expected = [f"task-{i}" for i in range(4)]
+        assert [e.metadata["task_id"] for e in sequential] == expected
+        assert [e.metadata["task_id"] for e in parallel] == expected
+
+    def test_parallel_collect_propagates_failures(self, tmp_path):
+        tasks = [_make_task(f"task-{i}") for i in range(3)]
+        runner = MagicMock(spec=EpisodeRunner)
+        runner.run_episode.side_effect = RuntimeError("API meltdown")
+        trainer = _make_trainer(
+            tmp_path,
+            config=MCTSTrainerConfig(epochs=1, seed=0, parallel_episodes=3),
+            runner=runner,
+            train_tasks=tasks,
+        )
+        with pytest.raises(RuntimeError, match="API meltdown"):
+            trainer._collect(3, n_simulations=2, base_seed=0)
+
+
 # ---------------------------------------------------------------------------
 # Live-style collection through the real runner (mocked model client)
 # ---------------------------------------------------------------------------

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -472,6 +472,25 @@ class TestBatchScoring:
         results = scorer.score_batch([], [])
         assert results == []
 
+    def test_batch_pool_threads_report_to_active_degradation_counter(self):
+        """Issue #91: the batch pool runs items in a copy of the submitting
+        context, so degradations in worker threads still attribute to the
+        episode's context-local counter."""
+        from bicameral_agent.llm_output import count_degradations
+
+        malformed = MagicMock()
+        malformed.content = "not json at all"
+        malformed.finish_reason = "STOP"
+        mock_client = MagicMock()
+        mock_client.generate.return_value = malformed
+        scorer = TaskScorer(client=mock_client, max_workers=4)
+
+        tasks = [_make_task(task_id=f"t_{i}") for i in range(3)]
+        answers = [f"answer {i}" for i in range(3)]
+        with count_degradations() as counter:
+            scorer.score_batch(tasks, answers)
+        assert counter.counts == {"TaskScorer": 3}
+
 
 # ---------------------------------------------------------------------------
 # TestIntegration (requires GEMINI_API_KEY)


### PR DESCRIPTION
# Run episodes concurrently within a condition

## What

- `--parallel-episodes N` (default 1 = sequential) on `scripts/run_baseline_benchmark.py` and `scripts/train_mcts.py`, threaded to `run_condition` / `run_benchmark` and `MCTSTrainerConfig` / `MCTSTrainer._collect`. LLM calls are I/O-bound stdlib `urllib`, so a bounded `ThreadPoolExecutor` over episode indices is sufficient.
- Per-episode isolation made real under concurrency (details below).
- Results stay in task order; incremental persistence stays crash-safe; per-episode transport containment and the >30% threshold abort keep working.

## Design

### Windowed submission, index-keyed results

`run_condition` keeps at most N episodes in flight, launched in task order, and collects results keyed by task index, so episode lists, metrics, failures, and `_latency_pairs` pairing come back in task order deterministically regardless of completion order. Windowed submission (instead of submitting everything upfront) means a worker can never race past the failure-threshold check — with `parallel_episodes=1` the loop is behaviorally identical to the old sequential one (same call counts, same callback order, same error propagation), which the pre-existing test suite verifies unchanged.

`on_episode` still fires as futures complete (crash-safety), always from the coordinating thread (never concurrently). The benchmark script now keys completed episodes by task index and rewrites the parquet sorted, so the file is always the ordered list of completed-so-far episodes.

Threshold abort: once failures exceed 30%, nothing new is launched (the unstarted tail is never submitted), in-flight episodes settle (completed ones still reach `on_episode`), then `ConditionAbortedError` is raised with the transport error as `__cause__`. Non-transport errors likewise stop launches and re-raise after in-flight episodes settle.

`MCTSTrainer._collect` gets the same treatment via `MCTSTrainerConfig.parallel_episodes`: per-episode seeds stay index-based (`base_seed + 10 + i`), results return in collection order, any failure cancels unstarted episodes and propagates.

### ContextVar-based degradation counter (both nesting directions)

`count_degradations` documented a NON-OVERLAPPING-EPISODES assumption (#82 / PR #85 review): the counter was a `logging.Handler` on a module-level logger, so concurrent episodes would count each other's degradations. It is now a stack of counters in a `ContextVar`; `safe_parse_json` reports to every counter active in the *current context*. Two directions had to keep working:

- **Outward (episodes on the pool):** each episode task is submitted via `contextvars.copy_context().run`, so every episode runs in its own context and its `count_degradations` block is invisible to sibling episodes.
- **Inward (threads an episode spawns):** `ThreadPoolExecutor` worker threads do NOT inherit the submitter's context — they run in the thread's own context, created empty at thread start (and scorer pool threads are created lazily, so even a capture-at-pool-construction scheme would be wrong). The scorer's shared batch machinery (`CachedConcurrentScorer._score_batch_cached`, used by `TaskScorer.score_batch` and `CoherenceJudge`) therefore now captures `contextvars.copy_context()` at submit time, per item, so judge degradations (and episode cost, below) in scorer worker threads still attribute to the submitting episode. The in-episode scoring path (`verifier.score()`) is a single same-thread call and never used the pool, but `score_batch` is public API and must stay attribution-correct — tested explicitly through `TaskScorer.score_batch` with a malformed judge response.

Nested-counter semantics are preserved (an outer counter still sees an inner block's degradations — existing test unchanged). Counter increments are lock-guarded since scorer worker threads may report concurrently.

### Context-local episode cost accumulators

The shared-state audit (below) found one real cross-contamination: `CostTracker`'s *episode-level* accumulators were plain fields — lock-guarded (no data race), but semantically shared: under concurrency one episode's `reset_episode()` would zero another's in-progress accumulation, `get_episode_cost()` would include other episodes' calls, and the per-episode budget would trip on combined spend. The episode accumulator is now a per-tracker `ContextVar` holding a mutable accumulator object: each episode (own context) resets/reads only its own, while threads the episode spawns with a copied context (scorer pool) mutate the same object under the existing lock. Session accumulators and both budgets remain shared, exactly as before; sequential behavior is unchanged (all existing tests pass untouched).

## Shared-state audit (`EpisodeRunner.run_episode` and friends)

Constructed fresh per episode (safe): `ContextQueue`, `ConversationLogger`, `ConsciousLoop`, `SimulatedUser`, `StateEncoder`, `ToolLatencyModel`, all three tools, `CostTrackedClient` wrappers, verifier/`TaskScorer`, controller (via `controller_factory(idx)` / `_make_controller(seed=base_seed + 10 + i)`).

Shared across concurrent episodes:
- `GeminiClient` / `OllamaCloudClient` — documented "no mutable state after `__init__`"; each `generate` is an independent request. Safe.
- `RetryingClientBase` — module-level `random.uniform` / `time.sleep` only; the shared `random` module is thread-safe. Safe.
- `CostTracker` — session side lock-guarded (safe); episode side was cross-contaminating → fixed (above).
- `count_degradations` — cross-contaminating by documented assumption → fixed (above).
- `SimulatedUser` would be safe even if shared (immutable after init) but is per-episode anyway; `TokenEstimator` / `LatencyTracker` are lock-guarded and also per-episode.
- MCTS collection: `PolicyValueNetwork` / `TransitionModel` are shared for inference only (eval mode, no grad, no stochastic layers — read-only forward passes); `MCTSEngine` + numpy RNGs are per-controller, seeded per episode index; `TrainingDataPipeline` holds only immutable config plus stateless encoder/latency models.

## Determinism

N>1 changes nothing about per-episode inputs: submission order = task order, controller seeds are index-derived, each episode's client traffic is independent. Verified: `run_condition` N=1 vs N=3 through the real `EpisodeRunner` with a deterministic content-keyed mock client produces identical episode content, order, turn counts, and per-episode degradation counts; stub-runner tests invert completion order with reversed per-task delays and still get task-order results.

## Tests

- N=3 vs N=1 identical episode set/order/metrics (stub runner with inverted completion order, and real `EpisodeRunner` + deterministic mocked client)
- Degradation counts stay per-episode under concurrency (barrier-forced overlap; real-runner N=3 run; scorer-pool attribution through `TaskScorer.score_batch`)
- Episode-cost isolation per context + copied-context worker attribution to the episode accumulator
- Failure containment at N=3 keeps task order; threshold abort launches nothing past the in-flight window and preserves `__cause__`
- `MCTSTrainer._collect` order preservation and failure propagation at N=3
- `parallel_episodes < 1` rejected (library + both CLIs)

## Test plan

- [x] `uv run --extra dev --extra torch pytest -q` — 1419 passed, 35 skipped
- [x] `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- [x] Live smoke vs Ollama Cloud (`--provider ollama --judge-provider ollama --conditions no_subconscious --tasks-per-condition 3 --max-turns 2 --quiet`, scratch output dirs outside `data/`):
  - `--parallel-episodes 1`: **205s** wall clock
  - `--parallel-episodes 3`: **76s** wall clock (**2.7x** faster)
  - Both runs completed 3/3 episodes with no transport failures; verified the N=3 parquet is in task order (`typical_001, tricky_001, tricky_002`, matching `select_tasks`), per-episode `parse_degradations` clean, and per-episode `episode_cost.call_count` = 5 for every episode (no cross-episode bleed).

Closes #91
