### PR TITLE
Add --parallel-episodes to the comparative evaluation

### DIFF
--- a/scripts/run_comparative_eval.py
+++ b/scripts/run_comparative_eval.py
@@ -44,7 +44,11 @@ from bicameral_agent.comparative_eval import (
 from bicameral_agent.config import HyperConfig
 from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
-from bicameral_agent.runner_setup import add_model_args, resolve_runner_clients
+from bicameral_agent.runner_setup import (
+    add_model_args,
+    resolve_parallel_episodes,
+    resolve_runner_clients,
+)
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
 
@@ -66,6 +70,12 @@ def main(argv: list[str] | None = None) -> int:
                         help="Task count (split 50/25/25 across "
                              "typical/hard/tricky) or an explicit mix, e.g. "
                              "'typical=50,hard=25,tricky=25'.")
+    parser.add_argument("--parallel-episodes", type=int, default=None,
+                        help="Episodes run concurrently within a condition "
+                             "(bounded thread pool; 1 = sequential). Set this "
+                             "to the provider plan's concurrent-request "
+                             "allowance. Defaults to the config's [run] "
+                             "parallel_episodes (else 1).")
     parser.add_argument("--policy-checkpoint", required=True,
                         help="PolicyValueNetwork checkpoint (.pt) for the "
                              "learned conditions.")
@@ -90,6 +100,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)
 
+    if args.parallel_episodes is not None and args.parallel_episodes < 1:
+        parser.error(f"--parallel-episodes must be >= 1, got {args.parallel_episodes}")
+
     logging.basicConfig(
         level=logging.WARNING if args.quiet else logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
@@ -101,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
     hyper = (
         HyperConfig.from_toml(args.config) if args.config else HyperConfig.from_defaults()
     ).with_env_overrides()
+    parallel_episodes = resolve_parallel_episodes(args, hyper)
 
     eval_dataset = build_dataset(args.dataset)
     metric = resolve_metric(eval_dataset, args.metric)
@@ -151,18 +165,24 @@ def main(argv: list[str] | None = None) -> int:
 
     # Persist episodes incrementally: rewrite the condition's parquet after
     # every completed episode so a late crash keeps all prior results.
-    completed: dict[str, list[Episode]] = {}
+    # Episodes are keyed by task index and written sorted, so the file stays
+    # in task order even when --parallel-episodes completes out of order
+    # (run_condition serializes these callbacks on its coordinating thread).
+    completed: dict[str, dict[int, Episode]] = {}
 
-    def persist_episode(condition: str, _idx: int, episode: Episode) -> None:
-        completed.setdefault(condition, []).append(episode)
+    def persist_episode(condition: str, idx: int, episode: Episode) -> None:
+        by_index = completed.setdefault(condition, {})
+        by_index[idx] = episode
         episodes_to_parquet(
-            completed[condition], str(output_dir / f"{condition}.parquet")
+            [by_index[i] for i in sorted(by_index)],
+            str(output_dir / f"{condition}.parquet"),
         )
 
     evaluator = ComparativeEvaluator(
         runner,
         on_episode=persist_episode,
         failure_threshold=args.failure_threshold,
+        parallel_episodes=parallel_episodes,
     )
     result = evaluator.run(tasks, conditions)
 

--- a/src/bicameral_agent/comparative_eval.py
+++ b/src/bicameral_agent/comparative_eval.py
@@ -374,10 +374,12 @@ class ComparativeEvaluator:
         *,
         on_episode: EpisodeCallback | None = None,
         failure_threshold: float = FAILURE_THRESHOLD,
+        parallel_episodes: int = 1,
     ) -> None:
         self._runner = runner
         self._on_episode = on_episode
         self._failure_threshold = failure_threshold
+        self._parallel_episodes = parallel_episodes
 
     def run(
         self,
@@ -388,9 +390,14 @@ class ComparativeEvaluator:
 
         ``conditions`` maps condition name to a per-task controller
         factory (called with the task index). Conditions run in dict
-        order; within a condition, tasks run in list order — the same
+        order; within a condition, tasks launch in list order — the same
         list for every condition, which is what makes the comparison
-        paired. Per-episode transport failures are contained by
+        paired. ``parallel_episodes`` bounds within-condition episode
+        concurrency (issue #91); :func:`run_condition` keys results by
+        task index and returns them in task order regardless of
+        completion order, so the pairing invariant (``metrics[c][i]``
+        belongs to ``completed_indices(c)[i]``) holds under concurrency.
+        Per-episode transport failures are contained by
         :func:`~bicameral_agent.baseline_benchmark.run_condition` (which
         raises ``ConditionAbortedError`` past ``failure_threshold``) and
         recorded on the result.
@@ -407,6 +414,7 @@ class ComparativeEvaluator:
                 condition=condition,
                 on_episode=self._on_episode,
                 failure_threshold=self._failure_threshold,
+                parallel_episodes=self._parallel_episodes,
             )
             result.episodes[condition] = episodes
             result.metrics[condition] = metrics

--- a/tests/test_comparative_eval.py
+++ b/tests/test_comparative_eval.py
@@ -7,8 +7,11 @@ skipped when it is unavailable.
 
 from __future__ import annotations
 
+import importlib.util
 import json
-from unittest.mock import MagicMock
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -273,6 +276,86 @@ class TestComparativeEvaluator:
             {"no_subconscious": lambda _idx: NoSubconsciousController()},
         )
         assert calls == [("no_subconscious", 0, "t1"), ("no_subconscious", 1, "t2")]
+
+
+class _DelayedRunner:
+    """Thread-safe EpisodeRunner stand-in with reversed per-task delays.
+
+    Later tasks finish sooner, so with ``parallel_episodes > 1`` completion
+    order inverts task order; episode content depends only on the task, so
+    a parallel run must collect the exact same episodes as a sequential one.
+    """
+
+    def __init__(self, n_tasks: int, delay_step_s: float = 0.01) -> None:
+        self._n_tasks = n_tasks
+        self._delay_step_s = delay_step_s
+
+    def run_episode(self, task, controller):
+        idx = int(task.task_id[1:])
+        time.sleep((self._n_tasks - idx) * self._delay_step_s)
+        return _episode(quality_score=0.1 * (idx + 1), task_id=task.task_id)
+
+
+class TestParallelEpisodes:
+    """Issue #91 concurrency, reused for the comparative harness.
+
+    run_condition keys results by task index and returns them in task
+    order regardless of completion order, so the paired design needs no
+    extra work here — asserted by the report-identity test below.
+    """
+
+    def _run(self, parallel: int) -> ComparativeResult:
+        tasks = [
+            _task("t0", TaskDifficulty.TYPICAL),
+            _task("t1", TaskDifficulty.TYPICAL),
+            _task("t2", TaskDifficulty.HARD),
+            _task("t3", TaskDifficulty.TRICKY),
+        ]
+        conditions = {
+            "no_subconscious": lambda _idx: NoSubconsciousController(),
+            "random": lambda idx: RandomController(seed=idx),
+        }
+        evaluator = ComparativeEvaluator(
+            _DelayedRunner(len(tasks)), parallel_episodes=parallel
+        )
+        return evaluator.run(tasks, conditions)
+
+    def test_parallel_report_identical_to_sequential(self):
+        seq = _report(self._run(1))
+        par = _report(self._run(3))
+        assert par.to_json() == seq.to_json()
+        assert par.to_markdown() == seq.to_markdown()
+
+    def test_parallel_episodes_stay_in_task_order(self):
+        result = self._run(3)
+        for condition in ("no_subconscious", "random"):
+            assert [
+                e.metadata["task_id"] for e in result.episodes[condition]
+            ] == result.task_ids
+
+    def test_parallel_episodes_forwarded_to_run_condition(self):
+        with patch(
+            "bicameral_agent.comparative_eval.run_condition",
+            return_value=([], [], []),
+        ) as mock_run:
+            ComparativeEvaluator(
+                MagicMock(spec=EpisodeRunner), parallel_episodes=4
+            ).run(
+                [_task("t0")],
+                {"no_subconscious": lambda _idx: NoSubconsciousController()},
+            )
+        assert mock_run.call_args.kwargs["parallel_episodes"] == 4
+
+    def test_default_is_sequential(self):
+        with patch(
+            "bicameral_agent.comparative_eval.run_condition",
+            return_value=([], [], []),
+        ) as mock_run:
+            ComparativeEvaluator(MagicMock(spec=EpisodeRunner)).run(
+                [_task("t0")],
+                {"no_subconscious": lambda _idx: NoSubconsciousController()},
+            )
+        assert mock_run.call_args.kwargs["parallel_episodes"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -654,3 +737,87 @@ class TestTaskSelection:
     def test_select_raises_on_shortfall(self):
         with pytest.raises(ValueError, match="hard: want 5, have 2"):
             select_tasks(self._dataset(), {TaskDifficulty.HARD: 5})
+
+
+# ---------------------------------------------------------------------------
+# Script wiring: --parallel-episodes
+# ---------------------------------------------------------------------------
+
+
+def _load_comparative_script():
+    """Import scripts/run_comparative_eval.py (not a package) by path."""
+    path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "run_comparative_eval.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_comparative_eval", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestScriptParallelEpisodes:
+    """--parallel-episodes resolves CLI > config [run] > 1 and reaches
+    ComparativeEvaluator (issue #91 wiring for the comparative script)."""
+
+    def _evaluator_kwargs(self, tmp_path, extra_args=(), config_toml=None):
+        script = _load_comparative_script()
+        argv = [
+            "--output-dir", str(tmp_path / "out"),
+            "--tasks", "typical=1",
+            "--policy-checkpoint", "policy.pt",
+            "--transition-checkpoint", "transition.pt",
+            "--quiet",
+            *extra_args,
+        ]
+        if config_toml is not None:
+            config_path = tmp_path / "config.toml"
+            config_path.write_text(config_toml)
+            argv += ["--config", str(config_path)]
+        report = MagicMock()
+        report.to_json.return_value = "{}"
+        report.to_markdown.return_value = "md"
+        provenance = {"answerer": {}, "measurement": {}}
+        with (
+            patch.object(script, "learned_condition_factories", return_value={}),
+            patch.object(
+                script,
+                "resolve_runner_clients",
+                return_value=(MagicMock(), MagicMock(), provenance),
+            ),
+            patch.object(script, "EpisodeRunner"),
+            patch.object(script, "ComparativeEvaluator") as mock_evaluator,
+            patch.object(script, "build_report", return_value=report),
+        ):
+            assert script.main(argv) == 0
+        return mock_evaluator.call_args.kwargs
+
+    def test_flag_wins_over_config(self, tmp_path):
+        kwargs = self._evaluator_kwargs(
+            tmp_path,
+            extra_args=("--parallel-episodes", "3"),
+            config_toml="[run]\nparallel_episodes = 5\n",
+        )
+        assert kwargs["parallel_episodes"] == 3
+
+    def test_config_used_when_flag_unset(self, tmp_path):
+        kwargs = self._evaluator_kwargs(
+            tmp_path, config_toml="[run]\nparallel_episodes = 5\n"
+        )
+        assert kwargs["parallel_episodes"] == 5
+
+    def test_default_is_one(self, tmp_path):
+        kwargs = self._evaluator_kwargs(tmp_path)
+        assert kwargs["parallel_episodes"] == 1
+
+    def test_rejects_non_positive(self, tmp_path):
+        script = _load_comparative_script()
+        with pytest.raises(SystemExit):
+            script.main(
+                [
+                    "--output-dir", str(tmp_path / "out"),
+                    "--tasks", "typical=1",
+                    "--policy-checkpoint", "policy.pt",
+                    "--transition-checkpoint", "transition.pt",
+                    "--parallel-episodes", "0",
+                ]
+            )


### PR DESCRIPTION
## Summary

`scripts/run_comparative_eval.py` / `ComparativeEvaluator` never received the bounded episode concurrency #91 added to `run_baseline_benchmark.py` and `train_mcts.py`. Since `baseline_benchmark.run_condition` already accepts `parallel_episodes`, this is pure threading of the value:

- `ComparativeEvaluator` takes a `parallel_episodes` constructor kwarg (same pattern as `failure_threshold`) and forwards it to `run_condition`.
- The script gains `--parallel-episodes` with the shared precedence (CLI > config `[run].parallel_episodes` > 1, via `runner_setup.resolve_parallel_episodes`) and the same provider-concurrency guidance in `--help` as the sibling scripts, plus the `>= 1` validation.
- Incremental parquet persistence in the script now keys episodes by task index and writes sorted (mirroring the baseline script), so per-condition files stay in task order when episodes complete out of order.

## Why no extra pairing work is needed

`run_condition` keys results by task index and returns episode/metric/failure lists in task order regardless of completion order (#91). The comparative pairing logic (`completed_indices`, `paired_metrics`, difficulty breakdown) consumes those task-indexed lists, so ordering/pairing safety is inherited unchanged — asserted by a test that an N=3 run (with reversed per-task delays so completion order inverts task order) produces byte-identical JSON and markdown reports to N=1.

## Tests

- N=3 vs N=1 report identity (JSON + markdown) through `ComparativeEvaluator`.
- Episodes stay in task order under concurrency; `parallel_episodes` forwarded to `run_condition`; default stays sequential.
- Script wiring: flag > config > default precedence reaches `ComparativeEvaluator`; `--parallel-episodes 0` rejected.

## UI

No Ink UI change: `ui/src/core/command.ts` only drives `scripts/run_baseline_benchmark.py` — there is no comparative-eval screen to update.

## Gates

- `uv run --extra dev --extra torch pytest -q` — 1440 passed, 35 skipped
- `uv run --extra dev ruff check src/ tests/ scripts/` — clean

Refs #30, #91