### PR TITLE
Add BraveSearchProvider behind the gap scanner's SearchProvider protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Two backends satisfy the same client contract (`src/bicameral_agent/model_client
 - **Gemini** (default) — requires `GEMINI_API_KEY`
 - **Ollama Cloud** — open Gemma-class models; requires `OLLAMA_API_KEY` (see `docs/ollama_cloud.md`)
 
+The research gap scanner can additionally use real web search via the Brave
+Web Search API — requires `BRAVE_API_KEY`; enable with `--search-provider
+brave` or `[tools] search_provider = "brave"` (default `mock` keeps runs
+offline; see `docs/eval_datasets.md`).
+
 Select a backend per run with the `--provider` flag on scripts that support it:
 
 ```bash

--- a/docs/eval_datasets.md
+++ b/docs/eval_datasets.md
@@ -145,3 +145,20 @@ no single gold answer); a validator enforces the pairing.
 measurement-model provenance, per-condition `MetricSummary` aggregates
 (unchanged shape — the ui/ Review screen keeps working), plus per-task
 `results` with each episode's score and verification detail.
+
+## Real web search for the gap scanner (Issue #100)
+
+By default the research gap scanner searches a `MockSearchProvider` — 20
+canned snippets keyword-matched to the query — so the tool arm can only
+rearrange the answerer's own knowledge. `BraveSearchProvider`
+(`src/bicameral_agent/brave_search.py`) puts real web search behind the same
+`SearchProvider` protocol: Brave Web Search API, key from `BRAVE_API_KEY`,
+stdlib-urllib transport with retry on 429/5xx, and a thread-safe ~1 req/s
+client-side throttle sized for the free tier (safe under
+`--parallel-episodes`). A search outage degrades to no results with a warning
+(and a `BraveSearchProvider` entry in the episode's `parse_degradations`
+metadata) — it never kills an episode. Select the backend with
+`--search-provider mock|brave` on `run_baseline_benchmark.py`,
+`run_comparative_eval.py`, and `train_mcts.py`, or via `[tools]
+search_provider` in the config (precedence CLI > config; default `mock`, so
+offline tests and CI are unaffected).

--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -39,6 +39,7 @@ from bicameral_agent.runner_setup import (
     add_model_args,
     resolve_parallel_episodes,
     resolve_runner_clients,
+    resolve_search_provider,
 )
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
@@ -176,6 +177,7 @@ def main(argv: list[str] | None = None) -> int:
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,
+        search_provider=resolve_search_provider(args, hyper),
     )
 
     conditions = build_conditions(args, hyper, selected_conditions)

--- a/scripts/run_comparative_eval.py
+++ b/scripts/run_comparative_eval.py
@@ -48,6 +48,7 @@ from bicameral_agent.runner_setup import (
     add_model_args,
     resolve_parallel_episodes,
     resolve_runner_clients,
+    resolve_search_provider,
 )
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_to_parquet
@@ -161,6 +162,7 @@ def main(argv: list[str] | None = None) -> int:
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,
+        search_provider=resolve_search_provider(args, hyper),
     )
 
     # Persist episodes incrementally: rewrite the condition's parquet after

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -43,6 +43,7 @@ from bicameral_agent.runner_setup import (
     add_model_args,
     resolve_parallel_episodes,
     resolve_runner_clients,
+    resolve_search_provider,
 )
 from bicameral_agent.schema import Episode
 from bicameral_agent.serialization import episodes_from_parquet
@@ -119,6 +120,7 @@ def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeR
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,
+        search_provider=resolve_search_provider(args, hyper),
     )
     return runner, cost_tracker
 

--- a/src/bicameral_agent/__init__.py
+++ b/src/bicameral_agent/__init__.py
@@ -55,6 +55,7 @@ from bicameral_agent.assumption_auditor import (
     RiskLevel,
     SuggestedAction,
 )
+from bicameral_agent.brave_search import BraveSearchProvider
 from bicameral_agent.gap_scanner import (
     GapCategory,
     IdentifiedGap,
@@ -145,6 +146,7 @@ __all__ = [
     "APILatencyModel",
     "AssistantResponse",
     "AssumptionAuditor",
+    "BraveSearchProvider",
     "BudgetExceededError",
     "ChatMessage",
     "CoherenceJudge",

--- a/src/bicameral_agent/brave_search.py
+++ b/src/bicameral_agent/brave_search.py
@@ -1,0 +1,197 @@
+"""Brave Web Search backend for the gap scanner's SearchProvider protocol (issue #100).
+
+The default ``MockSearchProvider`` keyword-matches 20 canned snippets, so the
+subconscious can only rearrange the answerer's own knowledge. This provider
+performs real web search, the first configuration where the tool arm can hold
+information the answerer lacks (FRAMES-style multi-hop retrieval tasks).
+
+API contract (verified against Brave's Web Search API docs, 2026-07-08):
+``GET https://api.search.brave.com/res/v1/web/search?q=...&count=N`` with the
+key in the ``X-Subscription-Token`` header; results arrive rank-ordered in
+``web.results[]`` with ``title``/``description``/``url`` and, when requested
+via ``extra_snippets=true`` (available on the free AI plan), an
+``extra_snippets`` array of additional page excerpts. ``count`` caps at 20.
+
+Transport conventions match the repo: stdlib ``urllib`` (like
+``ollama_cloud.py``), retry on 429/5xx/network errors with exponential backoff
+(mirroring ``eval_datasets.hf_fetch``), and graceful degradation -- a search
+outage returns ``[]`` with a warning and a degradation count (issue #47
+philosophy) rather than killing the episode.
+
+A client-side throttle spaces requests at the free tier's ~1 req/s. It is
+thread-safe for concurrent episodes (``--parallel-episodes 10``): each caller
+atomically reserves the next send slot under a lock, then sleeps outside it,
+so callers queue up at 1 req/s without blocking each other during network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from bicameral_agent.gap_scanner import SearchResult
+from bicameral_agent.llm_output import report_degradation
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_USER_AGENT = "bicameral-agent/0.1 (research eval; issue-100)"
+
+# Tighter than hf_fetch's 4x30s: the scanner runs inside a live episode turn,
+# so a dead search backend must cost seconds, not minutes, before degrading.
+_TIMEOUT_S = 10.0
+_MAX_ATTEMPTS = 3
+_RETRY_BASE_DELAY_S = 1.0
+_RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
+
+_MAX_COUNT = 20  # Brave's per-request result cap
+_MAX_EXTRA_SNIPPETS = 2  # keep snippets QueueItem-sized
+
+
+class BraveSearchError(Exception):
+    """A Brave search request failed (non-retryably, or after all retries)."""
+
+
+class _RateLimiter:
+    """Thread-safe minimum-interval request spacer.
+
+    ``wait()`` atomically reserves the next available send slot under a lock
+    and sleeps outside it, so N concurrent callers serialize their requests
+    at one per ``min_interval_s`` without holding the lock during the sleep
+    or the subsequent network I/O.
+    """
+
+    def __init__(self, min_interval_s: float) -> None:
+        self._min_interval_s = min_interval_s
+        self._lock = threading.Lock()
+        self._next_slot = 0.0  # monotonic time of the next free send slot
+
+    def wait(self) -> None:
+        """Block until this caller's reserved send slot arrives."""
+        if self._min_interval_s <= 0:
+            return
+        with self._lock:
+            now = time.monotonic()
+            slot = max(self._next_slot, now)
+            self._next_slot = slot + self._min_interval_s
+        if slot > now:
+            time.sleep(slot - now)
+
+
+class BraveSearchProvider:
+    """Real web search via the Brave Web Search API.
+
+    Conforms to the ``SearchProvider`` protocol. Thread-safe: the only
+    mutable state is the rate limiter, which is lock-guarded.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        min_request_interval_s: float = 1.0,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("BRAVE_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "API key required: pass api_key= or set BRAVE_API_KEY env var"
+            )
+        self._api_key = resolved_key
+        self._throttle = _RateLimiter(min_request_interval_s)
+
+    def search(self, query: str, max_results: int = 3) -> list[SearchResult]:
+        """Search the web, degrading to ``[]`` on failure (never raises)."""
+        try:
+            payload = self._fetch(query, max_results)
+        except BraveSearchError as err:
+            # A search outage must not kill the episode: warn, count the
+            # degradation, and let the scanner proceed with no results.
+            logger.warning(
+                "BraveSearchProvider: search failed for %r; degrading to no "
+                "results: %s",
+                query,
+                err,
+            )
+            report_degradation("BraveSearchProvider")
+            return []
+        return _map_results(payload, max_results)
+
+    def _fetch(self, query: str, max_results: int) -> dict[str, Any]:
+        """One throttled GET with hf_fetch-style retry on transient errors."""
+        params = urllib.parse.urlencode(
+            {
+                "q": query,
+                "count": min(max(max_results, 1), _MAX_COUNT),
+                "extra_snippets": "true",
+            }
+        )
+        url = f"{_ENDPOINT}?{params}"
+        last_err: Exception | None = None
+        for attempt in range(_MAX_ATTEMPTS):
+            if attempt > 0:
+                time.sleep(_RETRY_BASE_DELAY_S * 2 ** (attempt - 1))
+            self._throttle.wait()
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": _USER_AGENT,
+                    "X-Subscription-Token": self._api_key,
+                },
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except urllib.error.HTTPError as err:
+                if err.code not in _RETRYABLE_HTTP_CODES:
+                    raise BraveSearchError(
+                        f"HTTP {err.code} from Brave search: {err.reason}"
+                    ) from err
+                last_err = err
+            except (
+                urllib.error.URLError,
+                TimeoutError,
+                ConnectionResetError,
+                json.JSONDecodeError,
+            ) as err:
+                last_err = err
+        raise BraveSearchError(
+            f"giving up after {_MAX_ATTEMPTS} attempts: {last_err}"
+        ) from last_err
+
+
+def _map_results(payload: dict[str, Any], max_results: int) -> list[SearchResult]:
+    """Map a Brave response payload to ``SearchResult`` items.
+
+    Brave returns results rank-ordered without numeric scores, so
+    ``relevance_score`` encodes the rank (1.0, 0.9, ...) to preserve the
+    ordering downstream; the scanner's LLM ranking pass reassigns real
+    relevance scores before anything reaches the queue.
+    """
+    raw = (payload.get("web") or {}).get("results") or []
+    results: list[SearchResult] = []
+    for item in raw:
+        if len(results) == max_results:
+            break
+        if not isinstance(item, dict):
+            continue
+        description = item.get("description") or ""
+        extras = [s for s in (item.get("extra_snippets") or []) if isinstance(s, str)]
+        snippet = " ".join([description, *extras[:_MAX_EXTRA_SNIPPETS]]).strip()
+        if not snippet:
+            continue
+        results.append(
+            SearchResult(
+                title=item.get("title") or "",
+                snippet=snippet,
+                relevance_score=round(max(0.1, 1.0 - 0.1 * len(results)), 3),
+                source=item.get("url") or "",
+            )
+        )
+    return results

--- a/src/bicameral_agent/config.py
+++ b/src/bicameral_agent/config.py
@@ -120,13 +120,29 @@ class ToolBudgetConfig(BaseModel):
     max_output_tokens: int = 20_000
 
 
+SEARCH_PROVIDER_NAMES = ("mock", "brave")
+"""Search backends selectable for the research gap scanner (issue #100)."""
+
+
 class ToolsConfig(BaseModel):
-    """Tool budget configuration."""
+    """Tool budget and search-backend configuration."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     default_budget: ToolBudgetConfig = Field(default_factory=ToolBudgetConfig)
     budgets: dict[str, ToolBudgetConfig] = Field(default_factory=dict)
+    search_provider: str = "mock"
+    """Gap-scanner search backend: "mock" (offline snippets) or "brave"
+    (Brave Web Search API; requires ``BRAVE_API_KEY``). Overridden by the
+    scripts' ``--search-provider`` flag (CLI > config > mock)."""
+
+    @field_validator("search_provider")
+    @classmethod
+    def _validate_search_provider(cls, v: str) -> str:
+        if v not in SEARCH_PROVIDER_NAMES:
+            msg = f"search_provider must be one of {SEARCH_PROVIDER_NAMES}, got {v!r}"
+            raise ValueError(msg)
+        return v
 
 
 class HeuristicConfig(BaseModel):

--- a/src/bicameral_agent/data/default_config.toml
+++ b/src/bicameral_agent/data/default_config.toml
@@ -24,6 +24,9 @@ token_threshold = 1000     # interrupt if total pending tokens reach this
 persistent_injection = true  # injected context enters history (false = transient one-generation whisper)
 
 [tools]
+search_provider = "mock"   # gap-scanner search backend: "mock" (offline snippets)
+                           # or "brave" (Brave Web Search API; needs BRAVE_API_KEY)
+
 # Default budget applied to all tools unless overridden below.
 [tools.default_budget]
 max_calls = 10

--- a/src/bicameral_agent/episode_runner.py
+++ b/src/bicameral_agent/episode_runner.py
@@ -18,7 +18,7 @@ from bicameral_agent.conscious_loop import AssistantResponse, ConsciousLoop
 from bicameral_agent.context_refresher import ContextRefresher
 from bicameral_agent.dataset import ResearchQATask
 from bicameral_agent.encoder import StateEncoder
-from bicameral_agent.gap_scanner import ResearchGapScanner
+from bicameral_agent.gap_scanner import ResearchGapScanner, SearchProvider
 from bicameral_agent.heuristic_controller import Action, DecisionLog, FullState, TOOL_IDS
 from bicameral_agent.llm_output import DegradationCounter, count_degradations
 from bicameral_agent.logger import ConversationLogger
@@ -125,8 +125,13 @@ class EpisodeRunner:
         cost_tracker: CostTracker | None = None,
         judge_client: ModelClient | None = None,
         sim_user_client: ModelClient | None = None,
+        search_provider: SearchProvider | None = None,
     ) -> None:
         self._client = client
+        # Search backend for the gap scanner (issue #100); None keeps the
+        # scanner's MockSearchProvider default. Shared across episodes so a
+        # real backend's rate limiting spans --parallel-episodes workers.
+        self._search_provider = search_provider
         self._judge_client = judge_client if judge_client is not None else client
         self._sim_user_client = (
             sim_user_client if sim_user_client is not None else client
@@ -214,7 +219,7 @@ class EpisodeRunner:
         latency_model = ToolLatencyModel()
 
         tools = {
-            TOOL_IDS[Action.SCANNER]: ResearchGapScanner(),
+            TOOL_IDS[Action.SCANNER]: ResearchGapScanner(self._search_provider),
             TOOL_IDS[Action.AUDITOR]: AssumptionAuditor(),
             TOOL_IDS[Action.REFRESHER]: ContextRefresher(),
         }

--- a/src/bicameral_agent/llm_output.py
+++ b/src/bicameral_agent/llm_output.py
@@ -66,9 +66,19 @@ def safe_parse_json(response: Any, *, context: str, default: dict | None = None)
         getattr(response, "finish_reason", "unknown"),
         len(text),
     )
-    for counter in _active_counters.get():
-        counter.add(context)
+    report_degradation(context)
     return default
+
+
+def report_degradation(component: str) -> None:
+    """Record one degradation for *component* with every active counter.
+
+    Shared by ``safe_parse_json`` and other degrade-to-default sites (e.g.
+    the Brave search provider's outage fallback, issue #100) so all
+    degradations land in the same episode-scoped counters.
+    """
+    for counter in _active_counters.get():
+        counter.add(component)
 
 
 class DegradationCounter:

--- a/src/bicameral_agent/runner_setup.py
+++ b/src/bicameral_agent/runner_setup.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import argparse
 import logging
 
-from bicameral_agent.config import HyperConfig
+from bicameral_agent.brave_search import BraveSearchProvider
+from bicameral_agent.config import SEARCH_PROVIDER_NAMES, HyperConfig
+from bicameral_agent.gap_scanner import SearchProvider
 from bicameral_agent.model_client import (
     ModelClient,
     build_client,
@@ -27,8 +29,9 @@ def add_model_args(parser: argparse.ArgumentParser) -> None:
     """Register the model/provider flags shared by episode-running CLIs.
 
     Adds ``--config``, ``--provider``, ``--model``, ``--judge-provider``,
-    ``--judge-model`` and ``--episode-budget``; consume them with
-    :func:`resolve_runner_clients`.
+    ``--judge-model``, ``--episode-budget`` and ``--search-provider``;
+    consume them with :func:`resolve_runner_clients` and
+    :func:`resolve_search_provider`.
     """
     parser.add_argument("--config", default=None,
                         help="Hyperparameter TOML file (defaults to the bundled "
@@ -50,6 +53,13 @@ def add_model_args(parser: argparse.ArgumentParser) -> None:
                              "file; unset uses the judge provider's default).")
     parser.add_argument("--episode-budget", type=float, default=None,
                         help="Optional per-episode cost ceiling in USD.")
+    parser.add_argument("--search-provider", choices=list(SEARCH_PROVIDER_NAMES),
+                        default=None,
+                        help="Search backend for the research gap scanner: "
+                             "'mock' (built-in snippets, offline) or 'brave' "
+                             "(Brave Web Search API; requires BRAVE_API_KEY). "
+                             "Overrides the config's [tools] search_provider; "
+                             "default mock.")
 
 
 def resolve_parallel_episodes(args: argparse.Namespace, hyper: HyperConfig) -> int:
@@ -63,6 +73,25 @@ def resolve_parallel_episodes(args: argparse.Namespace, hyper: HyperConfig) -> i
     if args.parallel_episodes is not None:
         return args.parallel_episodes
     return hyper.run.parallel_episodes
+
+
+def resolve_search_provider(
+    args: argparse.Namespace, hyper: HyperConfig
+) -> SearchProvider | None:
+    """Resolve the gap scanner's search backend: CLI > config > mock.
+
+    Returns ``None`` for "mock" (the scanner constructs its own
+    ``MockSearchProvider`` default, keeping offline runs untouched). For
+    "brave", returns one ``BraveSearchProvider`` shared by every episode,
+    so its client-side ~1 req/s throttle is process-wide under
+    ``--parallel-episodes``; a missing ``BRAVE_API_KEY`` fails fast here,
+    at script startup, rather than mid-run.
+    """
+    name = args.search_provider or hyper.tools.search_provider
+    if name == "brave":
+        logger.info("Gap scanner search backend: brave")
+        return BraveSearchProvider()
+    return None
 
 
 def resolve_runner_clients(

--- a/tests/test_brave_search.py
+++ b/tests/test_brave_search.py
@@ -1,0 +1,223 @@
+"""Tests for the Brave Web Search provider (issue #100).
+
+All transport is mocked (offline/CI-safe) except the final live smoke test,
+which is skipped unless ``BRAVE_API_KEY`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+from unittest.mock import patch
+
+import pytest
+
+from bicameral_agent.brave_search import BraveSearchProvider, _RateLimiter
+from bicameral_agent.gap_scanner import SearchProvider, SearchResult
+from bicameral_agent.llm_output import count_degradations
+
+
+def _payload(num_results: int = 2, extra_snippets: bool = False) -> dict:
+    results = []
+    for i in range(num_results):
+        item = {
+            "title": f"Result {i}",
+            "url": f"https://example.com/{i}",
+            "description": f"Description {i}.",
+        }
+        if extra_snippets:
+            item["extra_snippets"] = [f"Extra A{i}.", f"Extra B{i}.", f"Extra C{i}."]
+        results.append(item)
+    return {"web": {"results": results}}
+
+
+class _FakeResponse:
+    """Minimal stand-in for urllib.request.urlopen's context manager."""
+
+    def __init__(self, payload: dict) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "https://api.search.brave.com/res/v1/web/search",
+        code,
+        "error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=None,
+    )
+
+
+def _provider(**kwargs) -> BraveSearchProvider:
+    kwargs.setdefault("api_key", "test-key")
+    kwargs.setdefault("min_request_interval_s", 0.0)
+    return BraveSearchProvider(**kwargs)
+
+
+class TestConstruction:
+    def test_satisfies_search_provider_protocol(self):
+        assert isinstance(_provider(), SearchProvider)
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "env-key")
+        provider = BraveSearchProvider(min_request_interval_s=0.0)
+        assert provider._api_key == "env-key"
+
+    def test_explicit_key_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "env-key")
+        assert _provider(api_key="explicit")._api_key == "explicit"
+
+    def test_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="BRAVE_API_KEY"):
+            BraveSearchProvider()
+
+
+class TestRequestShape:
+    def test_url_headers_and_params(self):
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(_payload())) as mock_open:
+            _provider().search("fusion ignition NIF", max_results=5)
+
+        request = mock_open.call_args.args[0]
+        url = urllib.parse.urlparse(request.full_url)
+        assert url.scheme == "https"
+        assert url.netloc == "api.search.brave.com"
+        assert url.path == "/res/v1/web/search"
+        params = urllib.parse.parse_qs(url.query)
+        assert params["q"] == ["fusion ignition NIF"]
+        assert params["count"] == ["5"]
+        assert params["extra_snippets"] == ["true"]
+        assert request.get_header("X-subscription-token") == "test-key"
+        assert mock_open.call_args.kwargs["timeout"] == pytest.approx(10.0)
+
+    def test_count_clamped_to_brave_cap(self):
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(_payload())) as mock_open:
+            _provider().search("q", max_results=50)
+        url = urllib.parse.urlparse(mock_open.call_args.args[0].full_url)
+        assert urllib.parse.parse_qs(url.query)["count"] == ["20"]
+
+
+class TestResponseMapping:
+    def test_maps_web_results(self):
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(_payload(2))):
+            results = _provider().search("q", max_results=3)
+
+        assert len(results) == 2
+        assert all(isinstance(r, SearchResult) for r in results)
+        assert results[0].title == "Result 0"
+        assert results[0].snippet == "Description 0."
+        assert results[0].source == "https://example.com/0"
+        # Brave returns rank order without scores; rank is encoded descending.
+        assert results[0].relevance_score > results[1].relevance_score
+
+    def test_snippet_includes_capped_extra_snippets(self):
+        payload = _payload(1, extra_snippets=True)
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(payload)):
+            results = _provider().search("q")
+        assert results[0].snippet == "Description 0. Extra A0. Extra B0."
+
+    def test_respects_max_results(self):
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(_payload(5))):
+            results = _provider().search("q", max_results=2)
+        assert len(results) == 2
+
+    def test_empty_and_malformed_payloads_yield_no_results(self):
+        for payload in ({}, {"web": {}}, {"web": {"results": [42, {"title": "no snippet"}]}}):
+            with patch("urllib.request.urlopen", return_value=_FakeResponse(payload)):
+                assert _provider().search("q") == []
+
+
+class TestRetryAndDegradation:
+    def test_retries_transient_429_then_succeeds(self):
+        side_effects = [_http_error(429), _FakeResponse(_payload(1))]
+        with patch("urllib.request.urlopen", side_effect=side_effects) as mock_open, \
+                patch("bicameral_agent.brave_search.time.sleep") as mock_sleep:
+            results = _provider().search("q")
+        assert len(results) == 1
+        assert mock_open.call_count == 2
+        assert mock_sleep.called  # backoff before the retry
+
+    def test_non_retryable_http_error_degrades_without_retry(self, caplog):
+        with patch("urllib.request.urlopen", side_effect=_http_error(401)) as mock_open, \
+                caplog.at_level("WARNING"):
+            results = _provider().search("q")
+        assert results == []
+        assert mock_open.call_count == 1
+        assert any("degrading" in r.message for r in caplog.records)
+
+    def test_outage_degrades_to_empty_and_counts_degradation(self, caplog):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ) as mock_open, patch("bicameral_agent.brave_search.time.sleep"), \
+                caplog.at_level("WARNING"), count_degradations() as counter:
+            results = _provider().search("q")
+        assert results == []
+        assert mock_open.call_count == 3  # all attempts exhausted
+        assert counter.counts["BraveSearchProvider"] == 1
+        assert any("degrading" in r.message for r in caplog.records)
+
+
+class TestThrottle:
+    def test_zero_interval_is_noop(self):
+        limiter = _RateLimiter(0.0)
+        start = time.monotonic()
+        for _ in range(100):
+            limiter.wait()
+        assert time.monotonic() - start < 0.5
+
+    def test_concurrent_searches_are_spaced(self):
+        """N threads calling search() hit the transport >= interval apart."""
+        interval = 0.05
+        provider = _provider(min_request_interval_s=interval)
+        send_times: list[float] = []
+        times_lock = threading.Lock()
+
+        def fake_urlopen(request, timeout):
+            with times_lock:
+                send_times.append(time.monotonic())
+            return _FakeResponse(_payload(1))
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            threads = [
+                threading.Thread(target=provider.search, args=("q",))
+                for _ in range(5)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(send_times) == 5
+        send_times.sort()
+        gaps = [b - a for a, b in zip(send_times, send_times[1:])]
+        # Allow small scheduling jitter below the nominal interval.
+        assert all(gap >= interval * 0.8 for gap in gaps), gaps
+
+
+@pytest.mark.skipif(
+    not os.environ.get("BRAVE_API_KEY"),
+    reason="BRAVE_API_KEY not set; skipping live Brave Web Search smoke test",
+)
+class TestLiveSmoke:
+    def test_live_search_returns_results(self):
+        provider = BraveSearchProvider()
+        results = provider.search("Python programming language", max_results=2)
+        assert 1 <= len(results) <= 2
+        for result in results:
+            assert result.title
+            assert result.snippet
+            assert result.source.startswith("http")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,15 @@ class TestDefaults:
         assert cfg.tools.default_budget.max_input_tokens == 50_000
         assert cfg.tools.default_budget.max_output_tokens == 20_000
         assert cfg.tools.budgets == {}
+        assert cfg.tools.search_provider == "mock"
+
+    def test_tools_search_provider_accepts_brave(self):
+        cfg = HyperConfig.model_validate({"tools": {"search_provider": "brave"}})
+        assert cfg.tools.search_provider == "brave"
+
+    def test_tools_search_provider_rejects_unknown(self):
+        with pytest.raises(ValidationError, match="search_provider"):
+            HyperConfig.model_validate({"tools": {"search_provider": "bing"}})
 
     def test_heuristic_defaults(self):
         cfg = HyperConfig()

--- a/tests/test_episode_runner.py
+++ b/tests/test_episode_runner.py
@@ -156,6 +156,46 @@ class TestEpisodeConfig:
 
 
 # ---------------------------------------------------------------------------
+# TestSearchProviderWiring
+# ---------------------------------------------------------------------------
+
+
+class TestSearchProviderWiring:
+    def test_search_provider_threaded_to_gap_scanner(self):
+        """The runner's search_provider reaches the ResearchGapScanner (issue #100)."""
+        sentinel = object()
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+        runner = EpisodeRunner(
+            _make_mock_client(),
+            EpisodeConfig(max_turns=2),
+            search_provider=sentinel,
+        )
+
+        with patch(
+            "bicameral_agent.episode_runner.ResearchGapScanner"
+        ) as MockScanner, patch(
+            "bicameral_agent.episode_runner.SimulatedUser"
+        ) as MockSimUser:
+            mock_sim = MagicMock()
+            mock_sim.respond.return_value = UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+            MockSimUser.return_value = mock_sim
+            runner.run_episode(_make_task(), ctrl)
+
+        MockScanner.assert_called_once_with(sentinel)
+
+    def test_defaults_to_none_for_mock_provider(self):
+        """No search_provider arg keeps the scanner's MockSearchProvider default."""
+        runner = EpisodeRunner(_make_mock_client())
+        assert runner._search_provider is None
+
+
+# ---------------------------------------------------------------------------
 # TestEpisodeRunner
 # ---------------------------------------------------------------------------
 

--- a/tests/test_runner_setup.py
+++ b/tests/test_runner_setup.py
@@ -8,11 +8,13 @@ from unittest.mock import patch
 
 import pytest
 
+from bicameral_agent.brave_search import BraveSearchProvider
 from bicameral_agent.config import HyperConfig
 from bicameral_agent.runner_setup import (
     add_model_args,
     resolve_parallel_episodes,
     resolve_runner_clients,
+    resolve_search_provider,
 )
 
 
@@ -41,6 +43,11 @@ class TestAddModelArgs:
         assert args.judge_provider is None
         assert args.judge_model is None
         assert args.episode_budget is None
+        assert args.search_provider is None
+
+    def test_rejects_unknown_search_provider(self):
+        with pytest.raises(SystemExit):
+            _parse(["--search-provider", "not-a-backend"])
 
     def test_parses_values(self):
         args = _parse(
@@ -115,6 +122,36 @@ class TestResolveRunnerClients:
         assert judge_client is not client
         assert mock_build.call_count == 2
         assert provenance["measurement"] == {"provider": "gemini", "model": "tag-b"}
+
+
+class TestResolveSearchProvider:
+    """CLI flag > config [tools].search_provider > mock (None)."""
+
+    def test_defaults_to_none_for_mock(self, hyper):
+        args = _parse([])
+        assert resolve_search_provider(args, hyper) is None
+
+    def test_config_brave_builds_provider(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        args = _parse([])
+        hyper = HyperConfig.model_validate({"tools": {"search_provider": "brave"}})
+        assert isinstance(resolve_search_provider(args, hyper), BraveSearchProvider)
+
+    def test_cli_brave_overrides_config_mock(self, monkeypatch, hyper):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        args = _parse(["--search-provider", "brave"])
+        assert isinstance(resolve_search_provider(args, hyper), BraveSearchProvider)
+
+    def test_cli_mock_overrides_config_brave(self):
+        args = _parse(["--search-provider", "mock"])
+        hyper = HyperConfig.model_validate({"tools": {"search_provider": "brave"}})
+        assert resolve_search_provider(args, hyper) is None
+
+    def test_brave_without_key_fails_fast(self, monkeypatch, hyper):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        args = _parse(["--search-provider", "brave"])
+        with pytest.raises(ValueError, match="BRAVE_API_KEY"):
+            resolve_search_provider(args, hyper)
 
 
 class TestResolveParallelEpisodes:


### PR DESCRIPTION
## Summary

Implements #100: real web search for the research gap scanner. The default `MockSearchProvider` keyword-matches 20 canned snippets, so the tool arm can only rearrange the answerer's own knowledge; `BraveSearchProvider` is the first configuration where the subconscious can add information the answerer lacks (FRAMES-style multi-hop retrieval, where the tool conditions have the most headroom).

## API contract (verified against Brave's Web Search API docs)

`GET https://api.search.brave.com/res/v1/web/search?q=...&count=N` (count caps at 20) with the key in the `X-Subscription-Token` header. Results arrive rank-ordered in `web.results[]` with `title`/`description`/`url`; `extra_snippets=true` (available on the free AI plan) adds an `extra_snippets` array of additional page excerpts, of which up to 2 are folded into each `SearchResult.snippet`.

## Design

- **Transport** follows repo conventions: stdlib urllib (like `ollama_cloud.py`), 10s timeout, retry on 429/5xx/network errors with exponential backoff (mirroring `eval_datasets/hf_fetch.py`, tuned tighter because the scanner runs inside a live episode turn).
- **Degradation**: a typed `BraveSearchError` is caught in `search()`, which warns, records a `BraveSearchProvider` entry in the episode's `parse_degradations` metadata (via a new public `llm_output.report_degradation`, now also used by `safe_parse_json`), and returns `[]` — a search outage never kills an episode (#47 philosophy).
- **Throttle**: thread-safe ~1 req/s spacer for the free tier. Each caller atomically reserves the next send slot under a lock and sleeps outside it, so `--parallel-episodes 10` workers queue up at 1 req/s without blocking each other during network I/O. One provider instance is shared across all episodes (built once in `resolve_search_provider`), making the throttle process-wide.
- **Selection**: `[tools] search_provider = "mock" | "brave"` (default `mock` — offline tests and CI unaffected) plus a shared `--search-provider` flag on `run_baseline_benchmark.py` / `run_comparative_eval.py` / `train_mcts.py` (registered in `runner_setup.add_model_args`); precedence CLI > config > mock, threaded through `EpisodeRunner` to the `ResearchGapScanner` construction. A missing `BRAVE_API_KEY` fails fast at script startup, not mid-run.

## Tests

All offline-mocked: request shape (endpoint, `X-Subscription-Token`, `q`/`count` params, count clamping), response mapping (description + capped extra snippets, `max_results`, malformed payloads), retry on 429, non-retryable degradation, outage degradation + counter, throttle spacing under 5 concurrent threads, protocol conformance, key resolution, config validation, CLI precedence, and runner wiring. One live smoke test is gated on `BRAVE_API_KEY` and skips cleanly when unset.

Blocks #101 (the rerun experiment).

Closes #100