### PR TITLE
MVP success criteria validation (#31)

### DIFF
--- a/data/mvp_validation.json
+++ b/data/mvp_validation.json
@@ -1,0 +1,164 @@
+{
+  "issue": 31,
+  "determinations": {
+    "criterion_1": "FAIL",
+    "criterion_2": "FAIL",
+    "criterion_3": "PASS",
+    "criterion_4": "PASS",
+    "criterion_5": "UNRESOLVABLE",
+    "criterion_6": "UNEVALUATED"
+  },
+  "criteria": {
+    "criterion_1": {
+      "name": "Learned policy outperforms random by >= 15% on task quality",
+      "determination": "FAIL",
+      "threshold_relative_pct": 15.0,
+      "learned_condition": "learned_no_search",
+      "baseline_condition": "random",
+      "learned_mean": 0.6475,
+      "learned_ci": [
+        0.6076934353626434,
+        0.6873065646373565
+      ],
+      "baseline_mean": 0.6183333333333334,
+      "baseline_ci": [
+        0.5815317920920217,
+        0.6551348745746451
+      ],
+      "absolute_difference": 0.029166666666666563,
+      "difference_ci95": [
+        -0.02472217697748897,
+        0.08305551031082209
+      ],
+      "relative_improvement_pct": 4.716981132075454,
+      "welch_p_value": 0.28701776229076914,
+      "threshold_met": false,
+      "significant_at_95": false,
+      "n_per_condition": [
+        100,
+        100
+      ]
+    },
+    "criterion_2": {
+      "name": "Learned policy outperforms heuristic by >= 8% on task quality",
+      "determination": "FAIL",
+      "threshold_relative_pct": 8.0,
+      "learned_condition": "learned_no_search",
+      "baseline_condition": "heuristic",
+      "learned_mean": 0.6475,
+      "learned_ci": [
+        0.6076934353626434,
+        0.6873065646373565
+      ],
+      "baseline_mean": 0.6225,
+      "baseline_ci": [
+        0.585379006295234,
+        0.6596209937047661
+      ],
+      "absolute_difference": 0.02499999999999991,
+      "difference_ci95": [
+        -0.02910162231604603,
+        0.07910162231604585
+      ],
+      "relative_improvement_pct": 4.0160642570280976,
+      "welch_p_value": 0.3631907105359964,
+      "threshold_met": false,
+      "significant_at_95": false,
+      "n_per_condition": [
+        100,
+        100
+      ]
+    },
+    "criterion_3": {
+      "name": "At least one emergent timing pattern not in the heuristic",
+      "determination": "PASS",
+      "pattern": "secondary-tool inhibition gate (fire one tool early, then suppress)",
+      "multi_tool_episode_rate_by_iteration": [
+        0.28,
+        0.24,
+        0.04,
+        0.02,
+        0.02
+      ],
+      "p_invoke_turn1_final": 0.9878339032316581,
+      "p_invoke_turn2plus_final": 0.0239305783201147,
+      "inhibition_gap_by_iteration": [
+        0.7010115840492976,
+        0.8776640638374482,
+        0.9236138213193044,
+        0.997262427571288,
+        0.9639033249115434
+      ],
+      "inhibition_gap_final": 0.9639033249115434,
+      "inhibition_gap_min_required": 0.5,
+      "multi_tool_rate_halved": true,
+      "evidence": "docs/emergent_behavior_2026-07.md, docs/figures/emergent/"
+    },
+    "criterion_4": {
+      "name": "Training converged within 500 episodes",
+      "determination": "PASS",
+      "total_episodes": 250,
+      "episode_budget": 500,
+      "policy_entropy_by_iteration": [
+        0.6736875772476196,
+        0.35442596673965454,
+        0.22121386229991913,
+        0.02451946586370468,
+        0.14024749398231506
+      ],
+      "train_loss_by_iteration": [
+        0.6535010635852814,
+        0.3630329519510269,
+        0.22167762368917465,
+        0.03122452273964882,
+        0.14474927634000778
+      ],
+      "kl_from_heuristic_by_iteration": [
+        0.58343168580856,
+        0.22508741868869547,
+        0.060177169903595104,
+        0.01580152355342139,
+        0.04605410215947715
+      ],
+      "entropy_threshold": 0.2,
+      "loss_fraction_threshold": 0.25,
+      "within_budget": true,
+      "entropy_converged": true,
+      "loss_converged": true,
+      "curve": "docs/figures/emergent/training_dynamics.png"
+    },
+    "criterion_5": {
+      "name": "Learned policy triggers fewer unintended interrupts than heuristic",
+      "determination": "UNRESOLVABLE",
+      "learned_mean": 0.0,
+      "learned_ci": [
+        0.0,
+        0.0
+      ],
+      "heuristic_mean": 0.0,
+      "heuristic_ci": [
+        0.0,
+        0.0
+      ],
+      "absolute_difference": 0.0,
+      "difference_ci95": [
+        0.0,
+        0.0
+      ],
+      "n_per_condition": [
+        100,
+        100
+      ],
+      "note": "Both conditions measured exactly zero interrupts across all episodes. The evaluation ran in BREAKPOINT injection mode, which drains the queue at every turn boundary before an interrupt threshold can be crossed, so mid-turn interrupts are structurally impossible and equality-at-zero cannot demonstrate 'fewer'."
+    },
+    "criterion_6": {
+      "name": "Queue-based delivery produces fewer derailments than synchronous injection",
+      "committed_episodes_by_injection_mode": {
+        "breakpoint": 1095
+      },
+      "determination": "UNEVALUATED",
+      "note": "No committed run contains SYNCHRONOUS-mode episodes; every committed episode ran in BREAKPOINT mode. The #22 A/B framework (bicameral_agent.ab_test) is implemented and tested but has not been run live against a synchronous arm.",
+      "command_to_produce_data": "GEMINI_API_KEY=... uv run python - <<'PY'\nfrom pathlib import Path\n\nfrom bicameral_agent.ab_test import ABTestRunner, default_conditions\nfrom bicameral_agent.eval_datasets import build_dataset\nfrom bicameral_agent.gemini import GeminiClient\nfrom bicameral_agent.heuristic_controller import HeuristicController\n\nPath(\"data/ab_test\").mkdir(parents=True, exist_ok=True)\ntasks = build_dataset(\"builtin\").load().eval_tasks()[:50]\nresult = ABTestRunner(GeminiClient()).run(tasks, default_conditions(HeuristicController))\nresult.to_json(\"data/ab_test/report.json\")\nresult.to_csv(\"data/ab_test/episodes.csv\")\nPY"
+    }
+  }
+}

--- a/docs/mvp_validation_2026-07.md
+++ b/docs/mvp_validation_2026-07.md
@@ -1,0 +1,252 @@
+# MVP Success Criteria Validation (Issue #31)
+
+*Final Phase-5 deliverable. Every number below is extracted mechanically from
+committed run artifacts by `scripts/validate_mvp.py`, which writes the
+machine-readable verdict to `data/mvp_validation.json` (the determinations in
+this document are tested against that output). No live model calls are
+involved; re-running after new data lands is free.*
+
+```
+uv run python scripts/validate_mvp.py --out data/mvp_validation.json
+```
+
+## Executive summary
+
+| # | Criterion | Determination |
+|---|---|---|
+| 1 | Learned policy beats **random** by ≥ 15% on task quality | **FAIL** (+4.7%, p = 0.29) |
+| 2 | Learned policy beats **heuristic** by ≥ 8% on task quality | **FAIL** (+4.0%, p = 0.36) |
+| 3 | At least one emergent timing pattern not in the heuristic | **PASS** (learned inhibition gate) |
+| 4 | Training converged within 500 episodes | **PASS** (250 episodes) |
+| 5 | Fewer unintended interrupts than the heuristic | **UNRESOLVABLE** (both exactly 0) |
+| 6 | Queue-based delivery beats synchronous injection on derailments | **UNEVALUATED** (no synchronous-arm data) |
+
+The honest overall picture:
+
+- **The architecture works end-to-end.** The full pipeline — subconscious tool
+  layer, queue-based context delivery, MCTS self-improvement training, and a
+  5-condition × 100-task comparative evaluation — ran live with zero transport
+  failures (500 comparative episodes plus 250 training episodes, all
+  committed). Training converged well inside its episode budget, and the
+  trained policy was deployed and measured as a first-class condition.
+- **An emergent behavior was genuinely learned.** The policy taught itself a
+  "fire one tool early, then suppress" inhibition gate that is not written
+  anywhere in the heuristic baseline (criterion 3, evidence in
+  [emergent_behavior_2026-07.md](emergent_behavior_2026-07.md)).
+- **But the MVP's headline quality-improvement thresholds are not met.** At
+  the measured effect sizes the learned policy adds **+2 to +4 points of task
+  quality on a 100-point scale** over the baselines (+2.9 vs random, +2.5 vs
+  heuristic, +4.1 vs the no-subconscious control) at a **~64% token premium**
+  over running with no subconscious layer at all — and none of these
+  differences is statistically significant (best p = 0.137).
+- **The direction is consistent, the power is not.** The hypothesized quality
+  ordering (subconscious conditions above controls; learned at the top)
+  appeared directionally in **two independent runs** — the #46 baseline rerun
+  and the #30 comparative evaluation — without reaching significance in
+  either. The #46 power analysis estimates roughly 230 episodes/condition are
+  needed to resolve effects of this size; both runs used ≤ 100. An
+  **adequately powered confirmation run is tracked in #89**.
+
+In short: the system is built, trained, and instrumented as specified, and
+learning demonstrably happened — but on today's evidence the learned
+subconscious does **not** deliver the quality gains the MVP promised, and the
+two headline criteria fail.
+
+## How to read the numbers
+
+- **task_quality** is an LLM-judge rubric score in [0, 1] (higher is better),
+  judged by a fixed model (`gemma4:31b-cloud`) that never sees which condition
+  produced a transcript. "+4 points" means +0.04 on this scale.
+- **Conditions** (100 tasks each, identical task list, seed 42):
+  - `no_subconscious` — the plain assistant, no background tool layer (control).
+  - `random` — subconscious layer with a random invocation policy (control).
+  - `heuristic` — hand-written invocation rules (the baseline to beat).
+  - `learned_no_search` — **the trained policy as deployed** (network only,
+    no inference-time search). This is "the learned policy" throughout.
+  - `learned_with_search` — the same network with inference-time MCTS
+    (reported as a sensitivity check; it scored slightly *lower*: 0.6392).
+- CIs are 95%; p-values are two-sided Welch t-tests.
+- Sources: `data/comparative/report.{json,md}` (#30),
+  `data/mcts_training/metrics_history.json` (#29),
+  `docs/figures/emergent/emergent_stats.json` (#32).
+
+## Criterion 1 — Learned > random by ≥ 15% on task quality
+
+**Determination: FAIL.**
+
+| Condition | task_quality mean [95% CI] | n |
+|---|---|---|
+| learned_no_search | 0.6475 [0.6077, 0.6873] | 100 |
+| random | 0.6183 [0.5815, 0.6551] | 100 |
+
+- Absolute difference: **+0.0292** (95% CI of the difference
+  **[−0.0247, +0.0831]** — it spans zero).
+- Relative improvement: **+4.7%**, versus the **15%** the criterion requires.
+- Welch t-test: t = 1.068, **p = 0.287** — not significant.
+
+The measured effect is less than a third of the required threshold, and the
+data cannot even rule out zero (or a small negative) effect. Fails on the
+point estimate; fails on significance.
+
+## Criterion 2 — Learned > heuristic by ≥ 8% on task quality
+
+**Determination: FAIL.**
+
+| Condition | task_quality mean [95% CI] | n |
+|---|---|---|
+| learned_no_search | 0.6475 [0.6077, 0.6873] | 100 |
+| heuristic | 0.6225 [0.5854, 0.6596] | 100 |
+
+- Absolute difference: **+0.0250** (95% CI **[−0.0291, +0.0791]**).
+- Relative improvement: **+4.0%**, versus the required **8%**.
+- Welch t-test: t = 0.911, **p = 0.363** — not significant.
+
+Half the required effect, not significant. Consistent with the #32 finding
+that training distilled the policy *toward* the heuristic (final action
+agreement 98.1%): a policy that acts almost identically to the baseline
+cannot outscore it by 8%.
+
+*Context for both criteria:* the strongest contrast in the whole grid —
+learned vs the `no_subconscious` control — is +0.0408 (+6.7% relative,
+p = 0.137), bought at a token cost of 5,465 vs 3,330 per episode (**+64%**).
+The full hypothesized ordering (learned > heuristic > random >
+no_subconscious) did appear, and the heuristic-above-controls direction
+replicated the independent #46 baseline rerun
+([baseline_rerun_2026-07.md](baseline_rerun_2026-07.md)), but no task-quality
+pair in either run is significant. Direction: consistent. Magnitude: far
+below the MVP bar. Power: insufficient (~230 episodes/condition needed per
+the #46 calculation; confirmation tracked in **#89**).
+
+## Criterion 3 — At least one emergent timing pattern not in the heuristic
+
+**Determination: PASS** — the learned **secondary-tool inhibition gate**
+("fire one tool early, then suppress"), established by the #32 analysis
+([emergent_behavior_2026-07.md](emergent_behavior_2026-07.md)).
+
+The pattern, in plain terms: early in training the policy often fired a
+redundant second background tool in the same episode; by the end of training
+it had learned to fire exactly one tool on the first turn and then hold back
+— a rule that appears nowhere in the hand-written heuristic (which only has
+fixed interval/stop rules, no "already invoked this episode, so stop").
+
+Evidence (from `docs/figures/emergent/emergent_stats.json`, 250 training
+episodes and 5 checkpoints):
+
+1. Multi-tool episode rate across training iterations:
+   **28% → 24% → 4% → 2% → 2%**, while held-out eval quality stayed flat —
+   the suppression was learned without a quality trade-off.
+2. Probing every checkpoint on the same 104 reconstructed decision points,
+   the invocation-probability gap between turn 1 (no tool fired yet) and
+   turn 2+ (tool already fired) widens **0.70 → 0.88 → 0.92 → 1.00 → 0.96**
+   as policy entropy collapses.
+3. At the final checkpoint the gate is near-binary on tool history:
+   P(invoke) = **0.988** at turn 1 vs **0.024** at turn 2+ (gap 0.96, well
+   above the 0.5 pass rule in `scripts/validate_mvp.py`).
+
+Figures: `docs/figures/emergent/emergent_inhibition.png`,
+`timing_by_turn.png`. The #32 report also states the negative results plainly
+(no queue-aware inhibition, compound tool sequences are a transient of early
+exploration), so this pass is scoped to the inhibition gate only.
+
+## Criterion 4 — Training converged within 500 episodes
+
+**Determination: PASS.** The #29 MCTS training run used **250 episodes**
+(5 iterations × 50), half the budget, and converged by every tracked measure:
+
+| Iteration | Episodes (cum.) | Policy entropy (nats) | Train loss | KL from heuristic |
+|---|---|---|---|---|
+| 0 | 50 | 0.674 | 0.654 | 0.583 |
+| 1 | 100 | 0.354 | 0.363 | 0.225 |
+| 2 | 150 | 0.221 | 0.222 | 0.060 |
+| 3 | 200 | 0.025 | 0.031 | 0.016 |
+| 4 | 250 | 0.140 | 0.145 | 0.046 |
+
+- Policy entropy collapses **0.67 → 0.14** nats (minimum 0.025 at iteration
+  3; the iteration-4 uptick comes from fresh MCTS targets on newly collected
+  data, expected with a moving target).
+- Training loss falls **0.65 → 0.14** (minimum 0.031) — a 78% reduction,
+  against the ≤ 25%-of-initial pass rule in `scripts/validate_mvp.py`.
+- KL from the heuristic reaches 0.046 with 98% action agreement — the policy
+  stopped moving.
+
+Convergence curve (entropy, loss, KL, and agreement per iteration):
+
+![Training dynamics](figures/emergent/training_dynamics.png)
+
+(Regenerate with `uv run --extra torch python
+scripts/analyze_emergent_behavior.py`.)
+
+Caveat, stated so the pass is not over-read: the policy converged *to the
+heuristic*, not past it — see criterion 2.
+
+## Criterion 5 — Fewer unintended interrupts than the heuristic
+
+**Determination: UNRESOLVABLE** (not decidable from this data).
+
+Measured interrupt rate over 100 episodes per condition: learned
+**0.00 [0, 0]**, heuristic **0.00 [0, 0]**. Difference: 0.00 [0, 0].
+
+The criterion's letter asks for *fewer* interrupts than the heuristic.
+Zero-equals-zero is not "fewer", so a literal reading fails; but we decline
+to score it either way, for a structural reason: the comparative evaluation
+ran in **BREAKPOINT injection mode**, which drains the context queue at every
+turn boundary before any interrupt threshold can be crossed. Mid-turn
+interrupts were therefore *impossible by construction* for every condition —
+the metric carried no information in this configuration (the same
+degeneracy is documented in the #32 analysis and holds across all 250
+training episodes). Declaring a "pass by vacuity" would credit the learned
+policy for something the harness precluded; declaring a failure would
+penalize it for the same artifact. What the data does support: the learned
+policy is trivially **no worse** (0 ≤ 0). A meaningful test needs episodes
+run in INTERRUPT mode with reachable thresholds (`AB_INTERRUPT_CONFIG` in
+`src/bicameral_agent/ab_test.py` exists for exactly this purpose) and is
+subsumed by the criterion-6 run below.
+
+## Criterion 6 — Queue-based delivery produces fewer derailments than synchronous injection
+
+**Determination: UNEVALUATED** — the required A/B data was never collected.
+
+This criterion needs the #22 A/B test comparing injection strategies
+(synchronous vs queue-based) on derailment counts. The framework is
+implemented and unit-tested (`src/bicameral_agent/ab_test.py`: three
+conditions — `synchronous`, `breakpoint`, `interrupt` — with derailment
+counting from the simulated user's own follow-up labels), but **no live run
+of it was ever committed**. A scan of every committed episode corpus finds
+**1,095 episodes, all in BREAKPOINT mode and zero in SYNCHRONOUS mode**
+(`data/baseline*`, `data/comparative`, `data/mcts_training`), so there is no
+synchronous arm to compare against, and we will not manufacture a verdict
+without one.
+
+The exact command that would produce the missing data (live LLM calls;
+budget ~150 episodes for 50 tasks × 3 conditions):
+
+```
+GEMINI_API_KEY=... uv run python - <<'PY'
+from pathlib import Path
+
+from bicameral_agent.ab_test import ABTestRunner, default_conditions
+from bicameral_agent.eval_datasets import build_dataset
+from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.heuristic_controller import HeuristicController
+
+Path("data/ab_test").mkdir(parents=True, exist_ok=True)
+tasks = build_dataset("builtin").load().eval_tasks()[:50]
+result = ABTestRunner(GeminiClient()).run(tasks, default_conditions(HeuristicController))
+result.to_json("data/ab_test/report.json")
+result.to_csv("data/ab_test/episodes.csv")
+PY
+```
+
+Once `data/ab_test/report.json` is committed, `scripts/validate_mvp.py`
+detects it automatically and resolves this criterion to PASS/FAIL on the
+derailment means — no code change needed.
+
+## Where this leaves the MVP
+
+Two criteria pass (emergent behavior, convergence), two fail (both headline
+quality thresholds), one is unresolvable on structurally degenerate data
+(interrupts), and one was never run (derailment A/B). The engineering goals
+of the MVP are met; the *performance* goals are not, at the effect sizes two
+independent runs agree on. The decisive next step is not more architecture —
+it is statistical power: the adequately powered comparison (and the deferred
+Gemini-answerer arm) tracked in **#89**, plus the criterion-6 A/B run above.

--- a/scripts/validate_mvp.py
+++ b/scripts/validate_mvp.py
@@ -1,0 +1,399 @@
+"""MVP success-criteria validation (issue #31).
+
+Extracts each of the six MVP criteria's numbers from committed run
+artifacts, determines pass/fail mechanically, prints a human-readable
+report, and writes a machine-readable JSON verdict. No live LLM calls are
+made, so re-running after new data lands is free and deterministic.
+
+Inputs (all committed):
+
+- ``data/comparative/report.json`` — #30 comparative evaluation
+  (5 conditions x 100 tasks; criteria 1, 2, 5)
+- ``data/mcts_training/metrics_history.json`` — #29 MCTS training run
+  (criterion 4)
+- ``docs/figures/emergent/emergent_stats.json`` — #32 emergent-behavior
+  analysis (criterion 3)
+- committed episode parquets and any A/B result JSON under ``data/``
+  (criterion 6: queue-based vs synchronous injection)
+
+Usage::
+
+    uv run python scripts/validate_mvp.py --out data/mvp_validation.json
+
+The narrative companion is ``docs/mvp_validation_2026-07.md``; the
+determinations there are transcribed from this script's output (enforced
+by ``tests/test_validate_mvp.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+from bicameral_agent.ab_test import t_critical_95
+
+# The learned condition used for the headline criteria. learned_no_search is
+# the trained policy exactly as it acts at deployment (no inference-time MCTS);
+# learned_with_search is reported alongside as a sensitivity check.
+LEARNED_CONDITION = "learned_no_search"
+
+# Convergence rule for criterion 4 (thresholds stated in the report):
+# final policy entropy below this many nats ...
+CONVERGED_ENTROPY_MAX = 0.2
+# ... and final train loss at most this fraction of the iteration-0 loss.
+CONVERGED_LOSS_FRACTION_MAX = 0.25
+EPISODE_BUDGET = 500
+
+# Emergent-pattern rule for criterion 3: the turn-1 vs turn-2+ invocation gap
+# of the final checkpoint must be at least this wide, and the multi-tool
+# episode rate must at least halve from iteration 0 to the final iteration.
+INHIBITION_GAP_MIN = 0.5
+
+_INJECTION_MODE_RE = re.compile(r'"injection_mode":\s*"([a-z_]+)"')
+
+
+# ---------------------------------------------------------------------------
+# Shared statistics
+# ---------------------------------------------------------------------------
+
+
+def welch_diff_ci(a: dict, b: dict) -> tuple[float, float, float]:
+    """95% Welch CI for mean(a) - mean(b) from two MetricSummary dicts."""
+    se_a = a["std"] ** 2 / a["n"]
+    se_b = b["std"] ** 2 / b["n"]
+    se = math.sqrt(se_a + se_b)
+    diff = a["mean"] - b["mean"]
+    if se == 0:
+        return diff, diff, diff
+    df = (se_a + se_b) ** 2 / (se_a**2 / (a["n"] - 1) + se_b**2 / (b["n"] - 1))
+    margin = t_critical_95(max(1, int(df))) * se
+    return diff, diff - margin, diff + margin
+
+
+def _summary(report: dict, condition: str, metric: str) -> dict:
+    return report["conditions"][condition]["summaries"][metric]
+
+
+def _pairwise(report: dict, a: str, b: str, metric: str = "task_quality") -> dict | None:
+    for row in report["pairwise"]:
+        if row["metric"] != metric:
+            continue
+        if {row["condition_a"], row["condition_b"]} == {a, b}:
+            return row
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Criteria
+# ---------------------------------------------------------------------------
+
+
+def quality_criterion(report: dict, baseline: str, threshold_pct: float, name: str) -> dict:
+    """Criteria 1 and 2: learned beats *baseline* by >= threshold_pct on quality."""
+    learned = _summary(report, LEARNED_CONDITION, "task_quality")
+    base = _summary(report, baseline, "task_quality")
+    diff, ci_lo, ci_hi = welch_diff_ci(learned, base)
+    rel_pct = 100.0 * diff / base["mean"]
+    pair = _pairwise(report, LEARNED_CONDITION, baseline)
+    p_value = pair["p_value"] if pair else None
+    threshold_met = rel_pct >= threshold_pct
+    significant = p_value is not None and p_value < 0.05
+    return {
+        "name": name,
+        "determination": "PASS" if (threshold_met and significant) else "FAIL",
+        "threshold_relative_pct": threshold_pct,
+        "learned_condition": LEARNED_CONDITION,
+        "baseline_condition": baseline,
+        "learned_mean": learned["mean"],
+        "learned_ci": [learned["ci_lower"], learned["ci_upper"]],
+        "baseline_mean": base["mean"],
+        "baseline_ci": [base["ci_lower"], base["ci_upper"]],
+        "absolute_difference": diff,
+        "difference_ci95": [ci_lo, ci_hi],
+        "relative_improvement_pct": rel_pct,
+        "welch_p_value": p_value,
+        "threshold_met": threshold_met,
+        "significant_at_95": significant,
+        "n_per_condition": [learned["n"], base["n"]],
+    }
+
+
+def emergent_criterion(stats: dict) -> dict:
+    """Criterion 3: at least one emergent timing pattern not in the heuristic."""
+    per_iter = stats["per_iteration_episode_stats"]
+    iterations = sorted(per_iter, key=int)
+    multi_tool_rates = [per_iter[i]["multi_tool_rate"] for i in iterations]
+    gap = stats["inhibition_gap"]
+    p_turn1 = gap["p_invoke_turn1"]
+    p_turn2plus = gap["p_invoke_turn2plus"]
+    gaps = [t1 - t2 for t1, t2 in zip(p_turn1, p_turn2plus)]
+    final_gap = gaps[-1]
+    rate_halved = multi_tool_rates[-1] <= multi_tool_rates[0] / 2
+    passed = final_gap >= INHIBITION_GAP_MIN and rate_halved
+    return {
+        "name": "At least one emergent timing pattern not in the heuristic",
+        "determination": "PASS" if passed else "FAIL",
+        "pattern": "secondary-tool inhibition gate (fire one tool early, then suppress)",
+        "multi_tool_episode_rate_by_iteration": multi_tool_rates,
+        "p_invoke_turn1_final": p_turn1[-1],
+        "p_invoke_turn2plus_final": p_turn2plus[-1],
+        "inhibition_gap_by_iteration": gaps,
+        "inhibition_gap_final": final_gap,
+        "inhibition_gap_min_required": INHIBITION_GAP_MIN,
+        "multi_tool_rate_halved": rate_halved,
+        "evidence": "docs/emergent_behavior_2026-07.md, docs/figures/emergent/",
+    }
+
+
+def convergence_criterion(history: list[dict]) -> dict:
+    """Criterion 4: training converged within 500 episodes."""
+    total_episodes = sum(it["n_episodes"] for it in history)
+    entropy = [it["policy_entropy"] for it in history]
+    loss = [it["train_loss"] for it in history]
+    kl = [it["kl_from_heuristic"] for it in history]
+    within_budget = total_episodes <= EPISODE_BUDGET
+    entropy_converged = entropy[-1] <= CONVERGED_ENTROPY_MAX
+    loss_converged = loss[-1] <= CONVERGED_LOSS_FRACTION_MAX * loss[0]
+    passed = within_budget and entropy_converged and loss_converged
+    return {
+        "name": f"Training converged within {EPISODE_BUDGET} episodes",
+        "determination": "PASS" if passed else "FAIL",
+        "total_episodes": total_episodes,
+        "episode_budget": EPISODE_BUDGET,
+        "policy_entropy_by_iteration": entropy,
+        "train_loss_by_iteration": loss,
+        "kl_from_heuristic_by_iteration": kl,
+        "entropy_threshold": CONVERGED_ENTROPY_MAX,
+        "loss_fraction_threshold": CONVERGED_LOSS_FRACTION_MAX,
+        "within_budget": within_budget,
+        "entropy_converged": entropy_converged,
+        "loss_converged": loss_converged,
+        "curve": "docs/figures/emergent/training_dynamics.png",
+    }
+
+
+def interrupt_criterion(report: dict) -> dict:
+    """Criterion 5: learned triggers fewer unintended interrupts than heuristic."""
+    learned = _summary(report, LEARNED_CONDITION, "interrupt_rate")
+    heuristic = _summary(report, "heuristic", "interrupt_rate")
+    diff, ci_lo, ci_hi = welch_diff_ci(learned, heuristic)
+    if learned["mean"] < heuristic["mean"]:
+        determination = "PASS"
+    elif learned["mean"] > heuristic["mean"]:
+        determination = "FAIL"
+    else:
+        determination = "UNRESOLVABLE"
+    return {
+        "name": "Learned policy triggers fewer unintended interrupts than heuristic",
+        "determination": determination,
+        "learned_mean": learned["mean"],
+        "learned_ci": [learned["ci_lower"], learned["ci_upper"]],
+        "heuristic_mean": heuristic["mean"],
+        "heuristic_ci": [heuristic["ci_lower"], heuristic["ci_upper"]],
+        "absolute_difference": diff,
+        "difference_ci95": [ci_lo, ci_hi],
+        "n_per_condition": [learned["n"], heuristic["n"]],
+        "note": (
+            "Both conditions measured exactly zero interrupts across all "
+            "episodes. The evaluation ran in BREAKPOINT injection mode, which "
+            "drains the queue at every turn boundary before an interrupt "
+            "threshold can be crossed, so mid-turn interrupts are structurally "
+            "impossible and equality-at-zero cannot demonstrate 'fewer'."
+        ),
+    }
+
+
+def _injection_mode_counts(data_dir: Path) -> dict[str, int]:
+    """Count episodes per injection mode across committed episode parquets."""
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:  # pragma: no cover - pyarrow is a core dependency
+        return {}
+    counts: dict[str, int] = {}
+    for path in sorted(data_dir.rglob("*.parquet")):
+        try:
+            table = pq.read_table(path, columns=["payload"])
+        except Exception:
+            continue  # not an episode parquet (e.g. training examples)
+        for payload in table["payload"]:
+            match = _INJECTION_MODE_RE.search(payload.as_py())
+            mode = match.group(1) if match else "unknown"
+            counts[mode] = counts.get(mode, 0) + 1
+    return counts
+
+
+def _find_ab_result(data_dir: Path) -> tuple[Path, dict] | None:
+    """Locate a committed ABTestResult JSON with a synchronous arm, if any."""
+    for path in sorted(data_dir.rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(payload, dict) or "conditions" not in payload:
+            continue
+        conditions = payload["conditions"]
+        if not isinstance(conditions, list):
+            continue
+        names = {c.get("name") for c in conditions if isinstance(c, dict)}
+        if "synchronous" in names and "breakpoint" in names:
+            return path, payload
+    return None
+
+
+AB_TEST_COMMAND = """\
+GEMINI_API_KEY=... uv run python - <<'PY'
+from pathlib import Path
+
+from bicameral_agent.ab_test import ABTestRunner, default_conditions
+from bicameral_agent.eval_datasets import build_dataset
+from bicameral_agent.gemini import GeminiClient
+from bicameral_agent.heuristic_controller import HeuristicController
+
+Path("data/ab_test").mkdir(parents=True, exist_ok=True)
+tasks = build_dataset("builtin").load().eval_tasks()[:50]
+result = ABTestRunner(GeminiClient()).run(tasks, default_conditions(HeuristicController))
+result.to_json("data/ab_test/report.json")
+result.to_csv("data/ab_test/episodes.csv")
+PY"""
+
+
+def derailment_criterion(data_dir: Path) -> dict:
+    """Criterion 6: queue-based delivery beats synchronous injection on derailments.
+
+    Requires per-condition derailment counts from the #22 A/B framework
+    (``bicameral_agent.ab_test``). All committed episode corpora were collected
+    in BREAKPOINT mode, so unless a synchronous-arm A/B result JSON has been
+    committed under ``data/``, the criterion is UNEVALUATED.
+    """
+    mode_counts = _injection_mode_counts(data_dir)
+    found = _find_ab_result(data_dir)
+    base = {
+        "name": "Queue-based delivery produces fewer derailments than synchronous injection",
+        "committed_episodes_by_injection_mode": mode_counts,
+    }
+    if found is None:
+        return {
+            **base,
+            "determination": "UNEVALUATED",
+            "note": (
+                "No committed run contains SYNCHRONOUS-mode episodes; every "
+                "committed episode ran in BREAKPOINT mode. The #22 A/B "
+                "framework (bicameral_agent.ab_test) is implemented and "
+                "tested but has not been run live against a synchronous arm."
+            ),
+            "command_to_produce_data": AB_TEST_COMMAND,
+        }
+    path, payload = found
+    by_name = {c["name"]: c for c in payload["conditions"]}
+    sync = by_name["synchronous"]["derailments"]
+    queued = by_name["breakpoint"]["derailments"]
+    return {
+        **base,
+        "determination": "PASS" if queued["mean"] < sync["mean"] else "FAIL",
+        "source": str(path),
+        "breakpoint_derailments_mean": queued["mean"],
+        "synchronous_derailments_mean": sync["mean"],
+        "breakpoint_ci": [queued["ci_lower"], queued["ci_upper"]],
+        "synchronous_ci": [sync["ci_lower"], sync["ci_upper"]],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def build_validation(
+    comparative_report: dict,
+    metrics_history: list[dict],
+    emergent_stats: dict,
+    data_dir: Path,
+) -> dict:
+    criteria = {
+        "criterion_1": quality_criterion(
+            comparative_report,
+            baseline="random",
+            threshold_pct=15.0,
+            name="Learned policy outperforms random by >= 15% on task quality",
+        ),
+        "criterion_2": quality_criterion(
+            comparative_report,
+            baseline="heuristic",
+            threshold_pct=8.0,
+            name="Learned policy outperforms heuristic by >= 8% on task quality",
+        ),
+        "criterion_3": emergent_criterion(emergent_stats),
+        "criterion_4": convergence_criterion(metrics_history),
+        "criterion_5": interrupt_criterion(comparative_report),
+        "criterion_6": derailment_criterion(data_dir),
+    }
+    return {
+        "issue": 31,
+        "determinations": {key: c["determination"] for key, c in criteria.items()},
+        "criteria": criteria,
+    }
+
+
+def print_report(validation: dict) -> None:
+    print("MVP Success Criteria Validation (issue #31)")
+    print("=" * 60)
+    for key, criterion in validation["criteria"].items():
+        number = key.split("_")[1]
+        print(f"\nCriterion {number}: {criterion['name']}")
+        print(f"  Determination: {criterion['determination']}")
+        for field in (
+            "relative_improvement_pct",
+            "threshold_relative_pct",
+            "welch_p_value",
+            "difference_ci95",
+            "inhibition_gap_final",
+            "multi_tool_episode_rate_by_iteration",
+            "total_episodes",
+            "policy_entropy_by_iteration",
+            "train_loss_by_iteration",
+            "learned_mean",
+            "heuristic_mean",
+            "committed_episodes_by_injection_mode",
+        ):
+            if field in criterion:
+                value = criterion[field]
+                if isinstance(value, float):
+                    value = f"{value:.4g}"
+                elif isinstance(value, list) and all(isinstance(v, float) for v in value):
+                    value = "[" + ", ".join(f"{v:.4g}" for v in value) + "]"
+                print(f"  {field}: {value}")
+        if criterion.get("note"):
+            print(f"  note: {criterion['note']}")
+    print("\nSummary:", json.dumps(validation["determinations"], indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--comparative-report", default="data/comparative/report.json")
+    parser.add_argument("--metrics-history", default="data/mcts_training/metrics_history.json")
+    parser.add_argument("--emergent-stats", default="docs/figures/emergent/emergent_stats.json")
+    parser.add_argument("--data-dir", default="data", help="Scanned for synchronous-arm A/B data")
+    parser.add_argument("--out", default="data/mvp_validation.json")
+    args = parser.parse_args(argv)
+
+    validation = build_validation(
+        comparative_report=json.loads(Path(args.comparative_report).read_text()),
+        metrics_history=json.loads(Path(args.metrics_history).read_text()),
+        emergent_stats=json.loads(Path(args.emergent_stats).read_text()),
+        data_dir=Path(args.data_dir),
+    )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(validation, indent=2) + "\n")
+    print_report(validation)
+    print(f"\nWrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_validate_mvp.py
+++ b/tests/test_validate_mvp.py
@@ -1,0 +1,122 @@
+"""Tests for scripts/validate_mvp.py (issue #31).
+
+Runs the validator against the committed artifacts (no live LLM calls) and
+checks that the machine-readable determinations match both the expected
+verdicts and the narrative report in docs/mvp_validation_2026-07.md.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import validate_mvp  # noqa: E402
+
+_DOC = _REPO_ROOT / "docs" / "mvp_validation_2026-07.md"
+
+EXPECTED_DETERMINATIONS = {
+    "criterion_1": "FAIL",
+    "criterion_2": "FAIL",
+    "criterion_3": "PASS",
+    "criterion_4": "PASS",
+    "criterion_5": "UNRESOLVABLE",
+    "criterion_6": "UNEVALUATED",
+}
+
+
+@pytest.fixture(scope="module")
+def validation(tmp_path_factory: pytest.TempPathFactory) -> dict:
+    """Run the validator once against the committed artifacts."""
+    out = tmp_path_factory.mktemp("mvp") / "mvp_validation.json"
+    rc = validate_mvp.main(
+        [
+            "--comparative-report",
+            str(_REPO_ROOT / "data" / "comparative" / "report.json"),
+            "--metrics-history",
+            str(_REPO_ROOT / "data" / "mcts_training" / "metrics_history.json"),
+            "--emergent-stats",
+            str(_REPO_ROOT / "docs" / "figures" / "emergent" / "emergent_stats.json"),
+            "--data-dir",
+            str(_REPO_ROOT / "data"),
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    return json.loads(out.read_text())
+
+
+def test_determinations_match_expected(validation: dict) -> None:
+    assert validation["determinations"] == EXPECTED_DETERMINATIONS
+
+
+def test_json_matches_doc_determinations(validation: dict) -> None:
+    """The JSON verdicts and the stakeholder doc must agree, criterion by criterion."""
+    text = _DOC.read_text()
+    doc_determinations = {
+        f"criterion_{m.group(1)}": m.group(2)
+        for m in re.finditer(
+            r"## Criterion (\d).*?\*\*Determination: (PASS|FAIL|UNRESOLVABLE|UNEVALUATED)",
+            text,
+            re.DOTALL,
+        )
+    }
+    assert doc_determinations == validation["determinations"]
+
+
+def test_headline_effect_sizes(validation: dict) -> None:
+    """The two failing quality criteria fail on effect size, not on a data hiccup."""
+    c1 = validation["criteria"]["criterion_1"]
+    assert c1["relative_improvement_pct"] == pytest.approx(4.72, abs=0.01)
+    assert c1["relative_improvement_pct"] < c1["threshold_relative_pct"]
+    assert not c1["significant_at_95"]
+
+    c2 = validation["criteria"]["criterion_2"]
+    assert c2["relative_improvement_pct"] == pytest.approx(4.02, abs=0.01)
+    assert c2["relative_improvement_pct"] < c2["threshold_relative_pct"]
+    assert not c2["significant_at_95"]
+
+
+def test_criterion_6_reports_no_synchronous_data(validation: dict) -> None:
+    c6 = validation["criteria"]["criterion_6"]
+    modes = c6["committed_episodes_by_injection_mode"]
+    assert "synchronous" not in modes
+    assert modes.get("breakpoint", 0) > 0
+    assert "ABTestRunner" in c6["command_to_produce_data"]
+
+
+def test_criterion_6_resolves_when_ab_data_lands(tmp_path: Path) -> None:
+    """Once a synchronous-arm ABTestResult JSON is committed, C6 becomes decidable."""
+
+    def condition(name: str, derailment_mean: float) -> dict:
+        return {
+            "name": name,
+            "derailments": {
+                "mean": derailment_mean,
+                "std": 0.5,
+                "ci_lower": derailment_mean - 0.2,
+                "ci_upper": derailment_mean + 0.2,
+                "n": 50,
+            },
+        }
+
+    result = {
+        "conditions": [condition("synchronous", 1.4), condition("breakpoint", 0.6)],
+        "episode_metrics": [],
+        "best_condition": "breakpoint",
+        "justification": "",
+    }
+    (tmp_path / "ab_test").mkdir()
+    (tmp_path / "ab_test" / "report.json").write_text(json.dumps(result))
+
+    c6 = validate_mvp.derailment_criterion(tmp_path)
+    assert c6["determination"] == "PASS"
+    assert c6["breakpoint_derailments_mean"] == pytest.approx(0.6)
+    assert c6["synchronous_derailments_mean"] == pytest.approx(1.4)


### PR DESCRIPTION
## Summary

Final Phase-5 analysis deliverable: evaluates the trained policy against the six MVP success criteria using only committed artifacts (`data/comparative/`, `data/mcts_training/`, `docs/figures/emergent/`) — no live model calls.

**Determinations** (full evidence in `docs/mvp_validation_2026-07.md`):

| # | Criterion | Determination |
|---|---|---|
| 1 | Learned > random by >= 15% on task quality | **FAIL** (+4.7% relative, diff CI [-0.025, +0.083], p = 0.287) |
| 2 | Learned > heuristic by >= 8% on task quality | **FAIL** (+4.0% relative, diff CI [-0.029, +0.079], p = 0.363) |
| 3 | Emergent timing pattern not in the heuristic | **PASS** (learned secondary-tool inhibition gate, #32: multi-tool rate 28% -> 2%, turn-1 vs turn-2+ P(invoke) 0.988 vs 0.024) |
| 4 | Convergence within 500 episodes | **PASS** (250 episodes; entropy 0.67 -> 0.14, loss 0.65 -> 0.14, KL-from-heuristic 0.046) |
| 5 | Fewer unintended interrupts than heuristic | **UNRESOLVABLE** (both exactly 0/100; BREAKPOINT mode makes interrupts structurally impossible, so equality-at-zero carries no information) |
| 6 | Queue-based delivery beats synchronous injection on derailments | **UNEVALUATED** (all 1,095 committed episodes are BREAKPOINT-mode; the exact `ABTestRunner` command to produce the missing synchronous arm is in the report, and the validator auto-resolves C6 once that JSON lands) |

Honest headline: the architecture works end-to-end and an emergent behavior was genuinely learned, but the MVP's quality-improvement thresholds are not met at measured effect sizes (+2-4 quality points at a ~64% token premium, nothing significant). The directional ordering is consistent across two independent runs (#46, #30); the adequately powered confirmation is tracked in #89.

## What's in the PR

- `scripts/validate_mvp.py` — mechanical extractor: reads the committed artifacts, applies the stated pass rules, prints the report, writes `data/mvp_validation.json` (committed). Deterministic, free to re-run.
- `docs/mvp_validation_2026-07.md` — stakeholder report, one section per criterion with effect sizes, CIs, and evidence pointers; executive summary up front.
- `tests/test_validate_mvp.py` — locks the JSON determinations to the doc and expected verdicts; covers the criterion-6 auto-resolution path with a synthetic A/B result.

## Verification

- `uv run --extra dev --extra torch pytest -q` — 1447 passed, 35 skipped
- `uv run --extra dev --extra torch ruff check src/ tests/ scripts/` — clean

Closes #31.