### PR TITLE
Fix live collection path in train_mcts

### DIFF
--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -208,7 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         dataset = ResearchQADataset()
         eval_tasks = select_eval_tasks(dataset, args.eval_tasks)
         held_out = {t.task_id for t in eval_tasks}
-        train_tasks = [t for t in dataset.tasks() if t.task_id not in held_out]
+        train_tasks = [t for t in dataset.tasks if t.task_id not in held_out]
         logger.info(
             "Live mode: %d collection tasks, %d held-out eval tasks",
             len(train_tasks), len(eval_tasks),

--- a/tests/test_train_mcts_script.py
+++ b/tests/test_train_mcts_script.py
@@ -1,0 +1,91 @@
+"""Regression tests for scripts/train_mcts.py's live-collection wiring.
+
+The offline (--episodes-parquet) path never touches task selection, so a
+``dataset.tasks()`` TypeError hid until the first real training launch
+(``ResearchQADataset.tasks`` is a property, unlike the ``eval_tasks()`` /
+``tool_test_tasks()`` methods beside it). These tests drive the live-mode
+branch of ``main()`` without any network by mocking the runner and
+trainer.
+
+The module requires torch (the script constructs the policy/transition
+nets before task selection) and is skipped when unavailable.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402  (imports below the importorskip guard are intentional)
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bicameral_agent.dataset import ResearchQADataset
+
+
+def _load_script():
+    """Import scripts/train_mcts.py (not a package) by path."""
+    path = Path(__file__).resolve().parent.parent / "scripts" / "train_mcts.py"
+    spec = importlib.util.spec_from_file_location("train_mcts", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestDatasetTaskAccess:
+    def test_tasks_is_a_property_returning_all_tasks(self):
+        """Guard the property-vs-method split on ResearchQADataset.
+
+        ``tasks`` is a property (calling it raises ``TypeError: 'list'
+        object is not callable``) while its siblings ``eval_tasks()`` /
+        ``tool_test_tasks()`` are methods — the exact confusion behind
+        the live-path bug.
+        """
+        assert isinstance(ResearchQADataset.tasks, property)
+        dataset = ResearchQADataset()
+        assert dataset.tasks == list(dataset)
+
+
+class TestLiveCollectionPath:
+    def test_main_reaches_trainer_with_disjoint_task_pools(self, tmp_path):
+        """Live mode builds train/eval task pools without network."""
+        script = _load_script()
+
+        cost_tracker = MagicMock()
+        cost_tracker.get_total.return_value = SimpleNamespace(total=0.0, call_count=0)
+
+        with (
+            patch.object(
+                script, "build_runner", return_value=(MagicMock(), cost_tracker)
+            ) as mock_build_runner,
+            patch.object(script, "MCTSTrainer") as MockTrainer,
+        ):
+            rc = script.main(
+                [
+                    "--output-dir", str(tmp_path / "run"),
+                    "--iterations", "0",
+                    "--eval-tasks", "2",
+                    "--policy-hidden-dim", "16",
+                    "--transition-hidden-dim", "16",
+                    "--quiet",
+                ]
+            )
+
+        assert rc == 0
+        assert mock_build_runner.called
+        kwargs = MockTrainer.call_args.kwargs
+        train_tasks = kwargs["train_tasks"]
+        eval_tasks = kwargs["eval_tasks"]
+        assert len(eval_tasks) == 2
+        assert len(train_tasks) > 0
+
+        train_ids = {t.task_id for t in train_tasks}
+        eval_ids = {t.task_id for t in eval_tasks}
+        assert train_ids.isdisjoint(eval_ids)
+        # Collection pool == every dataset task not held out for eval.
+        all_ids = {t.task_id for t in ResearchQADataset()}
+        assert train_ids | eval_ids == all_ids


### PR DESCRIPTION
## Summary

The first real #29 training launch crashed in live mode: `scripts/train_mcts.py` called `dataset.tasks()` when building the collection pool, but `ResearchQADataset.tasks` is a **property** returning a list (unlike the `eval_tasks()` / `tool_test_tasks()` methods beside it) — `TypeError: 'list' object is not callable`. The offline `--episodes-parquet` path never reaches that line, which is why it hid. One-character fix: drop the call parentheses.

## Work performed

- `scripts/train_mcts.py`: `dataset.tasks()` → `dataset.tasks`.
- `tests/test_train_mcts_script.py` (new):
  - No-network regression test that drives `main()`'s live branch (mocked `build_runner` + `MCTSTrainer`) through the task-pool wiring and asserts held-out/collection pools are disjoint and cover the dataset. Verified it fails with the exact `TypeError` at the old line on unfixed code.
  - A guard pinning the property-vs-method split on `ResearchQADataset` (`tasks` is a property; `ds.tasks == list(ds)`) — the confusion class behind the bug.

## Test plan

- [x] Minimal live smoke of the **full live path** (ollama answerer + judge, 1 iteration, 2 episodes, `--parallel-episodes 2`, 10 simulations, 2 eval tasks, max 2 turns, pretrained hidden-64 policy + transition checkpoints): completed end to end in **210.0s**, producing `iteration-000/{policy_value.pt,transition.pt,metrics.json}`, `metrics_history.json`, `store/`, `episodes/iteration-000.parquet`, and a real eval comparison (`eval=0.833` vs `heuristic=0.75`). No other live-only bugs surfaced — the tool output-parsing warnings are pre-existing graceful degradations inside the tools, and the `$0.0000 across 38 calls` session cost is by design (Ollama Cloud tags are flat-rate in `MODEL_PRICING`).
- [x] `uv run --extra dev --extra torch pytest -q` — 1425 passed, 35 skipped
- [x] `uv run --extra dev ruff check src/ tests/ scripts/` — clean

Refs #29