### PR TITLE
Record CLI-resolved values in episode hyperparameter metadata

### DIFF
--- a/scripts/run_baseline_benchmark.py
+++ b/scripts/run_baseline_benchmark.py
@@ -37,6 +37,7 @@ from bicameral_agent.no_subconscious_controller import NoSubconsciousController
 from bicameral_agent.random_controller import RandomController
 from bicameral_agent.runner_setup import (
     add_model_args,
+    effective_hyper_config,
     resolve_parallel_episodes,
     resolve_runner_clients,
     resolve_search_provider,
@@ -173,7 +174,7 @@ def main(argv: list[str] | None = None) -> int:
             score_episode=True,
             metric=metric,
         ),
-        hyper_config=hyper,
+        hyper_config=effective_hyper_config(args, hyper, provenance),
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,

--- a/scripts/run_comparative_eval.py
+++ b/scripts/run_comparative_eval.py
@@ -46,6 +46,7 @@ from bicameral_agent.episode_runner import EpisodeRunner
 from bicameral_agent.eval_datasets import build_dataset, dataset_names, resolve_metric
 from bicameral_agent.runner_setup import (
     add_model_args,
+    effective_hyper_config,
     resolve_parallel_episodes,
     resolve_runner_clients,
     resolve_search_provider,
@@ -158,7 +159,7 @@ def main(argv: list[str] | None = None) -> int:
             score_episode=True,
             metric=metric,
         ),
-        hyper_config=hyper,
+        hyper_config=effective_hyper_config(args, hyper, provenance),
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,

--- a/scripts/train_mcts.py
+++ b/scripts/train_mcts.py
@@ -41,6 +41,7 @@ from bicameral_agent.mcts_trainer import MCTSTrainer, MCTSTrainerConfig
 from bicameral_agent.policy_value_net import PolicyValueNetwork
 from bicameral_agent.runner_setup import (
     add_model_args,
+    effective_hyper_config,
     resolve_parallel_episodes,
     resolve_runner_clients,
     resolve_search_provider,
@@ -107,7 +108,7 @@ def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeR
     if args.episode_budget is not None:
         cost_tracker.set_episode_budget(args.episode_budget)
 
-    client, judge_client, _provenance = resolve_runner_clients(args, hyper)
+    client, judge_client, provenance = resolve_runner_clients(args, hyper)
 
     runner = EpisodeRunner(
         client,
@@ -116,7 +117,7 @@ def build_runner(args: argparse.Namespace, hyper: HyperConfig) -> tuple[EpisodeR
             score_episode=True,
             metric=args.metric,
         ),
-        hyper_config=hyper,
+        hyper_config=effective_hyper_config(args, hyper, provenance),
         cost_tracker=cost_tracker,
         judge_client=judge_client,
         sim_user_client=judge_client,

--- a/src/bicameral_agent/runner_setup.py
+++ b/src/bicameral_agent/runner_setup.py
@@ -13,7 +13,7 @@ import argparse
 import logging
 
 from bicameral_agent.brave_search import BraveSearchProvider
-from bicameral_agent.config import SEARCH_PROVIDER_NAMES, HyperConfig
+from bicameral_agent.config import SEARCH_PROVIDER_NAMES, HyperConfig, ModelConfig
 from bicameral_agent.gap_scanner import SearchProvider
 from bicameral_agent.model_client import (
     ModelClient,
@@ -75,6 +75,11 @@ def resolve_parallel_episodes(args: argparse.Namespace, hyper: HyperConfig) -> i
     return hyper.run.parallel_episodes
 
 
+def _search_provider_name(args: argparse.Namespace, hyper: HyperConfig) -> str:
+    """Resolve the gap scanner's search backend name: CLI > config > mock."""
+    return args.search_provider or hyper.tools.search_provider
+
+
 def resolve_search_provider(
     args: argparse.Namespace, hyper: HyperConfig
 ) -> SearchProvider | None:
@@ -87,7 +92,7 @@ def resolve_search_provider(
     ``--parallel-episodes``; a missing ``BRAVE_API_KEY`` fails fast here,
     at script startup, rather than mid-run.
     """
-    name = args.search_provider or hyper.tools.search_provider
+    name = _search_provider_name(args, hyper)
     if name == "brave":
         logger.info("Gap scanner search backend: brave")
         return BraveSearchProvider()
@@ -137,3 +142,36 @@ def resolve_runner_clients(
         "measurement": {"provider": judge_provider, "model": judge_client.model},
     }
     return client, judge_client, provenance
+
+
+def effective_hyper_config(
+    args: argparse.Namespace,
+    hyper: HyperConfig,
+    provenance: dict[str, dict[str, str]],
+) -> HyperConfig:
+    """Overlay the CLI-resolved runtime values onto *hyper* (issue #103).
+
+    ``EpisodeRunner`` stamps ``hyper_config.to_dict()`` into every episode's
+    ``metadata.hyperparameters``, so handing it the loaded config verbatim
+    records the config-file defaults whenever a CLI flag overrides them.
+    Pass this copy -- answerer ``[model]``, ``[measurement_model]``,
+    ``run.parallel_episodes`` and ``tools.search_provider`` replaced by the
+    resolved values -- as the runner's ``hyper_config`` instead.
+    ``provenance`` is the mapping returned by :func:`resolve_runner_clients`.
+    """
+    answerer = provenance["answerer"]
+    measurement = provenance["measurement"]
+    return hyper.model_copy(update={
+        "model": hyper.model.model_copy(
+            update={"provider": answerer["provider"], "name": answerer["model"]}
+        ),
+        "measurement_model": (hyper.measurement_model or ModelConfig()).model_copy(
+            update={"provider": measurement["provider"], "name": measurement["model"]}
+        ),
+        "run": hyper.run.model_copy(
+            update={"parallel_episodes": resolve_parallel_episodes(args, hyper)}
+        ),
+        "tools": hyper.tools.model_copy(
+            update={"search_provider": _search_provider_name(args, hyper)}
+        ),
+    })

--- a/tests/test_comparative_eval.py
+++ b/tests/test_comparative_eval.py
@@ -776,7 +776,10 @@ class TestScriptParallelEpisodes:
         report = MagicMock()
         report.to_json.return_value = "{}"
         report.to_markdown.return_value = "md"
-        provenance = {"answerer": {}, "measurement": {}}
+        provenance = {
+            "answerer": {"provider": "gemini", "model": "tag-a"},
+            "measurement": {"provider": "gemini", "model": "tag-a"},
+        }
         with (
             patch.object(script, "learned_condition_factories", return_value={}),
             patch.object(

--- a/tests/test_runner_setup.py
+++ b/tests/test_runner_setup.py
@@ -4,18 +4,24 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from bicameral_agent.brave_search import BraveSearchProvider
 from bicameral_agent.config import HyperConfig
+from bicameral_agent.dataset import ResearchQATask, TaskDifficulty, TaskSplit
+from bicameral_agent.episode_runner import Controller, EpisodeConfig, EpisodeRunner
+from bicameral_agent.gemini import GeminiResponse
+from bicameral_agent.heuristic_controller import Action
 from bicameral_agent.runner_setup import (
     add_model_args,
+    effective_hyper_config,
     resolve_parallel_episodes,
     resolve_runner_clients,
     resolve_search_provider,
 )
+from bicameral_agent.simulated_user import ActionType, UserAction
 
 
 @dataclass
@@ -175,3 +181,109 @@ class TestResolveParallelEpisodes:
         args = argparse.Namespace(parallel_episodes=1)
         hyper = HyperConfig.model_validate({"run": {"parallel_episodes": 5}})
         assert resolve_parallel_episodes(args, hyper) == 1
+
+
+def _fake_build_client(provider: str, model: str | None) -> MagicMock:
+    """A client double matching what the scripts get from ``build_client``."""
+    client = MagicMock()
+    client.model = model or "fake-default"
+    client.generate.return_value = GeminiResponse(
+        content="Test response",
+        input_tokens=10,
+        output_tokens=20,
+        duration_ms=100.0,
+        finish_reason="STOP",
+    )
+    return client
+
+
+def _resolve_effective(
+    argv: list[str], hyper: HyperConfig, parallel_episodes: int | None = None
+):
+    """Run the scripts' resolution flow and return (client, effective config)."""
+    args = _parse(argv)
+    args.parallel_episodes = parallel_episodes
+    with patch(
+        "bicameral_agent.runner_setup.build_client", side_effect=_fake_build_client
+    ):
+        client, _judge, provenance = resolve_runner_clients(args, hyper)
+    return client, effective_hyper_config(args, hyper, provenance)
+
+
+class TestEffectiveHyperConfig:
+    """The runner's hyper_config must carry resolved values, not defaults (#103)."""
+
+    def test_cli_overrides_recorded(self, hyper):
+        _, effective = _resolve_effective(
+            [
+                "--provider", "ollama", "--model", "tag-a",
+                "--judge-provider", "gemini", "--judge-model", "tag-b",
+                "--search-provider", "brave",
+            ],
+            hyper,
+            parallel_episodes=10,
+        )
+        assert (effective.model.provider, effective.model.name) == ("ollama", "tag-a")
+        assert effective.measurement_model is not None
+        assert (
+            effective.measurement_model.provider,
+            effective.measurement_model.name,
+        ) == ("gemini", "tag-b")
+        assert effective.run.parallel_episodes == 10
+        assert effective.tools.search_provider == "brave"
+
+    def test_no_flags_keeps_config_values(self, hyper):
+        _, effective = _resolve_effective([], hyper)
+        assert effective.model == hyper.model
+        assert effective.run.parallel_episodes == hyper.run.parallel_episodes
+        assert effective.tools.search_provider == hyper.tools.search_provider
+        # The resolved measurement pin is stamped even when the config
+        # leaves [measurement_model] unset (defaults to gemini, issue #53).
+        assert effective.measurement_model is not None
+        assert effective.measurement_model.provider == "gemini"
+
+    def test_original_config_untouched(self, hyper):
+        _resolve_effective(["--provider", "ollama"], hyper, parallel_episodes=10)
+        assert hyper.model.provider == "gemini"
+        assert hyper.run.parallel_episodes == 1
+
+    def test_episode_metadata_records_effective_values(self, hyper):
+        """A mocked-client run with CLI-style overrides stamps the resolved
+        provider/parallel_episodes/search_provider into episode metadata."""
+        client, effective = _resolve_effective(
+            ["--provider", "ollama", "--search-provider", "brave"],
+            hyper,
+            parallel_episodes=10,
+        )
+
+        runner = EpisodeRunner(
+            client, config=EpisodeConfig(max_turns=3), hyper_config=effective
+        )
+        ctrl = MagicMock(spec=Controller)
+        ctrl.decisions = []
+        ctrl.decide.return_value = Action.DO_NOTHING
+        task = ResearchQATask(
+            task_id="test-103",
+            difficulty=TaskDifficulty.TYPICAL,
+            split=TaskSplit.EVAL,
+            question="What is photosynthesis?",
+            gold_answer="Plants convert light energy into chemical energy.",
+            known_gaps=None,
+            known_assumptions=None,
+            scoring_rubric="5: Complete explanation. 3: Partial. 1: Wrong.",
+        )
+        with patch("bicameral_agent.episode_runner.SimulatedUser") as MockSimUser:
+            sim = MagicMock()
+            sim.respond.return_value = UserAction(
+                action_type=ActionType.TASK_COMPLETE,
+                response_delay_ms=100,
+                confidence=0.9,
+            )
+            MockSimUser.return_value = sim
+            episode = runner.run_episode(task, ctrl)
+
+        recorded = episode.metadata["hyperparameters"]
+        assert recorded["model"]["provider"] == "ollama"
+        assert recorded["run"]["parallel_episodes"] == 10
+        assert recorded["tools"]["search_provider"] == "brave"
+        assert recorded["measurement_model"]["provider"] == "gemini"


### PR DESCRIPTION
## Problem

Every episode's `metadata.hyperparameters` recorded the **config-file defaults**, not the resolved runtime values: the 2026-07-13 run executed with `--provider ollama --parallel-episodes 10 --search-provider brave` yet recorded `model.provider: "gemini"`, `run.parallel_episodes: 1`, `tools.search_provider: "mock"`. The scripts passed the loaded `HyperConfig` verbatim as the runner's `hyper_config`, so CLI overrides never reached the stamped blob — silently poisoning any per-episode provenance filtering (TrainingDataStore metadata filters, mixed-run corpora).

## Change

- **`runner_setup.effective_hyper_config(args, hyper, provenance)`** — one shared overlay (not three per-script copies) that returns a `model_copy` of the loaded config with the resolved values in place:
  - answerer `[model]` provider/name from the `resolve_runner_clients` provenance,
  - `[measurement_model]` provider/name from the same provenance (stamped even when the config leaves it unset, matching the #53 gemini default),
  - `run.parallel_episodes` via the existing `resolve_parallel_episodes`,
  - `tools.search_provider` via the same name resolution `resolve_search_provider` uses (factored into a shared `_search_provider_name` so the two cannot drift).
- All three episode-running scripts (`run_baseline_benchmark.py`, `train_mcts.py`, `run_comparative_eval.py`) now pass that copy as `hyper_config`. Runtime behavior is unchanged — the copy only feeds the metadata stamp; clients/concurrency/search backend were already resolved separately.
- Tests: unit coverage for the overlay (CLI overrides, no-flag passthrough, source config untouched) plus an end-to-end mocked-client episode asserting `metadata.hyperparameters` records the effective provider, parallel_episodes, search_provider, and measurement pin. The comparative-eval script test's stubbed provenance now carries the real `provider`/`model` keys.

## Historical data

Committed episodes (`data/baseline*`, `data/mcts_training`, `data/comparative`) retain their default-valued metadata — committed data is not rewritten; each run's `summary.json` answerer/measurement blocks (#53) remain the authoritative provenance for those.

Closes #103