### PR TITLE
Expose episode concurrency in config and the Ink UI

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -35,7 +35,11 @@ from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_
 from bicameral_agent.eval_report import EvalReport
 from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
-from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+from bicameral_agent.runner_setup import (
+    add_model_args,
+    resolve_parallel_episodes,
+    resolve_runner_clients,
+)
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
 
@@ -115,11 +119,12 @@ def main(argv: list[str] | None = None) -> int:
                              f"(of: {', '.join(CONDITION_NAMES)}; default all). "
                              "Lets an aborted run be resumed per-condition.")
     parser.add_argument("--tasks-per-condition", type=int, default=50)
-    parser.add_argument("--parallel-episodes", type=int, default=1,
+    parser.add_argument("--parallel-episodes", type=int, default=None,
                         help="Episodes run concurrently within a condition "
-                             "(bounded thread pool; 1 = sequential). Match the "
-                             "provider's concurrent-request allowance "
-                             "(Ollama Cloud: 3).")
+                             "(bounded thread pool; 1 = sequential). Set this "
+                             "to the provider plan's concurrent-request "
+                             "allowance. Defaults to the config's [run] "
+                             "parallel_episodes (else 1).")
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument("--random-seed", type=int, default=42)
     parser.add_argument("--random-probability", type=float, default=0.2)
@@ -130,7 +135,7 @@ def main(argv: list[str] | None = None) -> int:
         selected_conditions = parse_conditions(args.conditions)
     except ValueError as exc:
         parser.error(str(exc))
-    if args.parallel_episodes < 1:
+    if args.parallel_episodes is not None and args.parallel_episodes < 1:
         parser.error(f"--parallel-episodes must be >= 1, got {args.parallel_episodes}")
 
     logging.basicConfig(
@@ -144,6 +149,7 @@ def main(argv: list[str] | None = None) -> int:
     hyper = (
         HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
     ).with_env_overrides()
+    parallel_episodes = resolve_parallel_episodes(args, hyper)
 
     eval_dataset = build_dataset(args.dataset)
     metric = resolve_metric(eval_dataset, args.metric)
@@ -191,7 +197,7 @@ def main(argv: list[str] | None = None) -> int:
 
     result = run_benchmark(
         client, tasks, conditions, runner=runner, on_episode=persist_episode,
-        parallel_episodes=args.parallel_episodes,
+        parallel_episodes=parallel_episodes,
     )
 
     report_text = format_report(result)

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -39,7 +39,11 @@ from bicameral_agent.dataset import (
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.mcts_trainer import MCTSTrainer, MCTSTrainerConfig
 from bicameral_agent.policy_value_net import PolicyValueNetwork
-from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+from bicameral_agent.runner_setup import (
+    add_model_args,
+    resolve_parallel_episodes,
+    resolve_runner_clients,
+)
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_from_parquet
 from bicameral_agent.training_pipeline import STATE_DIM, TrainingDataPipeline
@@ -127,11 +131,12 @@ def main(argv: list[str] | None = None) -> int:
                         help="Verification metric used to score episodes.")
     parser.add_argument("--iterations", type=int, default=10)
     parser.add_argument("--episodes-per-iteration", type=int, default=50)
-    parser.add_argument("--parallel-episodes", type=int, default=1,
+    parser.add_argument("--parallel-episodes", type=int, default=None,
                         help="Collection episodes run concurrently (bounded "
-                             "thread pool; 1 = sequential). Match the "
-                             "provider's concurrent-request allowance "
-                             "(Ollama Cloud: 3).")
+                             "thread pool; 1 = sequential). Set this to the "
+                             "provider plan's concurrent-request allowance. "
+                             "Defaults to the config's [run] "
+                             "parallel_episodes (else 1).")
     parser.add_argument("--simulations", type=int, default=50,
                         help="MCTS budget per decision point.")
     parser.add_argument("--eval-tasks", type=int, default=20,
@@ -172,8 +177,12 @@ def main(argv: list[str] | None = None) -> int:
 
     policy, transition = load_models(args)
 
-    if args.parallel_episodes < 1:
+    if args.parallel_episodes is not None and args.parallel_episodes < 1:
         parser.error(f"--parallel-episodes must be >= 1, got {args.parallel_episodes}")
+
+    hyper = (
+        HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
+    ).with_env_overrides()
 
     trainer_config = MCTSTrainerConfig(
         collect_with_search=not args.no_search,
@@ -181,7 +190,7 @@ def main(argv: list[str] | None = None) -> int:
         retrain_transition=args.retrain_transition,
         max_turns=args.max_turns,
         seed=args.seed,
-        parallel_episodes=args.parallel_episodes,
+        parallel_episodes=resolve_parallel_episodes(args, hyper),
     )
     pipeline = TrainingDataPipeline(max_turns=args.max_turns)
 
@@ -190,9 +199,6 @@ def main(argv: list[str] | None = None) -> int:
     cost_tracker = None
     train_tasks: list[ResearchQATask] = []
     eval_tasks: list[ResearchQATask] = []
-    hyper = (
-        HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
-    ).with_env_overrides()
 
     if offline:
         offline_episodes = []

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -205,6 +205,19 @@ class EvaluationConfig(BaseModel):
     random_seed: int = 42
 
 
+class RunConfig(BaseModel):
+    """Episode-run execution settings shared by the runner scripts."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    parallel_episodes: int = Field(default=1, ge=1)
+    """Episodes run concurrently (1 = sequential).
+
+    Should match the provider's concurrent-request allowance; overridden
+    by the scripts' ``--parallel-episodes`` flag (CLI > config > 1).
+    """
+
+
 class HyperConfig(BaseModel):
     """Root hyperparameter configuration.
 
@@ -233,6 +246,7 @@ class HyperConfig(BaseModel):
     mcts: MCTSConfig = Field(default_factory=MCTSConfig)
     evaluation: EvaluationConfig = Field(default_factory=EvaluationConfig)
     cost: CostConfig = Field(default_factory=CostConfig)
+    run: RunConfig = Field(default_factory=RunConfig)
 
     @classmethod
     def from_toml(cls, path: str | Path) -> HyperConfig:

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -69,3 +69,8 @@ random_seed = 42
 [cost]
 # session_budget = 1.00   # max dollars per session (unset = unlimited)
 # episode_budget = 0.25   # max dollars per episode (unset = unlimited)
+
+[run]
+parallel_episodes = 1    # episodes run concurrently (1 = sequential); match the
+                         # provider's concurrent-request allowance
+

--- a/src/bicameral_agent/runner_setup.py
+++ b/src/bicameral_agent/runner_setup.py
@@ -52,6 +52,19 @@ def add_model_args(parser: argparse.ArgumentParser) -> None:
                         help="Optional per-episode cost ceiling in USD.")
 
 
+def resolve_parallel_episodes(args: argparse.Namespace, hyper: HyperConfig) -> int:
+    """Resolve episode concurrency: CLI flag > config ``[run]`` > default 1.
+
+    The ``--parallel-episodes`` flag is registered per-script (the help
+    text differs) with ``default=None`` so an unset flag is distinguishable
+    from an explicit ``1`` and falls through to the config's
+    ``run.parallel_episodes`` (validated >= 1 at config load).
+    """
+    if args.parallel_episodes is not None:
+        return args.parallel_episodes
+    return hyper.run.parallel_episodes
+
+
 def resolve_runner_clients(
     args: argparse.Namespace, hyper: HyperConfig
 ) -> tuple[ModelClient, ModelClient, dict[str, dict[str, str]]]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from bicameral_agent.config import (
     HyperConfig,
     ModelConfig,
     QueueConfig,
+    RunConfig,
     ToolBudgetConfig,
     ToolsConfig,
     TrainingConfig,
@@ -78,6 +79,10 @@ class TestDefaults:
         cfg = HyperConfig()
         assert cfg.evaluation.num_tasks == 10
         assert cfg.evaluation.random_seed == 42
+
+    def test_run_defaults(self):
+        assert HyperConfig().run.parallel_episodes == 1
+        assert HyperConfig.from_defaults().run.parallel_episodes == 1
 
     def test_from_defaults_matches_constructor(self):
         from_defaults = HyperConfig.from_defaults()
@@ -264,6 +269,14 @@ class TestValidation:
     def test_gamma_negative(self):
         with pytest.raises(ValidationError, match="gamma"):
             TrainingConfig(gamma=-0.1)
+
+    def test_parallel_episodes_zero_rejected(self):
+        with pytest.raises(ValidationError, match="parallel_episodes"):
+            RunConfig(parallel_episodes=0)
+
+    def test_run_unknown_field_rejected(self):
+        with pytest.raises(ValidationError, match="parallel_episode"):
+            RunConfig(parallel_episode=2)
 
 
 class TestFrozen:

--- a/tests/test_runner_setup.py
+++ b/tests/test_runner_setup.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 import pytest
 
 from bicameral_agent.config import HyperConfig
-from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+from bicameral_agent.runner_setup import (
+    add_model_args,
+    resolve_parallel_episodes,
+    resolve_runner_clients,
+)
 
 
 @dataclass
@@ -111,3 +115,26 @@ class TestResolveRunnerClients:
         assert judge_client is not client
         assert mock_build.call_count == 2
         assert provenance["measurement"] == {"provider": "gemini", "model": "tag-b"}
+
+
+class TestResolveParallelEpisodes:
+    """CLI flag > config [run].parallel_episodes > default 1."""
+
+    def test_defaults_to_one(self, hyper):
+        args = argparse.Namespace(parallel_episodes=None)
+        assert resolve_parallel_episodes(args, hyper) == 1
+
+    def test_config_used_when_flag_unset(self):
+        args = argparse.Namespace(parallel_episodes=None)
+        hyper = HyperConfig.model_validate({"run": {"parallel_episodes": 5}})
+        assert resolve_parallel_episodes(args, hyper) == 5
+
+    def test_cli_overrides_config(self):
+        args = argparse.Namespace(parallel_episodes=3)
+        hyper = HyperConfig.model_validate({"run": {"parallel_episodes": 5}})
+        assert resolve_parallel_episodes(args, hyper) == 3
+
+    def test_explicit_one_overrides_config(self):
+        args = argparse.Namespace(parallel_episodes=1)
+        hyper = HyperConfig.model_validate({"run": {"parallel_episodes": 5}})
+        assert resolve_parallel_episodes(args, hyper) == 1

--- a/ui/README.md
+++ b/ui/README.md
@@ -29,7 +29,10 @@ runner and for `data/` discovery.
 ## Screens
 
 - **New experiment** — step-through form: provider (gemini/ollama), model,
-  tasks-per-condition, max turns, per-episode budget, output dir. With
+  tasks-per-condition, max turns, parallel episodes, per-episode budget,
+  output dir. Parallel episodes (default 1) maps to the runner's
+  `--parallel-episodes` and should match the provider plan's
+  concurrent-request allowance. With
   provider=ollama the model picker is populated live from
   `GET https://ollama.com/api/tags` (type to filter); if the request fails it
   falls back to free-text entry, and `tab` switches to free text at any time.

--- a/ui/src/core/command.ts
+++ b/ui/src/core/command.ts
@@ -15,6 +15,9 @@ export interface ExperimentConfig {
   model: string;
   tasksPerCondition: number;
   maxTurns: number;
+  /** Episodes run concurrently (1 = sequential); should match the
+   * provider's concurrent-request allowance. */
+  parallelEpisodes: number;
   /** Per-episode USD ceiling; null = runner default (no ceiling). */
   episodeBudget: number | null;
   /** Output dir for run artifacts, relative to the repo root. */
@@ -39,6 +42,7 @@ const FLAG_SPECS: FlagSpec[] = [
   { flag: '--model', value: (c) => c.model || null },
   { flag: '--tasks-per-condition', value: (c) => c.tasksPerCondition },
   { flag: '--max-turns', value: (c) => c.maxTurns },
+  { flag: '--parallel-episodes', value: (c) => c.parallelEpisodes },
   { flag: '--episode-budget', value: (c) => c.episodeBudget },
   { flag: '--config', value: (c) => c.configPath },
 ];

--- a/ui/src/screens/Configure.tsx
+++ b/ui/src/screens/Configure.tsx
@@ -18,6 +18,7 @@ type Step =
   | 'model'
   | 'tasks'
   | 'maxTurns'
+  | 'parallel'
   | 'budget'
   | 'outputDir'
   | 'confirm';
@@ -27,6 +28,7 @@ const STEP_ORDER: Step[] = [
   'model',
   'tasks',
   'maxTurns',
+  'parallel',
   'budget',
   'outputDir',
   'confirm',
@@ -57,6 +59,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
   const [catalog, setCatalog] = useState<CatalogState>({ kind: 'loading' });
   const [tasks, setTasks] = useState('5');
   const [maxTurns, setMaxTurns] = useState('10');
+  const [parallel, setParallel] = useState('1');
   const [budget, setBudget] = useState('');
   const [outputDir, setOutputDir] = useState(defaultOutputDir());
 
@@ -91,6 +94,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
     model,
     tasksPerCondition: Number(tasks),
     maxTurns: Number(maxTurns),
+    parallelEpisodes: Number(parallel),
     episodeBudget: budget === '' ? null : Number(budget),
     outputDir,
     configPath: null,
@@ -126,8 +130,12 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
     setStep('tasks');
   };
 
+  // Each Field is keyed by its step: consecutive steps render <Field> at the
+  // same tree position, and without a key React reuses the instance, carrying
+  // the previous step's text into the next one.
   const modelField = (
     <Field
+      key="model"
       label="Model tag"
       initialValue={model}
       hint={
@@ -209,6 +217,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
     case 'tasks':
       body = (
         <Field
+          key="tasks"
           label="Tasks per condition"
           initialValue={tasks}
           validate={positiveInt}
@@ -223,6 +232,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
     case 'maxTurns':
       body = (
         <Field
+          key="maxTurns"
           label="Max turns per episode"
           initialValue={maxTurns}
           validate={positiveInt}
@@ -234,9 +244,26 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
         />
       );
       break;
+    case 'parallel':
+      body = (
+        <Field
+          key="parallel"
+          label="Parallel episodes"
+          initialValue={parallel}
+          hint="Match the provider's concurrent-request allowance; 1 = sequential"
+          validate={positiveInt}
+          onSubmit={(v) => {
+            setParallel(v);
+            next();
+          }}
+          onCancel={back}
+        />
+      );
+      break;
     case 'budget':
       body = (
         <Field
+          key="budget"
           label="Per-episode budget (USD)"
           initialValue={budget}
           hint="Empty = no per-episode ceiling"
@@ -256,6 +283,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
     case 'outputDir':
       body = (
         <Field
+          key="outputDir"
           label="Output dir (relative to repo root)"
           initialValue={outputDir}
           validate={(v) => (v.trim() === '' ? 'output dir is required' : null)}
@@ -274,7 +302,7 @@ export default function Configure({ pricingKeys, onLaunch, onCancel }: Props) {
           <Text bold>Ready to launch</Text>
           <Text>
             {'  '}provider={provider} model={model} tasks={tasks} max-turns=
-            {maxTurns} budget={budget || 'none'}
+            {maxTurns} parallel={parallel} budget={budget || 'none'}
           </Text>
           <Text>
             {'  '}output: {outputDir}

--- a/ui/tests/command.test.ts
+++ b/ui/tests/command.test.ts
@@ -11,6 +11,7 @@ const base: ExperimentConfig = {
   model: 'gemma4:31b',
   tasksPerCondition: 2,
   maxTurns: 10,
+  parallelEpisodes: 3,
   episodeBudget: 0.5,
   outputDir: 'data/run-x',
   configPath: null,
@@ -32,9 +33,18 @@ describe('buildRunnerArgs', () => {
       '2',
       '--max-turns',
       '10',
+      '--parallel-episodes',
+      '3',
       '--episode-budget',
       '0.5',
     ]);
+  });
+
+  it('always passes --parallel-episodes, including the sequential default', () => {
+    const args = buildRunnerArgs({ ...base, parallelEpisodes: 1 });
+    const i = args.indexOf('--parallel-episodes');
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe('1');
   });
 
   it('passes the model tag verbatim (no -cloud rewriting)', () => {

--- a/ui/tests/configure.test.tsx
+++ b/ui/tests/configure.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import Configure from '../src/screens/Configure';
+import type { ExperimentConfig } from '../src/core/command';
+
+// With no pricing keys the gemini model step is a free-text field, so the
+// wizard can be driven end-to-end without any catalog fetch.
+function renderWizard(onLaunch: (c: ExperimentConfig) => void = () => {}) {
+  return render(
+    <Configure pricingKeys={[]} onLaunch={onLaunch} onCancel={() => {}} />,
+  );
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 20));
+
+/** Drive the wizard up to (but not past) the parallel-episodes step. */
+async function stepToParallel(stdin: { write: (s: string) => void }) {
+  stdin.write('\r'); // provider: gemini
+  await tick();
+  stdin.write('m'); // model tag (free text)
+  await tick();
+  stdin.write('\r');
+  await tick();
+  stdin.write('\r'); // tasks: default 5
+  await tick();
+  stdin.write('\r'); // max turns: default 10
+  await tick();
+}
+
+describe('Configure wizard: parallel episodes', () => {
+  it('shows the step with default 1 and a provider-concurrency hint', async () => {
+    const { lastFrame, stdin, unmount } = renderWizard();
+    await stepToParallel(stdin);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Parallel episodes');
+    expect(frame).toContain('1');
+    expect(frame).toContain("provider's concurrent-request allowance");
+    unmount();
+  });
+
+  it('threads the value into the confirm summary and launch config', async () => {
+    const launches: ExperimentConfig[] = [];
+    const { lastFrame, stdin, unmount } = renderWizard((c) => {
+      launches.push(c);
+    });
+    await stepToParallel(stdin);
+    stdin.write('0'); // append to default "1" → 10
+    await tick();
+    stdin.write('\r');
+    await tick();
+    stdin.write('\r'); // budget: none
+    await tick();
+    stdin.write('\r'); // output dir: default
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('parallel=10');
+    expect(frame).toContain('--parallel-episodes 10');
+    stdin.write('\r'); // launch
+    await tick();
+    expect(launches).toHaveLength(1);
+    expect(launches[0].parallelEpisodes).toBe(10);
+    unmount();
+  });
+
+  it('rejects zero', async () => {
+    const { lastFrame, stdin, unmount } = renderWizard();
+    await stepToParallel(stdin);
+    stdin.write('\x7f'); // backspace the default "1"
+    await tick();
+    stdin.write('0');
+    await tick();
+    stdin.write('\r');
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Parallel episodes');
+    expect(frame).toContain('enter a positive whole number');
+    unmount();
+  });
+});

--- a/ui/tests/parquet.test.ts
+++ b/ui/tests/parquet.test.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parquetRowCount } from '../src/core/parquet';
 
-// A real artifact committed with the historical baseline run.
+// A real artifact committed with the historical baseline run (the 2026-07
+// re-run holds 45 episodes).
 const BASELINE_PARQUET = path.resolve(
   __dirname,
   '../../data/baseline/no_subconscious.parquet',
@@ -13,7 +14,7 @@ describe('parquetRowCount', () => {
   it.skipIf(!fs.existsSync(BASELINE_PARQUET))(
     'reads the row count of a real runner artifact',
     async () => {
-      expect(await parquetRowCount(BASELINE_PARQUET)).toBe(50);
+      expect(await parquetRowCount(BASELINE_PARQUET)).toBe(45);
     },
   );
 


### PR DESCRIPTION
## Summary

`--parallel-episodes` (#91) was CLI-only. This gives episode concurrency first-class surfaces per #93, with precedence **CLI flag > config > default 1**.

### Config surface
- New `[run] parallel_episodes` section in `HyperConfig` + `data/default_config.toml` (frozen, `extra="forbid"`, validated `>= 1`); `BICAMERAL_RUN__PARALLEL_EPISODES` env override works via the existing mechanism.
- Both scripts' `--parallel-episodes` argparse default is now `None` so an unset flag is distinguishable from an explicit `1`; resolution goes through a shared `runner_setup.resolve_parallel_episodes` helper so `run_baseline_benchmark.py` and `train_mcts.py` cannot drift.

### Ink UI
- New "Parallel episodes" step in the New Experiment wizard (numeric, default 1, hint to match the provider's concurrent-request allowance), threaded through the data-driven flag table in `core/command.ts` and shown in the confirm summary.
- Fix surfaced while testing: consecutive wizard steps render `<Field>` at the same tree position, so React reused the component instance and carried the previous step's text into the next step (the new step inherited "10" from max turns instead of defaulting to 1). Each Field is now keyed by its step.

### Docs
- One line in `ui/README.md`; both scripts' `--help` note the setting maps to the provider plan's concurrent-request allowance.

### Deviations
- `ui/tests/parquet.test.ts` expected 50 rows from the committed baseline artifact, but the 2026-07 re-run (bcfb525) holds 45 — a pre-existing failure on main that broke the `npm test` gate. Updated the expectation to 45.

## Testing
- `uv run --extra dev --extra torch pytest -q` — 1430 passed, 35 skipped
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean
- `cd ui && npm test` — 41 passed (incl. new wizard + command-assembly tests); `npx tsc --noEmit` — clean
- Smoke: config default resolves to 1, `BICAMERAL_RUN__PARALLEL_EPISODES=7` override applies, `--parallel-episodes 0` still rejected at parse time

Closes #93